### PR TITLE
feat(discord): implement parsing for user, role, and channel mentions in messages

### DIFF
--- a/apps/discord/src/index.ts
+++ b/apps/discord/src/index.ts
@@ -31,7 +31,7 @@ const safeParseJSON = (raw: string) => {
   ];
 };
 
-const parseDiscordMentions = (message: Message): string => {
+const parseContentAsMarkdown = (message: Message): string => {
   let content = message.content;
 
   // Replace user mentions: <@userId> or <@!userId> with @Username
@@ -214,7 +214,7 @@ client.on("messageCreate", async (message) => {
 
   if (!threadId) return;
 
-  const contentWithMentions = parseDiscordMentions(message);
+  const contentWithMentions = parseContentAsMarkdown(message);
 
   store.mutate.message.insert({
     id: ulid().toLowerCase(),


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Converts Discord mention tokens to readable text and switches authors to display names. Mentions now render correctly across the app.

- **New Features**
  - Replace user (<@id>/<@!id>), role (<@&id>), and channel (<#id>) mentions with @DisplayName/@RoleName/#channel.
  - Convert content before parsing/storing to ensure correct rendering downstream.
  - Use message.author.displayName when creating authors.

<sup>Written for commit ad3cb50cf5d022e6f9fd00cfd1fa560560672e05. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



