### PR TITLE
feat(discord): send portal link message for threads in Discord

### DIFF
--- a/apps/discord/src/index.ts
+++ b/apps/discord/src/index.ts
@@ -159,8 +159,8 @@ client.on("messageCreate", async (message) => {
       if (organization?.slug) {
         const baseUrl = process.env.BASE_URL ?? "https://tryfrontdesk.app";
         const baseUrlObj = new URL(baseUrl);
-        const baseHostname = baseUrlObj.hostname;
-        const portalUrl = `${baseUrlObj.protocol}//${organization.slug}.${baseHostname}/threads/${threadId}`;
+        const port = baseUrlObj.port ? `:${baseUrlObj.port}` : "";
+        const portalUrl = `${baseUrlObj.protocol}//${organization.slug}.${baseUrlObj.hostname}${port}/threads/${threadId}`;
 
         const portalMessage = `This thread is also being tracked in our community portal: ${portalUrl}`;
         await message.channel.send({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically posts a customized portal link message when new Discord threads are created in monitored channels; links are tailored to your organization's configuration.

* **Bug Fixes / Reliability**
  * Added error handling around portal message delivery to reduce failed or duplicate posts and surface posting errors for improved reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->