### PR TITLE
feat(settings): add digest settings model and UI

### DIFF
--- a/apps/api/src/live-state/schema.ts
+++ b/apps/api/src/live-state/schema.ts
@@ -3,12 +3,14 @@ import {
   createRelations,
   createSchema,
   id,
+  json,
   number,
   object,
   reference,
   string,
   timestamp,
 } from "@live-state/sync";
+import type { OrganizationSettings } from "@workspace/schemas/organization";
 
 const organization = object("organization", {
   id: id(),
@@ -18,6 +20,7 @@ const organization = object("organization", {
   logoUrl: string().nullable(),
   socials: string().nullable(),
   customInstructions: string().nullable(),
+  settings: json<OrganizationSettings>().nullable(),
 });
 
 const subscription = object("subscription", {

--- a/apps/web/src/routes/app/_workspace/settings/organization/index.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/index.tsx
@@ -401,7 +401,7 @@ function DigestSettingsForm({ org, currentOrg, isUserOwner }: OrgFormProps) {
           ...settings.digest,
           pendingReplyThresholdMinutes: value.pendingReplyThresholdMinutes,
           time: value.digestTime,
-          slackChannelId: channelName,
+          slackChannelId: null, // TODO(AS-8): resolve channel ID via Slack API
           slackChannelName: channelName,
         },
       });

--- a/apps/web/src/routes/app/_workspace/settings/organization/index.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/index.tsx
@@ -1,9 +1,24 @@
 import { useLiveQuery } from "@live-state/sync/client";
 import { useForm, useStore } from "@tanstack/react-form";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import {
+  type OrganizationSettings,
+  organizationSettingsSchema,
+  safeParseOrgSettings,
+} from "@workspace/schemas/organization";
 import { Avatar, AvatarUpload } from "@workspace/ui/components/avatar";
 import { Button } from "@workspace/ui/components/button";
 import { Card, CardContent } from "@workspace/ui/components/card";
+import {
+  type BaseItem,
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxTrigger,
+} from "@workspace/ui/components/combobox";
 import {
   FormControl,
   FormItem,
@@ -12,6 +27,7 @@ import {
 } from "@workspace/ui/components/form";
 import { Input } from "@workspace/ui/components/input";
 import { useAtomValue } from "jotai/react";
+import { useMemo } from "react";
 import { z } from "zod";
 import { activeOrganizationAtom } from "~/lib/atoms";
 import { mutate, query } from "~/lib/live-state";
@@ -58,8 +74,28 @@ const reservedSlugs = [
   "legal",
 ];
 
+const timezoneItems: BaseItem[] = Intl.supportedValuesOf("timeZone").map(
+  (tz) => ({
+    value: tz,
+    label: tz.replace(/_/g, " "),
+  }),
+);
+
+const digestFormSchema = z.object({
+  pendingReplyThresholdMinutes: z
+    .number()
+    .int()
+    .min(5, "Minimum is 5 minutes")
+    .max(1440, "Maximum is 1440 minutes"),
+  digestTime: z
+    .string()
+    .regex(/^([01]\d|2[0-3]):[0-5]\d$/, "Must be a valid time"),
+  slackChannelName: z.string().optional(),
+});
+
 const orgProfileSchema = z.object({
   orgName: z.string(),
+  orgTimezone: z.string(),
   orgSlug: z
     .string()
     .min(4, "Must be at least 4 characters")
@@ -101,9 +137,47 @@ function RouteComponent() {
       }),
     )?.role === "owner";
 
+  if (!org || !currentOrg) return null;
+
+  return (
+    <div className="p-4 flex flex-col gap-8 w-full">
+      <OrgProfileForm
+        org={org}
+        currentOrg={currentOrg}
+        isUserOwner={isUserOwner}
+      />
+      <DigestSettingsForm
+        org={org}
+        currentOrg={currentOrg}
+        isUserOwner={isUserOwner}
+      />
+    </div>
+  );
+}
+
+interface OrgFormProps {
+  org: {
+    id: string;
+    name: string;
+    slug: string;
+    logoUrl: string | null;
+    socials: string | null;
+    settings: OrganizationSettings | null;
+  };
+  currentOrg: { id: string; logoUrl: string | null };
+  isUserOwner: boolean;
+}
+
+function OrgProfileForm({ org, currentOrg, isUserOwner }: OrgFormProps) {
+  const settings = useMemo(
+    () => safeParseOrgSettings(org?.settings),
+    [org?.settings],
+  );
+
   const { Field, handleSubmit, store } = useForm({
     defaultValues: {
       orgName: org?.name ?? "",
+      orgTimezone: settings.timezone,
       orgSlug: org?.slug ?? "",
       orgLogo: undefined,
       orgSocials: (() => {
@@ -131,11 +205,17 @@ function RouteComponent() {
         logoUrl = await uploadFile({ data: formData });
       }
 
+      const nextSettings = organizationSettingsSchema.parse({
+        ...settings,
+        timezone: value.orgTimezone,
+      });
+
       mutate.organization.update(currentOrg.id, {
         name: value.orgName,
         slug: value.orgSlug,
         logoUrl,
         socials: JSON.stringify({ discord: value.orgSocials }),
+        settings: nextSettings,
       });
     },
   });
@@ -144,11 +224,9 @@ function RouteComponent() {
     return Object.values(s.fieldMeta).some((field) => !field?.isDefaultValue);
   });
 
-  if (!org) return null;
-
   return (
     <form
-      className="p-4 flex flex-col gap-4 w-full"
+      className="flex flex-col gap-4 w-full"
       onSubmit={(e) => {
         e.preventDefault();
         handleSubmit();
@@ -241,6 +319,193 @@ function RouteComponent() {
                       className="w-full max-w-3xs"
                       disabled={!isUserOwner}
                     />
+                  </FormControl>
+                  <FormMessage />
+                </div>
+              </FormItem>
+            )}
+          </Field>
+          <Field name="orgTimezone">
+            {(field) => (
+              <FormItem field={field} className="flex justify-between">
+                <FormLabel>Timezone</FormLabel>
+                <FormControl>
+                  <Combobox
+                    items={timezoneItems}
+                    value={field.state.value}
+                    onValueChange={(value) => {
+                      if (value) field.setValue(value);
+                    }}
+                    disabled={!isUserOwner}
+                  >
+                    <ComboboxTrigger className="w-full max-w-3xs" />
+                    <ComboboxContent>
+                      <ComboboxInput placeholder="Search timezone..." />
+                      <ComboboxEmpty>No timezone found.</ComboboxEmpty>
+                      <ComboboxList>
+                        {(item: BaseItem) => (
+                          <ComboboxItem key={item.value} value={item.value}>
+                            {item.label}
+                          </ComboboxItem>
+                        )}
+                      </ComboboxList>
+                    </ComboboxContent>
+                  </Combobox>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          </Field>
+        </CardContent>
+      </Card>
+      {isUserOwner && (
+        <div className="flex justify-end">
+          <Button disabled={!nonPersistentIsDirty} type="submit">
+            Save
+          </Button>
+        </div>
+      )}
+    </form>
+  );
+}
+
+function DigestSettingsForm({ org, currentOrg, isUserOwner }: OrgFormProps) {
+  const settings = useMemo(
+    () => safeParseOrgSettings(org?.settings),
+    [org?.settings],
+  );
+
+  const slackIntegration = useLiveQuery(
+    query.integration.first({ organizationId: currentOrg?.id, type: "slack" }),
+  );
+  const hasSlack = !!slackIntegration?.enabled;
+
+  const { Field, handleSubmit, store } = useForm({
+    defaultValues: {
+      pendingReplyThresholdMinutes:
+        settings.digest.pendingReplyThresholdMinutes,
+      digestTime: settings.digest.time,
+      slackChannelName: settings.digest.slackChannelName ?? "",
+    } as z.infer<typeof digestFormSchema>,
+    validators: {
+      onSubmit: digestFormSchema,
+    },
+    onSubmit: ({ value }) => {
+      if (!currentOrg?.id) return;
+
+      const channelName = value.slackChannelName?.trim() || null;
+
+      const nextSettings = organizationSettingsSchema.parse({
+        ...settings,
+        digest: {
+          ...settings.digest,
+          pendingReplyThresholdMinutes: value.pendingReplyThresholdMinutes,
+          time: value.digestTime,
+          slackChannelId: channelName,
+          slackChannelName: channelName,
+        },
+      });
+
+      mutate.organization.update(currentOrg.id, {
+        settings: nextSettings,
+      });
+    },
+  });
+
+  const nonPersistentIsDirty = useStore(store, (s) => {
+    return Object.values(s.fieldMeta).some((field) => !field?.isDefaultValue);
+  });
+
+  return (
+    <form
+      className="flex flex-col gap-4 w-full"
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleSubmit();
+      }}
+      autoComplete="off"
+    >
+      <h2 className="text-base">Digest</h2>
+      <Card className="bg-[#27272A]/30">
+        <CardContent>
+          <Field name="pendingReplyThresholdMinutes">
+            {(field) => (
+              <FormItem field={field} className="flex justify-between">
+                <FormLabel>Pending reply threshold (minutes)</FormLabel>
+                <div className="flex flex-col w-full max-w-3xs">
+                  <FormControl>
+                    <Input
+                      id={field.name}
+                      type="number"
+                      min={5}
+                      max={1440}
+                      value={field.state.value}
+                      onChange={(e) => field.setValue(Number(e.target.value))}
+                      autoComplete="off"
+                      className="w-full max-w-3xs"
+                      disabled={!isUserOwner}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </div>
+              </FormItem>
+            )}
+          </Field>
+          <Field name="digestTime">
+            {(field) => (
+              <FormItem field={field} className="flex justify-between">
+                <FormLabel>Daily digest time</FormLabel>
+                <div className="flex flex-col w-full max-w-3xs">
+                  <FormControl>
+                    <Input
+                      id={field.name}
+                      type="time"
+                      value={field.state.value}
+                      onChange={(e) => field.setValue(e.target.value)}
+                      autoComplete="off"
+                      className="w-full max-w-3xs"
+                      disabled={!isUserOwner}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </div>
+              </FormItem>
+            )}
+          </Field>
+          <Field name="slackChannelName">
+            {(field) => (
+              <FormItem field={field} className="flex justify-between">
+                <FormLabel>Slack channel</FormLabel>
+                <div className="flex flex-col w-full max-w-3xs">
+                  <FormControl>
+                    {hasSlack ? (
+                      <Input
+                        id={field.name}
+                        value={field.state.value}
+                        onChange={(e) => field.setValue(e.target.value)}
+                        placeholder="#channel-name"
+                        autoComplete="off"
+                        className="w-full max-w-3xs"
+                        disabled={!isUserOwner}
+                      />
+                    ) : (
+                      <div className="flex items-center gap-2">
+                        <Input
+                          disabled
+                          placeholder="No Slack integration"
+                          className="w-full max-w-3xs"
+                        />
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          render={
+                            <Link to="/app/settings/organization/integration/slack">
+                              Connect Slack
+                            </Link>
+                          }
+                        />
+                      </div>
+                    )}
                   </FormControl>
                   <FormMessage />
                 </div>

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -8,7 +8,8 @@
   },
   "exports": {
     "./integration/*": "./src/integration/*.ts",
-    "./external-issue": "./src/external-issue.ts"
+    "./external-issue": "./src/external-issue.ts",
+    "./organization": "./src/organization.ts"
   },
   "dependencies": {
     "zod": "catalog:"

--- a/packages/schemas/src/organization.ts
+++ b/packages/schemas/src/organization.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+const digestSettingsDefaults = {
+  pendingReplyThresholdMinutes: 30,
+  time: "09:00",
+  slackChannelId: null,
+  slackChannelName: null,
+} as const;
+
+export const digestSettingsSchema = z.object({
+  pendingReplyThresholdMinutes: z.number().int().min(5).max(1440).default(30),
+  time: z
+    .string()
+    .regex(/^([01]\d|2[0-3]):[0-5]\d$/, "Must be HH:mm")
+    .default("09:00"),
+  slackChannelId: z.string().nullable().default(null),
+  slackChannelName: z.string().nullable().default(null),
+});
+
+export const organizationSettingsSchema = z.object({
+  timezone: z.string().default("UTC"),
+  digest: digestSettingsSchema.default(digestSettingsDefaults),
+});
+
+export type OrganizationSettings = z.infer<typeof organizationSettingsSchema>;
+
+/** Safely parse settings from the JSON column, falling back to defaults on null or invalid data. */
+export const safeParseOrgSettings = (
+  settings: unknown,
+): OrganizationSettings => {
+  if (!settings) return organizationSettingsSchema.parse({});
+  try {
+    return organizationSettingsSchema.parse(settings);
+  } catch {
+    return organizationSettingsSchema.parse({});
+  }
+};


### PR DESCRIPTION
## Summary
- Add `settings` JSON column (`jsonb`) to the `organization` table via live-state's `json<T>()` type
- Create `@workspace/schemas/organization` with `digestSettingsSchema`, `organizationSettingsSchema`, and `safeParseOrgSettings` helper (Zod defaults handle existing orgs with null settings)
- Add **Digest** settings section to org settings page: pending reply threshold (5–1440 min), daily digest time, Slack channel (free-text input, or "Connect Slack" CTA when no integration)
- Add **Timezone** combobox to the Organization profile card (searchable IANA timezone list)

## Test plan
- [ ] `bun run --filter api dev` boots — confirm `settings` jsonb column exists on `organization`
- [ ] Open org settings for an existing org — defaults show UTC / 30 / 09:00 / no channel
- [ ] Set threshold to 45, time to 08:30, channel to `#alerts`, save and reload — values persist
- [ ] Validation: threshold < 5 or > 1440 shows error; invalid time shows error
- [ ] Clear channel input and save — `slackChannelId` and `slackChannelName` are null
- [ ] Org without Slack integration shows disabled input + "Connect Slack" button
- [ ] Non-owner sees Digest section as read-only
- [ ] `bun run typecheck` and `bun run lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds org-level Digest settings and a Timezone field, backed by a new `settings` JSON column and a typed schema with safe defaults. Owners can configure threshold, daily time, and Slack channel; non-owners see read-only.

- **New Features**
  - `settings` JSON (`jsonb`) column on `organization` via `@live-state/sync` `json<T>()`; new `@workspace/schemas/organization` with `organizationSettingsSchema`, `digestSettingsSchema`, and `safeParseOrgSettings`.
  - Digest UI: pending reply threshold (5–1440 min), daily digest time (HH:mm), Slack channel input or “Connect Slack” when no Slack integration; non-owners are read-only.
  - Timezone combobox on Organization profile using a searchable IANA list; persisted in `settings`.

- **Bug Fixes**
  - `slackChannelId` is set to null and only the channel name is stored until the Slack channel ID can be resolved via API.

<sup>Written for commit 0a56c6c24ca4e1b513a7ef35765c19bd9aae41c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timezone configuration for organization settings
  * Digest settings: pending-reply threshold, digest time, and optional Slack channel
  * Slack channel input enabled only when Slack integration is active

* **Chores**
  * Organization settings can now be stored and validated server-side with a new settings schema
<!-- end of auto-generated comment: release notes by coderabbit.ai -->