### PR TITLE
feat(web): revamp onboarding flow

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -10,10 +10,11 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SignUpRouteImport } from './routes/sign-up'
-import { Route as OnboardingRouteImport } from './routes/onboarding'
 import { Route as AppRouteRouteImport } from './routes/app/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AppWorkspaceRouteRouteImport } from './routes/app/_workspace/route'
+import { Route as AppOnboardingIndexRouteImport } from './routes/app/onboarding/index'
+import { Route as AppOnboardingNewRouteImport } from './routes/app/onboarding/new'
 import { Route as AppInvitationIdRouteImport } from './routes/app/invitation.$id'
 import { Route as AppWorkspaceSettingsRouteRouteImport } from './routes/app/_workspace/settings/route'
 import { Route as AppWorkspaceMainRouteRouteImport } from './routes/app/_workspace/_main/route'
@@ -29,11 +30,6 @@ const SignUpRoute = SignUpRouteImport.update({
   path: '/sign-up',
   getParentRoute: () => rootRouteImport,
 } as any)
-const OnboardingRoute = OnboardingRouteImport.update({
-  id: '/onboarding',
-  path: '/onboarding',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const AppRouteRoute = AppRouteRouteImport.update({
   id: '/app',
   path: '/app',
@@ -46,6 +42,16 @@ const IndexRoute = IndexRouteImport.update({
 } as any)
 const AppWorkspaceRouteRoute = AppWorkspaceRouteRouteImport.update({
   id: '/_workspace',
+  getParentRoute: () => AppRouteRoute,
+} as any)
+const AppOnboardingIndexRoute = AppOnboardingIndexRouteImport.update({
+  id: '/onboarding/',
+  path: '/onboarding/',
+  getParentRoute: () => AppRouteRoute,
+} as any)
+const AppOnboardingNewRoute = AppOnboardingNewRouteImport.update({
+  id: '/onboarding/new',
+  path: '/onboarding/new',
   getParentRoute: () => AppRouteRoute,
 } as any)
 const AppInvitationIdRoute = AppInvitationIdRouteImport.update({
@@ -102,10 +108,11 @@ const AppWorkspaceMainThreadsIdRoute =
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/app': typeof AppWorkspaceMainRouteRouteWithChildren
-  '/onboarding': typeof OnboardingRoute
   '/sign-up': typeof SignUpRoute
   '/app/settings': typeof AppWorkspaceSettingsRouteRouteWithChildren
   '/app/invitation/$id': typeof AppInvitationIdRoute
+  '/app/onboarding/new': typeof AppOnboardingNewRoute
+  '/app/onboarding': typeof AppOnboardingIndexRoute
   '/app/': typeof AppWorkspaceMainIndexRoute
   '/app/settings/': typeof AppWorkspaceSettingsIndexRoute
   '/app/threads/$id': typeof AppWorkspaceMainThreadsIdRoute
@@ -116,9 +123,10 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/app': typeof AppWorkspaceMainIndexRoute
-  '/onboarding': typeof OnboardingRoute
   '/sign-up': typeof SignUpRoute
   '/app/invitation/$id': typeof AppInvitationIdRoute
+  '/app/onboarding/new': typeof AppOnboardingNewRoute
+  '/app/onboarding': typeof AppOnboardingIndexRoute
   '/app/settings': typeof AppWorkspaceSettingsIndexRoute
   '/app/threads/$id': typeof AppWorkspaceMainThreadsIdRoute
   '/app/settings/organization/team': typeof AppWorkspaceSettingsOrganizationTeamRoute
@@ -129,12 +137,13 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/app': typeof AppRouteRouteWithChildren
-  '/onboarding': typeof OnboardingRoute
   '/sign-up': typeof SignUpRoute
   '/app/_workspace': typeof AppWorkspaceRouteRouteWithChildren
   '/app/_workspace/_main': typeof AppWorkspaceMainRouteRouteWithChildren
   '/app/_workspace/settings': typeof AppWorkspaceSettingsRouteRouteWithChildren
   '/app/invitation/$id': typeof AppInvitationIdRoute
+  '/app/onboarding/new': typeof AppOnboardingNewRoute
+  '/app/onboarding/': typeof AppOnboardingIndexRoute
   '/app/_workspace/_main/': typeof AppWorkspaceMainIndexRoute
   '/app/_workspace/settings/': typeof AppWorkspaceSettingsIndexRoute
   '/app/_workspace/_main/threads/$id': typeof AppWorkspaceMainThreadsIdRoute
@@ -147,10 +156,11 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/app'
-    | '/onboarding'
     | '/sign-up'
     | '/app/settings'
     | '/app/invitation/$id'
+    | '/app/onboarding/new'
+    | '/app/onboarding'
     | '/app/'
     | '/app/settings/'
     | '/app/threads/$id'
@@ -161,9 +171,10 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/app'
-    | '/onboarding'
     | '/sign-up'
     | '/app/invitation/$id'
+    | '/app/onboarding/new'
+    | '/app/onboarding'
     | '/app/settings'
     | '/app/threads/$id'
     | '/app/settings/organization/team'
@@ -173,12 +184,13 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/app'
-    | '/onboarding'
     | '/sign-up'
     | '/app/_workspace'
     | '/app/_workspace/_main'
     | '/app/_workspace/settings'
     | '/app/invitation/$id'
+    | '/app/onboarding/new'
+    | '/app/onboarding/'
     | '/app/_workspace/_main/'
     | '/app/_workspace/settings/'
     | '/app/_workspace/_main/threads/$id'
@@ -190,7 +202,6 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AppRouteRoute: typeof AppRouteRouteWithChildren
-  OnboardingRoute: typeof OnboardingRoute
   SignUpRoute: typeof SignUpRoute
 }
 
@@ -201,13 +212,6 @@ declare module '@tanstack/react-router' {
       path: '/sign-up'
       fullPath: '/sign-up'
       preLoaderRoute: typeof SignUpRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/onboarding': {
-      id: '/onboarding'
-      path: '/onboarding'
-      fullPath: '/onboarding'
-      preLoaderRoute: typeof OnboardingRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/app': {
@@ -229,6 +233,20 @@ declare module '@tanstack/react-router' {
       path: ''
       fullPath: '/app'
       preLoaderRoute: typeof AppWorkspaceRouteRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
+    '/app/onboarding/': {
+      id: '/app/onboarding/'
+      path: '/onboarding'
+      fullPath: '/app/onboarding'
+      preLoaderRoute: typeof AppOnboardingIndexRouteImport
+      parentRoute: typeof AppRouteRoute
+    }
+    '/app/onboarding/new': {
+      id: '/app/onboarding/new'
+      path: '/onboarding/new'
+      fullPath: '/app/onboarding/new'
+      preLoaderRoute: typeof AppOnboardingNewRouteImport
       parentRoute: typeof AppRouteRoute
     }
     '/app/invitation/$id': {
@@ -350,11 +368,15 @@ const AppWorkspaceRouteRouteWithChildren =
 interface AppRouteRouteChildren {
   AppWorkspaceRouteRoute: typeof AppWorkspaceRouteRouteWithChildren
   AppInvitationIdRoute: typeof AppInvitationIdRoute
+  AppOnboardingNewRoute: typeof AppOnboardingNewRoute
+  AppOnboardingIndexRoute: typeof AppOnboardingIndexRoute
 }
 
 const AppRouteRouteChildren: AppRouteRouteChildren = {
   AppWorkspaceRouteRoute: AppWorkspaceRouteRouteWithChildren,
   AppInvitationIdRoute: AppInvitationIdRoute,
+  AppOnboardingNewRoute: AppOnboardingNewRoute,
+  AppOnboardingIndexRoute: AppOnboardingIndexRoute,
 }
 
 const AppRouteRouteWithChildren = AppRouteRoute._addFileChildren(
@@ -364,7 +386,6 @@ const AppRouteRouteWithChildren = AppRouteRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AppRouteRoute: AppRouteRouteWithChildren,
-  OnboardingRoute: OnboardingRoute,
   SignUpRoute: SignUpRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -6,7 +6,6 @@ import {
   Outlet,
   Scripts,
 } from "@tanstack/react-router";
-import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 import { DefaultCatchBoundary } from "~/components/DefaultCatchBoundary";
 import { NotFound } from "~/components/NotFound";
 import { Providers } from "~/components/providers";
@@ -82,7 +81,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
       <body className="w-screen min-h-screen text-sm">
         <Providers>
           {children}
-          <TanStackRouterDevtools position="bottom-right" />
+          {/* <TanStackRouterDevtools position="bottom-right" /> */}
         </Providers>
         <Scripts />
       </body>

--- a/apps/web/src/routes/app/_workspace/route.tsx
+++ b/apps/web/src/routes/app/_workspace/route.tsx
@@ -22,7 +22,7 @@ export const Route = createFileRoute("/app/_workspace")({
 
     if (!orgUsers || Object.keys(orgUsers).length === 0) {
       throw redirect({
-        to: "/onboarding",
+        to: "/app/onboarding",
       });
     }
 

--- a/apps/web/src/routes/app/onboarding/index.tsx
+++ b/apps/web/src/routes/app/onboarding/index.tsx
@@ -1,0 +1,154 @@
+import { createFileRoute, Link, redirect } from "@tanstack/react-router";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@workspace/ui/components/avatar";
+import { Button } from "@workspace/ui/components/button";
+import { Card, CardContent } from "@workspace/ui/components/card";
+import { Icon } from "@workspace/ui/components/logo";
+import { Separator } from "@workspace/ui/components/separator";
+import { Spinner } from "@workspace/ui/components/spinner";
+import { useAsyncAction } from "@workspace/ui/hooks/use-action";
+import { cn } from "@workspace/ui/lib/utils";
+import { ArrowRightIcon, Check } from "lucide-react";
+import { useState } from "react";
+import { fetchClient } from "~/lib/live-state";
+
+export const Route = createFileRoute("/app/onboarding/")({
+  component: RouteComponent,
+  async loader({ context }) {
+    const user = context.user;
+
+    const [orgUsers, invites] = await Promise.all([
+      fetchClient.query.organizationUser
+        .where({
+          userId: user.id,
+          enabled: true,
+        })
+        .include({
+          organization: true,
+        })
+        .get()
+        .catch(() => null),
+      fetchClient.query.invite
+        .where({
+          email: user.email,
+          active: true,
+          expiresAt: {
+            // FIXME follow https://github.com/pedroscosta/live-state/issues/75
+            // @ts-ignore
+            $gt: new Date(),
+          },
+        })
+        .include({
+          organization: true,
+        })
+        .get()
+        .catch(() => null),
+    ]);
+
+    if (orgUsers && orgUsers.length > 0) {
+      throw redirect({
+        to: "/app",
+      });
+    }
+
+    if (!invites || invites.length === 0) {
+      throw redirect({
+        to: "/app/onboarding/new",
+      });
+    }
+
+    return {
+      invites,
+    };
+  },
+});
+
+function OnboardingForm() {
+  const { invites } = Route.useLoaderData();
+  const [acceptedSomeInvite, setAcceptedSomeInvite] = useState(false);
+  const [isPending, asyncAction] = useAsyncAction();
+
+  return (
+    <div className="flex flex-col gap-6 w-md items-center">
+      <div className="absolute left-4 top-4 flex items-center gap-2">
+        <div className="size-fit p-2 border rounded-md bg-muted">
+          <Icon className="size-4" />
+        </div>
+        <h1 className="text-xl">FrontDesk</h1>
+      </div>
+      <h1 className="text-xl font-medium">Join your teammates</h1>
+      <Card className="w-full p-4 bg-muted/50">
+        <CardContent className="items-center gap-4">
+          {invites.map((invite) => (
+            <div key={invite.id} className="flex justify-between w-full">
+              <div className="flex gap-2 items-center">
+                <Avatar className="size-10 rounded-none">
+                  <AvatarImage
+                    className="rounded-md"
+                    src={invite.organization.logoUrl ?? undefined}
+                  />
+                  <AvatarFallback className="rounded-md text-xl">
+                    {invite.organization.name[0].toUpperCase()}
+                  </AvatarFallback>
+                </Avatar>
+                <h2>{invite.organization.name}</h2>
+              </div>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  asyncAction(() =>
+                    fetchClient.mutate.invite.accept({
+                      id: invite.id,
+                    }),
+                  ).then(() => {
+                    setAcceptedSomeInvite(true);
+                  });
+                }}
+              >
+                {isPending ? (
+                  <>
+                    <Spinner /> Joining
+                  </>
+                ) : acceptedSomeInvite ? (
+                  <>
+                    <Check /> Joined
+                  </>
+                ) : (
+                  "Join"
+                )}
+              </Button>
+            </div>
+          ))}
+          <Separator />
+          <Button variant="outline" className="w-full" asChild>
+            <Link to="/app/onboarding/new">Create new organization</Link>
+          </Button>
+        </CardContent>
+      </Card>
+      <div
+        className={cn(
+          "w-full flex justify-end opacity-0 pointer-events-none",
+          acceptedSomeInvite && "opacity-100 pointer-events-auto",
+        )}
+      >
+        <Button asChild>
+          <Link to="/app">
+            Continue to app
+            <ArrowRightIcon className="size-4" />
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function RouteComponent() {
+  return (
+    <div className="w-screen h-screen flex items-center justify-center bg-muted/20">
+      <OnboardingForm />
+    </div>
+  );
+}

--- a/apps/web/src/routes/app/onboarding/new.tsx
+++ b/apps/web/src/routes/app/onboarding/new.tsx
@@ -14,7 +14,7 @@ import { useState } from "react";
 import { z } from "zod";
 import { mutate } from "~/lib/live-state";
 
-export const Route = createFileRoute("/onboarding")({
+export const Route = createFileRoute("/app/onboarding/new")({
   component: RouteComponent,
 });
 
@@ -27,7 +27,7 @@ const onboardingFormSchema = z.object({
     .min(3, "Slug must be at least 3 characters")
     .regex(
       /^[a-z0-9-]+$/,
-      "Slug can only contain lowercase letters, numbers, and hyphens"
+      "Slug can only contain lowercase letters, numbers, and hyphens",
     ),
   teamMembers: z.string().optional(),
 });
@@ -82,10 +82,13 @@ function OnboardingForm() {
 
   return (
     <div className="flex flex-col gap-6 w-96 items-center">
-      <div className="size-fit p-4 border rounded-2xl bg-muted">
-        <Icon className="size-12" />
+      <div className="absolute left-4 top-4 flex items-center gap-2">
+        <div className="size-fit p-2 border rounded-md bg-muted">
+          <Icon className="size-4" />
+        </div>
+        <h1 className="text-xl">FrontDesk</h1>
       </div>
-      <h1 className="text-xl font-medium">Create Your Organization</h1>
+      <h1 className="text-xl font-medium">Create new organization</h1>
       {error ? <p className="text-destructive">{error}</p> : null}
       <form
         onSubmit={(e) => {
@@ -94,9 +97,8 @@ function OnboardingForm() {
         }}
         className="flex flex-col gap-4 w-full"
       >
-        <Field
-          name="organizationName"
-          children={(field) => (
+        <Field name="organizationName">
+          {(field) => (
             <FormItem field={field}>
               <FormLabel>Organization Name</FormLabel>
               <FormControl>
@@ -113,7 +115,7 @@ function OnboardingForm() {
 
                     // Get the current slug value
                     const currentSlug = getFieldValue(
-                      "organizationSlug"
+                      "organizationSlug",
                     ) as string;
 
                     // Only update the slug if it's empty or matches the previously generated value
@@ -131,14 +133,15 @@ function OnboardingForm() {
               <FormMessage />
             </FormItem>
           )}
-        />
+        </Field>
         {/* TODO validate uniqueness */}
         <Field
           name="organizationSlug"
           validators={{
             onChangeListenTo: ["organizationName"],
           }}
-          children={(field) => (
+        >
+          {(field) => (
             <FormItem field={field}>
               <FormLabel>Organization Slug</FormLabel>
               <FormControl>
@@ -156,27 +159,7 @@ function OnboardingForm() {
               </p>
             </FormItem>
           )}
-        />
-        {/* <Field
-          name="teamMembers"
-          children={(field) => (
-            <FormItem field={field}>
-              <FormLabel>Invite Team Members (Optional)</FormLabel>
-              <FormControl>
-                <Input
-                  placeholder="email1@example.com, email2@example.com"
-                  id={field.name}
-                  value={field.state.value}
-                  onChange={(e) => field.setValue(e.target.value)}
-                />
-              </FormControl>
-              <FormMessage />
-              <p className="text-xs text-muted-foreground">
-                Separate multiple email addresses with commas
-              </p>
-            </FormItem>
-          )}
-        /> */}
+        </Field>
         <Button type="submit" className="mt-6 w-full" disabled={loading}>
           {loading ? <Spinner /> : null} Create Organization
         </Button>


### PR DESCRIPTION
Closes FRO-38, FRO-29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an onboarding hub at /app/onboarding showing pending invites with one-click join and progress states.
  - Added redirect logic: users already in an organization go to /app; no invites redirect to /app/onboarding/new; option to create a new organization.

- Refactor
  - Moved onboarding routes from /onboarding to /app/onboarding and /app/onboarding/new; updated internal redirects accordingly.

- Style
  - Polished onboarding/new form layout, headers, and field structure.

- Chores
  - Disabled router devtools in the app shell.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->