### PR TITLE
feat(web): add refetch functionality for issues and pull requests on combobox open

### DIFF
--- a/apps/web/src/components/threads/issues.tsx
+++ b/apps/web/src/components/threads/issues.tsx
@@ -97,7 +97,7 @@ export function IssuesSection({
     }),
   );
 
-  const { data: allIssues } = useQuery({
+  const { data: allIssues, refetch: refetchIssues } = useQuery({
     queryKey: [
       "github-issues",
       currentOrg?.id,
@@ -266,6 +266,11 @@ export function IssuesSection({
           <Combobox
             items={comboboxItems}
             value={linkedIssue?.id.toString() ?? ""}
+            onOpenChange={(open) => {
+              if (open) {
+                refetchIssues();
+              }
+            }}
             onValueChange={(value) => {
               const oldIssueId = externalIssueId ?? null;
               const oldIssue = issues.find(

--- a/apps/web/src/components/threads/pull-requests.tsx
+++ b/apps/web/src/components/threads/pull-requests.tsx
@@ -56,7 +56,7 @@ export function PullRequestsSection({
     }),
   );
 
-  const { data: allPullRequests } = useQuery({
+  const { data: allPullRequests, refetch: refetchPullRequests } = useQuery({
     queryKey: [
       "github-pull-requests",
       currentOrg?.id,
@@ -124,6 +124,11 @@ export function PullRequestsSection({
           <Combobox
             items={comboboxItems}
             value={linkedPr?.id.toString() ?? ""}
+            onOpenChange={(open) => {
+              if (open) {
+                refetchPullRequests();
+              }
+            }}
             onValueChange={(value) => {
               const oldPrId = externalPrId ?? null;
               const oldPr = pullRequests.find(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refreshes GitHub issues and pull requests when opening the selection combobox so users see the latest items and avoid stale options.

- **New Features**
  - Trigger React Query refetch on combobox open in Issues and Pull Requests sections.
  - Keeps dropdown options in sync with GitHub without a page reload.

<sup>Written for commit fc6fe60e89cb52e4c8c9389c42c379488aa4d921. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* GitHub issues dropdown now automatically refreshes when opened to display the latest issues.
* GitHub pull requests dropdown now automatically refreshes when opened to display the latest pull requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->