### PR TITLE
feat(slack,discord): use user's pfp when sending impersonating messages

### DIFF
--- a/apps/discord/src/index.ts
+++ b/apps/discord/src/index.ts
@@ -200,7 +200,7 @@ client.on("messageCreate", async (message) => {
 const handleMessages = async (
   messages: InferLiveObject<
     (typeof schema)["message"],
-    { thread: true; author: true }
+    { thread: true; author: { user: true } }
   >[]
 ) => {
   for (const message of messages) {
@@ -243,7 +243,7 @@ const handleMessages = async (
         }),
         threadId: channel.id,
         username: message.author.name,
-        // avatarURL: message.author.displayAvatarURL(),
+        avatarURL: message.author?.user?.image ?? undefined,
       });
       store.mutate.message.update(message.id, {
         externalMessageId: webhookMessage.id,
@@ -369,7 +369,7 @@ setTimeout(async () => {
           discordChannelId: { $not: null },
         },
       })
-      .include({ thread: true, author: true })
+      .include({ thread: true, author: { user: true } })
       .get()
   );
   store.query.message
@@ -379,7 +379,7 @@ setTimeout(async () => {
         discordChannelId: { $not: null },
       },
     })
-    .include({ thread: true, author: true })
+    .include({ thread: true, author: { user: true } })
     .subscribe(handleMessages);
 
   // Handle updates for threads linked to Discord

--- a/apps/slack/src/index.ts
+++ b/apps/slack/src/index.ts
@@ -257,7 +257,7 @@ app.message(
 const handleMessages = async (
   messages: InferLiveObject<
     (typeof schema)["message"],
-    { thread: true; author: true }
+    { thread: true; author: { user: true } }
   >[]
 ) => {
   for (const message of messages) {
@@ -309,6 +309,7 @@ const handleMessages = async (
         }),
         thread_ts: threadTs,
         username: message.author.name,
+        icon_url: message.author?.user?.image ?? undefined,
       });
 
       if (result.ok && result.ts) {
@@ -463,7 +464,7 @@ const handleUpdates = async (
             externalMetadataStr: { $not: null },
           },
         })
-        .include({ thread: true, author: true })
+        .include({ thread: true, author: { user: true } })
         .get()
     );
     store.query.message
@@ -475,7 +476,7 @@ const handleUpdates = async (
           externalMetadataStr: { $not: null },
         },
       })
-      .include({ thread: true, author: true })
+      .include({ thread: true, author: { user: true } })
       .subscribe(handleMessages);
 
     const updates = await store.query.update

--- a/apps/web/src/routes/app/_workspace/settings/user/index.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/user/index.tsx
@@ -81,6 +81,7 @@ function RouteComponent() {
     <form
       className="p-4 flex flex-col gap-4 w-full"
       onSubmit={(e) => {
+        console.log("onSubmit");
         e.preventDefault();
         handleSubmit();
       }}
@@ -144,7 +145,9 @@ function RouteComponent() {
         </CardContent>
       </Card>
       <div className="flex justify-end">
-        <Button disabled={!nonPersistentIsDirty}>Save</Button>
+        <Button disabled={!nonPersistentIsDirty} type="submit">
+          Save
+        </Button>
       </div>
     </form>
   );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Slack and Discord now use the sender’s profile picture when posting impersonated messages. This addresses FRO-149 so cross-posted messages match the user’s identity.

- **Bug Fixes**
  - Discord: include author.user in queries and set webhook avatarURL to the user’s image.
  - Slack: include author.user and set icon_url to the user’s image.
  - Web: make the profile “Save” button submit the form to persist changes.

<sup>Written for commit 7adc08b9e0366699c04a3b63216fd3c6fd07a84d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sender avatars now display in Discord messages and Slack thread integrations when available.
  * Improved message sender identification across Discord and Slack platforms.

* **Bug Fixes**
  * Enhanced user settings form submission handling to ensure configuration changes are properly saved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->