### PR TITLE
feat(api): add email to allowlist when they accept an invite

### DIFF
--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -384,6 +384,17 @@ export const router = createRouter({
               });
             });
 
+            if (req.context?.user?.email) {
+              try {
+                await db.insert(schema.allowlist, {
+                  id: ulid().toLowerCase(),
+                  email: req.context.user.email.toLowerCase(),
+                });
+              } catch {
+                // Silently ignore errors (e.g., duplicate email)
+              }
+            }
+
             return {
               success: true,
             };

--- a/apps/api/src/live-state/schema.ts
+++ b/apps/api/src/live-state/schema.ts
@@ -150,7 +150,7 @@ const integrationRelations = createRelations(integration, ({ one }) => ({
 // This is a list of emails that are allowed to access the app - will be removed after the beta.
 const allowlist = object("allowlist", {
   id: id(),
-  email: string(),
+  email: string().unique().index(),
 });
 
 export const schema = createSchema({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User emails are now automatically recorded in the allowlist when accepting invitations, with improved handling of duplicate entries and enhanced data lookup performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->