### PR TITLE
chore(web): remove feature flag for widget

### DIFF
--- a/apps/web/src/components/sidebar/app-sidebar.tsx
+++ b/apps/web/src/components/sidebar/app-sidebar.tsx
@@ -1,9 +1,7 @@
-import { useFlag } from "@reflag/react-sdk";
 import { Link, useMatches } from "@tanstack/react-router";
 import {
   Sidebar,
   SidebarContent,
-  SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
   SidebarHeader,
@@ -12,7 +10,7 @@ import {
   SidebarMenuItem,
   SidebarRail,
 } from "@workspace/ui/components/sidebar";
-import { Book, MessageCircleQuestion, MessagesSquare } from "lucide-react";
+import { MessagesSquare } from "lucide-react";
 import { OrgSwitcher } from "./organization-switcher";
 
 const items: { title: string; url: string; icon: React.ComponentType<any> }[] =
@@ -26,8 +24,6 @@ const items: { title: string; url: string; icon: React.ComponentType<any> }[] =
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const matches = useMatches();
-
-  const { isEnabled: isWidgetEnabled, config } = useFlag("widget");
 
   return (
     <Sidebar variant="inset" className="bg-none">
@@ -60,26 +56,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         {/* <NavFavorites favorites={data.favorites} /> */}
         {/* <NavWorkspaces workspaces={data.workspaces} /> */}
         {/* <NavSecondary items={data.navSecondary} className="mt-auto" /> */}
-        {!isWidgetEnabled && (
-          <SidebarFooter>
-            <SidebarMenuButton asChild>
-              <a href="/docs" target="_blank" rel="noopener noreferrer">
-                <Book />
-                Docs
-              </a>
-            </SidebarMenuButton>
-            <SidebarMenuButton asChild>
-              <a
-                href="https://discord.gg/5MDHqKHrHr"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <MessageCircleQuestion />
-                Support
-              </a>
-            </SidebarMenuButton>
-          </SidebarFooter>
-        )}
       </SidebarContent>
       <SidebarRail />
     </Sidebar>

--- a/apps/web/src/routes/app/_workspace/_main/route.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/route.tsx
@@ -1,6 +1,5 @@
 import { FrontDesk } from "@front-desk/sdk";
 import { Widget } from "@front-desk/widget";
-import { useFlag } from "@reflag/react-sdk";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 import { Card } from "@workspace/ui/components/card";
 import { BookMarked, MessageCircleQuestion } from "lucide-react";
@@ -16,7 +15,6 @@ const frontdeskClient = new FrontDesk({
 
 function RouteComponent() {
   const { user } = Route.useRouteContext();
-  const { isEnabled: isWidgetEnabled } = useFlag("widget");
 
   return (
     <div className="w-screen h-screen flex overflow-hidden">
@@ -25,35 +23,33 @@ function RouteComponent() {
         <Outlet />
       </Card>
 
-      {isWidgetEnabled && (
-        <Widget
-          customer={{
-            id: user?.id,
-            name: user?.name,
-          }}
-          sdk={frontdeskClient}
-          position="bottom-left"
-          resourcesGroups={[
-            {
-              title: "Other links",
-              items: [
-                {
-                  title: "Documentation",
-                  link: "https://tryfrontdesk.app/docs",
-                  content: "Documentation",
-                  icon: <BookMarked />,
-                },
-                {
-                  title: "Discord",
-                  link: "https://discord.gg/5MDHqKHrHr",
-                  content: "Discord",
-                  icon: <MessageCircleQuestion />,
-                },
-              ],
-            },
-          ]}
-        />
-      )}
+      <Widget
+        customer={{
+          id: user?.id,
+          name: user?.name,
+        }}
+        sdk={frontdeskClient}
+        position="bottom-left"
+        resourcesGroups={[
+          {
+            title: "Other links",
+            items: [
+              {
+                title: "Documentation",
+                link: "https://tryfrontdesk.app/docs",
+                content: "Documentation",
+                icon: <BookMarked />,
+              },
+              {
+                title: "Discord",
+                link: "https://discord.gg/5MDHqKHrHr",
+                content: "Discord",
+                icon: <MessageCircleQuestion />,
+              },
+            ],
+          },
+        ]}
+      />
     </div>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Always enable the FrontDesk widget and remove the "widget" feature flag. This simplifies the UI and moves Docs/Support access into the widget.

- **Refactors**
  - Removed useFlag("widget") and related conditional logic.
  - Always render the Widget in the main workspace route.
  - Deleted SidebarFooter with Docs/Support links (previously shown only when the widget was off).
  - Cleaned up unused imports (Book, MessageCircleQuestion, SidebarFooter).

<sup>Written for commit f88669f7373738b15ef3c555c18711bcf20e66df. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Widget functionality is now always available without conditional behavior
  * Removed docs and support links from the sidebar footer

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->