### PR TITLE
feat(digest): detection scan & auto-resolution hooks

### DIFF
--- a/apps/api/src/lib/digest-signals.ts
+++ b/apps/api/src/lib/digest-signals.ts
@@ -1,0 +1,31 @@
+import type { ServerDB } from "@live-state/sync/server";
+import { schema } from "../live-state/schema";
+
+type DigestSignalType = "digest:pending_reply" | "digest:loop_to_close";
+
+/**
+ * Deactivate active digest signals for a thread.
+ * Used by message afterInsert, thread afterUpdate, and markAsAnswer hooks.
+ */
+export async function deactivateDigestSignals(
+  db: ServerDB<typeof schema>,
+  threadId: string,
+  types: DigestSignalType[],
+): Promise<void> {
+  const now = new Date();
+
+  for (const type of types) {
+    const suggestions = Object.values(
+      await db.find(schema.suggestion, {
+        where: { type, entityId: threadId, active: true },
+      }),
+    );
+
+    for (const suggestion of suggestions) {
+      await db.update(schema.suggestion, suggestion.id, {
+        active: false,
+        updatedAt: now,
+      });
+    }
+  }
+}

--- a/apps/api/src/lib/digest-signals.ts
+++ b/apps/api/src/lib/digest-signals.ts
@@ -9,6 +9,7 @@ type DigestSignalType = "digest:pending_reply" | "digest:loop_to_close";
  */
 export async function deactivateDigestSignals(
   db: ServerDB<typeof schema>,
+  organizationId: string,
   threadId: string,
   types: DigestSignalType[],
 ): Promise<void> {
@@ -17,7 +18,7 @@ export async function deactivateDigestSignals(
   for (const type of types) {
     const suggestions = Object.values(
       await db.find(schema.suggestion, {
-        where: { type, entityId: threadId, active: true },
+        where: { organizationId, type, entityId: threadId, active: true },
       }),
     );
 

--- a/apps/api/src/live-state/router/message.ts
+++ b/apps/api/src/live-state/router/message.ts
@@ -1,6 +1,7 @@
 import { ulid } from "ulid";
 import z from "zod";
 import { authorize } from "../../lib/authorize";
+import { deactivateDigestSignals } from "../../lib/digest-signals";
 import { enqueueIngestThreadJob } from "../../lib/queue";
 import { searchMessages } from "../../lib/search/qdrant";
 import { publicRoute } from "../factories";
@@ -191,6 +192,17 @@ export default publicRoute
             status: STATUS_RESOLVED,
           });
         });
+
+        // Deactivate digest signals since thread is now Resolved
+        deactivateDigestSignals(db, thread.id, [
+          "digest:pending_reply",
+          "digest:loop_to_close",
+        ]).catch((error) => {
+          console.error(
+            `Failed to deactivate digest signals for thread ${thread.id}:`,
+            error,
+          );
+        });
       }
 
       const updatedMessage = await db.message
@@ -221,7 +233,7 @@ export default publicRoute
     }),
   }))
   .withHooks({
-    afterInsert: ({ value }) => {
+    afterInsert: ({ value, db }) => {
       (async () => {
         try {
           const queuePriority = value.isBackfill ? "low" : "high";
@@ -234,6 +246,18 @@ export default publicRoute
             console.warn(
               `Redis queue not configured; skipping ingest-thread enqueue for thread ${value.threadId}`,
             );
+          }
+
+          // Only dismiss digest signals if the message author is the thread's assignee
+          const author = await db.findOne(schema.author, value.authorId);
+          if (author?.userId) {
+            const thread = await db.findOne(schema.thread, value.threadId);
+            if (thread?.assignedUserId === author.userId) {
+              await deactivateDigestSignals(db, value.threadId, [
+                "digest:pending_reply",
+                "digest:loop_to_close",
+              ]);
+            }
           }
         } catch (error) {
           console.error(

--- a/apps/api/src/live-state/router/message.ts
+++ b/apps/api/src/live-state/router/message.ts
@@ -194,7 +194,7 @@ export default publicRoute
         });
 
         // Deactivate digest signals since thread is now Resolved
-        deactivateDigestSignals(db, thread.id, [
+        deactivateDigestSignals(db, thread.organizationId, thread.id, [
           "digest:pending_reply",
           "digest:loop_to_close",
         ]).catch((error) => {
@@ -247,21 +247,33 @@ export default publicRoute
               `Redis queue not configured; skipping ingest-thread enqueue for thread ${value.threadId}`,
             );
           }
+        } catch (error) {
+          console.error(
+            `Unhandled error in afterInsert ingest enqueue for message ${value.id}`,
+            error,
+          );
+        }
 
-          // Only dismiss digest signals if the message author is the thread's assignee
-          const author = await db.findOne(schema.author, value.authorId);
-          if (author?.userId) {
-            const thread = await db.findOne(schema.thread, value.threadId);
-            if (thread?.assignedUserId === author.userId) {
-              await deactivateDigestSignals(db, value.threadId, [
-                "digest:pending_reply",
-                "digest:loop_to_close",
-              ]);
+        // Digest signal cleanup — separate from ingest enqueue so a queue
+        // failure doesn't prevent assignee replies from clearing signals.
+        try {
+          if (!value.isBackfill) {
+            const author = await db.findOne(schema.author, value.authorId);
+            if (author?.userId) {
+              const thread = await db.findOne(schema.thread, value.threadId);
+              if (thread?.assignedUserId === author.userId) {
+                await deactivateDigestSignals(
+                  db,
+                  thread.organizationId,
+                  value.threadId,
+                  ["digest:pending_reply", "digest:loop_to_close"],
+                );
+              }
             }
           }
         } catch (error) {
           console.error(
-            `Unhandled error in afterInsert hook for message ${value.id}`,
+            `Failed to deactivate digest signals for message ${value.id}`,
             error,
           );
         }

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -6,6 +6,7 @@ import {
 import { ulid } from "ulid";
 import z from "zod";
 import { createReadThroughCache } from "../../lib/cache/read-through.js";
+import { deactivateDigestSignals } from "../../lib/digest-signals";
 import { publicRoute } from "../factories";
 import { schema } from "../schema";
 
@@ -837,4 +838,24 @@ export default publicRoute
         },
       };
     }),
-  }));
+  }))
+  .withHooks({
+    afterUpdate: ({ value, previousValue, db }) => {
+      const CLOSED_STATUSES = [2, 3, 4]; // Resolved, Closed, Duplicated
+      if (
+        previousValue &&
+        !CLOSED_STATUSES.includes(previousValue.status) &&
+        CLOSED_STATUSES.includes(value.status)
+      ) {
+        deactivateDigestSignals(db, value.id, [
+          "digest:pending_reply",
+          "digest:loop_to_close",
+        ]).catch((error) => {
+          console.error(
+            `Failed to deactivate digest signals for thread ${value.id}:`,
+            error,
+          );
+        });
+      }
+    },
+  });

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -847,7 +847,7 @@ export default publicRoute
         !CLOSED_STATUSES.includes(previousValue.status) &&
         CLOSED_STATUSES.includes(value.status)
       ) {
-        deactivateDigestSignals(db, value.id, [
+        deactivateDigestSignals(db, value.organizationId, value.id, [
           "digest:pending_reply",
           "digest:loop_to_close",
         ]).catch((error) => {

--- a/apps/worker/src/handlers/digest-scan.ts
+++ b/apps/worker/src/handlers/digest-scan.ts
@@ -1,0 +1,264 @@
+import type { Job } from "bullmq";
+import { safeParseOrgSettings } from "@workspace/schemas/organization";
+import { ulid } from "ulid";
+import { fetchClient } from "../lib/database/client";
+
+const SUGGESTION_TYPE_PENDING_REPLY = "digest:pending_reply";
+const SUGGESTION_TYPE_LOOP_TO_CLOSE = "digest:loop_to_close";
+const SUGGESTION_TYPE_LINKED_PR = "linked_pr";
+const OPEN_STATUSES = [0, 1]; // Open, In Progress
+
+type SuggestionRow = {
+  id: string;
+  type: string;
+  entityId: string;
+  relatedEntityId: string | null;
+  active: boolean;
+  accepted: boolean;
+  organizationId: string;
+  resultsStr: string | null;
+  metadataStr: string | null;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+};
+
+type ThreadRow = {
+  id: string;
+  organizationId: string;
+  status: number;
+  deletedAt: Date | string | null;
+  externalPrId: string | null;
+  messages: Array<{
+    id: string;
+    authorId: string;
+    createdAt: Date | string;
+    isBackfill: boolean;
+  }>;
+};
+
+type AuthorRow = {
+  id: string;
+  userId: string | null;
+  metaId: string | null;
+  name: string;
+  organizationId: string | null;
+};
+
+type OrgRow = {
+  id: string;
+  settings: unknown;
+};
+
+/**
+ * Digest scan handler — runs every 5 minutes.
+ * Detects pending-reply and loop-to-close conditions, creates digest signals.
+ */
+export const handleDigestScan = async (_job: Job) => {
+  console.log("\n🔍 Digest scan: starting");
+
+  const organizations = (await fetchClient.query.organization.get()) as OrgRow[];
+
+  let totalPendingReply = 0;
+  let totalLoopToClose = 0;
+
+  for (const org of organizations) {
+    const settings = safeParseOrgSettings(org.settings);
+    const thresholdMs =
+      settings.digest.pendingReplyThresholdMinutes * 60 * 1000;
+
+    try {
+      const result = await scanOrganization(org.id, thresholdMs);
+      totalPendingReply += result.pendingReplyCreated;
+      totalLoopToClose += result.loopToCloseCreated;
+    } catch (error) {
+      console.error(`Digest scan failed for org ${org.id}:`, error);
+    }
+  }
+
+  console.log(
+    `🔍 Digest scan complete: ${totalPendingReply} pending-reply, ${totalLoopToClose} loop-to-close signals created`,
+  );
+
+  return { totalPendingReply, totalLoopToClose };
+};
+
+async function scanOrganization(
+  organizationId: string,
+  thresholdMs: number,
+): Promise<{ pendingReplyCreated: number; loopToCloseCreated: number }> {
+  // Fetch open/in-progress threads with messages
+  const threads = (await fetchClient.query.thread
+    .where({
+      organizationId,
+      status: { $in: OPEN_STATUSES },
+      deletedAt: null,
+    })
+    .include({ messages: true })
+    .get()) as ThreadRow[];
+
+  if (threads.length === 0) {
+    return { pendingReplyCreated: 0, loopToCloseCreated: 0 };
+  }
+
+  // Fetch existing active digest signals for dedup
+  const existingSignals = (await fetchClient.query.suggestion
+    .where({
+      organizationId,
+      type: { $in: [SUGGESTION_TYPE_PENDING_REPLY, SUGGESTION_TYPE_LOOP_TO_CLOSE] },
+      active: true,
+    })
+    .get()) as SuggestionRow[];
+
+  const activeSignalSet = new Set(
+    existingSignals.map((s) => `${s.type}:${s.entityId}`),
+  );
+
+  // Build author cache to avoid repeated lookups
+  const authorIds = new Set<string>();
+  for (const thread of threads) {
+    for (const msg of thread.messages) {
+      authorIds.add(msg.authorId);
+    }
+  }
+
+  const authorMap = new Map<string, AuthorRow>();
+  if (authorIds.size > 0) {
+    const authors = (await fetchClient.query.author
+      .where({ id: { $in: [...authorIds] } })
+      .get()) as AuthorRow[];
+    for (const author of authors) {
+      authorMap.set(author.id, author);
+    }
+  }
+
+  let pendingReplyCreated = 0;
+  let loopToCloseCreated = 0;
+
+  for (const thread of threads) {
+    // Skip threads with no messages
+    if (!thread.messages || thread.messages.length === 0) continue;
+
+    // Skip backfill-only threads
+    const hasNonBackfillMessage = thread.messages.some((m) => !m.isBackfill);
+    if (!hasNonBackfillMessage) continue;
+
+    // Skip bot-only threads (no external human ever wrote — all authors have userId set or no real participants)
+    const hasExternalHuman = thread.messages.some((m) => {
+      const author = authorMap.get(m.authorId);
+      return author && !author.userId;
+    });
+    if (!hasExternalHuman) continue;
+
+    // --- Pending reply detection ---
+    if (!activeSignalSet.has(`${SUGGESTION_TYPE_PENDING_REPLY}:${thread.id}`)) {
+      const sortedMessages = [...thread.messages].sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
+
+      const lastMessage = sortedMessages[0]!;
+      const lastAuthor = authorMap.get(lastMessage.authorId);
+
+      // External author (userId is null) and past threshold
+      if (lastAuthor && !lastAuthor.userId) {
+        const messageAge = Date.now() - new Date(lastMessage.createdAt).getTime();
+        if (messageAge > thresholdMs) {
+          await createDigestSignal({
+            type: SUGGESTION_TYPE_PENDING_REPLY,
+            threadId: thread.id,
+            organizationId,
+            resultsStr: JSON.stringify({
+              detectedAt: new Date().toISOString(),
+              lastMessageAt: new Date(lastMessage.createdAt).toISOString(),
+              thresholdMinutes: thresholdMs / 60_000,
+            }),
+          });
+          pendingReplyCreated++;
+        }
+      }
+    }
+
+    // --- Loop to close detection ---
+    if (
+      thread.externalPrId &&
+      !activeSignalSet.has(`${SUGGESTION_TYPE_LOOP_TO_CLOSE}:${thread.id}`)
+    ) {
+      // Find the accepted linked_pr suggestion for this thread to get the link timestamp
+      const linkedPrSuggestions = (await fetchClient.query.suggestion
+        .where({
+          type: SUGGESTION_TYPE_LINKED_PR,
+          entityId: thread.id,
+          organizationId,
+          accepted: true,
+        })
+        .get()) as SuggestionRow[];
+
+      const linkedPrSuggestion = linkedPrSuggestions[0];
+      if (linkedPrSuggestion) {
+        const linkedAt = new Date(linkedPrSuggestion.updatedAt).getTime();
+
+        // Check if any internal author posted after the PR was linked
+        const hasAgentReplyAfterLink = thread.messages.some((m) => {
+          const author = authorMap.get(m.authorId);
+          return (
+            author?.userId &&
+            new Date(m.createdAt).getTime() > linkedAt
+          );
+        });
+
+        if (!hasAgentReplyAfterLink) {
+          // Parse PR merge info from the linked_pr suggestion
+          let prMergedAt: string | null = null;
+          try {
+            const results = linkedPrSuggestion.resultsStr
+              ? JSON.parse(linkedPrSuggestion.resultsStr)
+              : null;
+            // Use suggestion updatedAt as proxy for merge time
+            prMergedAt = new Date(linkedPrSuggestion.updatedAt).toISOString();
+            if (results?.prId) {
+              // Store the PR reference
+            }
+          } catch {
+            prMergedAt = new Date(linkedPrSuggestion.updatedAt).toISOString();
+          }
+
+          await createDigestSignal({
+            type: SUGGESTION_TYPE_LOOP_TO_CLOSE,
+            threadId: thread.id,
+            organizationId,
+            resultsStr: JSON.stringify({
+              detectedAt: new Date().toISOString(),
+              linkedPrId: thread.externalPrId,
+              prMergedAt,
+            }),
+          });
+          loopToCloseCreated++;
+        }
+      }
+    }
+  }
+
+  return { pendingReplyCreated, loopToCloseCreated };
+}
+
+async function createDigestSignal(params: {
+  type: string;
+  threadId: string;
+  organizationId: string;
+  resultsStr: string;
+}): Promise<void> {
+  const now = new Date();
+  await fetchClient.mutate.suggestion.insert({
+    id: ulid().toLowerCase(),
+    type: params.type,
+    entityId: params.threadId,
+    relatedEntityId: null,
+    organizationId: params.organizationId,
+    active: true,
+    accepted: false,
+    resultsStr: params.resultsStr,
+    metadataStr: JSON.stringify({ digestIncludedAt: [] }),
+    createdAt: now,
+    updatedAt: now,
+  });
+}

--- a/apps/worker/src/handlers/digest-scan.ts
+++ b/apps/worker/src/handlers/digest-scan.ts
@@ -131,6 +131,49 @@ async function scanOrganization(
     }
   }
 
+  // Preload accepted linked_pr suggestions for all candidate threads (avoids N+1)
+  const prCandidateThreadIds = threads
+    .filter((t) => t.externalPrId)
+    .map((t) => t.id);
+
+  const linkedPrMap = new Map<string, SuggestionRow>();
+  if (prCandidateThreadIds.length > 0) {
+    const linkedPrSuggestions = (await fetchClient.query.suggestion
+      .where({
+        organizationId,
+        type: SUGGESTION_TYPE_LINKED_PR,
+        entityId: { $in: prCandidateThreadIds },
+        accepted: true,
+      })
+      .get()) as SuggestionRow[];
+
+    // Key by "threadId:externalPrId" — keep the latest per key
+    for (const s of linkedPrSuggestions) {
+      const thread = threads.find((t) => t.id === s.entityId);
+      if (!thread?.externalPrId) continue;
+
+      // Match suggestion to the thread's current PR via resultsStr
+      try {
+        const results = s.resultsStr ? JSON.parse(s.resultsStr) : null;
+        const suggestionPrRef = results
+          ? `github:${results.repo}#${results.prId}`
+          : null;
+        if (suggestionPrRef !== thread.externalPrId) continue;
+      } catch {
+        continue;
+      }
+
+      const key = `${s.entityId}:${thread.externalPrId}`;
+      const existing = linkedPrMap.get(key);
+      if (
+        !existing ||
+        new Date(s.updatedAt).getTime() > new Date(existing.updatedAt).getTime()
+      ) {
+        linkedPrMap.set(key, s);
+      }
+    }
+  }
+
   let pendingReplyCreated = 0;
   let loopToCloseCreated = 0;
 
@@ -183,17 +226,9 @@ async function scanOrganization(
       thread.externalPrId &&
       !activeSignalSet.has(`${SUGGESTION_TYPE_LOOP_TO_CLOSE}:${thread.id}`)
     ) {
-      // Find the accepted linked_pr suggestion for this thread to get the link timestamp
-      const linkedPrSuggestions = (await fetchClient.query.suggestion
-        .where({
-          type: SUGGESTION_TYPE_LINKED_PR,
-          entityId: thread.id,
-          organizationId,
-          accepted: true,
-        })
-        .get()) as SuggestionRow[];
+      const key = `${thread.id}:${thread.externalPrId}`;
+      const linkedPrSuggestion = linkedPrMap.get(key);
 
-      const linkedPrSuggestion = linkedPrSuggestions[0];
       if (linkedPrSuggestion) {
         const linkedAt = new Date(linkedPrSuggestion.updatedAt).getTime();
 
@@ -207,20 +242,7 @@ async function scanOrganization(
         });
 
         if (!hasAgentReplyAfterLink) {
-          // Parse PR merge info from the linked_pr suggestion
-          let prMergedAt: string | null = null;
-          try {
-            const results = linkedPrSuggestion.resultsStr
-              ? JSON.parse(linkedPrSuggestion.resultsStr)
-              : null;
-            // Use suggestion updatedAt as proxy for merge time
-            prMergedAt = new Date(linkedPrSuggestion.updatedAt).toISOString();
-            if (results?.prId) {
-              // Store the PR reference
-            }
-          } catch {
-            prMergedAt = new Date(linkedPrSuggestion.updatedAt).toISOString();
-          }
+          const prMergedAt = new Date(linkedPrSuggestion.updatedAt).toISOString();
 
           await createDigestSignal({
             type: SUGGESTION_TYPE_LOOP_TO_CLOSE,

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -1,6 +1,7 @@
-import { type Job, Worker } from "bullmq";
+import { type Job, Queue, Worker } from "bullmq";
 import Redis from "ioredis";
 import { handleCrawlDocumentation } from "./handlers/crawl-documentation";
+import { handleDigestScan } from "./handlers/digest-scan";
 import { handleEmbedPr } from "./handlers/embed-pr";
 import { ensureDocumentationCollection } from "./lib/qdrant/documentation";
 import { ensureMessagesCollection } from "./lib/qdrant/messages";
@@ -12,6 +13,7 @@ import { registerDefaultProcessors } from "./pipeline/processors/registration";
 const INGEST_THREAD_QUEUE = "ingest-thread";
 const CRAWL_DOCUMENTATION_QUEUE = "crawl-documentation";
 const EMBED_PR_QUEUE = "embed-pr";
+const DIGEST_SCAN_QUEUE = "digest-scan";
 
 interface IngestThreadJobData {
   threadIds: string[];
@@ -173,6 +175,38 @@ const embedPrWorker = new Worker(
   },
 );
 
+// Create digest-scan queue (for job scheduler) and worker
+const digestScanQueue = new Queue(DIGEST_SCAN_QUEUE, { connection });
+const digestScanWorker = new Worker(
+  DIGEST_SCAN_QUEUE,
+  handleDigestScan,
+  {
+    connection,
+    autorun: false,
+    concurrency: 1,
+    removeOnComplete: {
+      count: 50,
+      age: 24 * 3600,
+    },
+    removeOnFail: {
+      count: 500,
+    },
+  },
+);
+
+digestScanWorker.on("completed", (job) => {
+  console.log(`✅ Digest-scan job ${job.id} has been completed`);
+});
+
+digestScanWorker.on("failed", (job, err) => {
+  console.error(`❌ Digest-scan job ${job?.id} has failed:`, err.message);
+  console.error(err);
+});
+
+digestScanWorker.on("error", (err) => {
+  console.error("Digest-scan worker error:", err);
+});
+
 embedPrWorker.on("completed", (job) => {
   console.log(`✅ Embed-pr job ${job.id} has been completed`);
 });
@@ -226,10 +260,17 @@ const initialize = async () => {
 
   console.log("✅ Qdrant collections ready");
 
+  // Register digest scan scheduler (every 5 minutes)
+  await digestScanQueue.upsertJobScheduler("digest-scan", {
+    every: 300_000,
+  });
+  console.log("✅ Digest scan scheduler registered (every 5 min)");
+
   // Start workers now that collections are ready
   ingestThreadWorker.run();
   crawlDocWorker.run();
   embedPrWorker.run();
+  digestScanWorker.run();
 
   console.log("\nListening for jobs...");
 };
@@ -237,7 +278,7 @@ const initialize = async () => {
 // Graceful shutdown
 const handleShutdown = async () => {
   console.log("\nShutting down workers...");
-  await Promise.all([ingestThreadWorker.close(), crawlDocWorker.close(), embedPrWorker.close()]);
+  await Promise.all([ingestThreadWorker.close(), crawlDocWorker.close(), embedPrWorker.close(), digestScanWorker.close()]);
   await connection.quit();
   console.log("Workers shut down successfully");
   process.exit(0);


### PR DESCRIPTION
## Summary
- **`digest:scan` cron job** — BullMQ repeatable job (every 5 min) that scans all orgs for two signal types:
  - `digest:pending_reply` — customer wrote last, no assignee reply within threshold
  - `digest:loop_to_close` — thread has a linked merged PR with no agent reply since linking
- **Auto-resolution hooks** — deactivate digest signals event-driven:
  - Message `afterInsert`: clears both signals if the author is the thread's assignee
  - `markAsAnswer`: clears both signals when thread is resolved
  - Thread `afterUpdate`: clears both signals on status change to Resolved/Closed/Duplicated
- **Shared utility** `deactivateDigestSignals()` for reuse across all hook sites

Implements Epic 2 (AS-3, AS-4) of the [digest spec](./docs/digest-spec.md). Depends on Epic 1 (digest settings model + UI) which shipped in #241.

## Test plan
- [ ] Run `bun dev`, create a thread from the portal as an external user, lower pending reply threshold to 5 min in org settings, wait for scan — verify `digest:pending_reply` suggestion appears in DB
- [ ] Reply as the assigned user — verify the signal becomes `active = false`
- [ ] Link a merged PR to a thread, wait for scan — verify `digest:loop_to_close` suggestion appears
- [ ] Close/resolve the thread — verify all digest signals are deactivated
- [ ] Run scan twice on same data — verify no duplicate signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a scheduled `digest:scan` job to detect pending-reply and loop-to-close signals, and auto-resolves them when agents reply or threads close. Implements digest spec Epic 2 (AS-3, AS-4).

- **New Features**
  - 5‑min `bullmq` `digest:scan` scans all orgs for `digest:pending_reply` and `digest:loop_to_close`, de‑dupes signals, and stores context in `suggestion` rows.
  - Auto-resolution hooks: assignee reply, mark‑as‑answer, and status change to Resolved/Closed/Duplicated deactivate active signals; shared `deactivateDigestSignals()` utility.

- **Bug Fixes**
  - Scoped signal deactivation by `organizationId` and gated cleanup on non‑backfill messages; cleanup runs independently of ingest enqueue.
  - Batched accepted `linked_pr` lookups and matched to current `externalPrId` to avoid N+1 queries and false positives.

<sup>Written for commit 7dd31c2825288e862e306f2c312417aa12ca9b02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic digest signal management: signals are now deactivated when threads are resolved or closed.
  * Periodic background scan that creates digest signals for pending-reply and loop-to-close cases to surface threads needing attention.
* **Bug Fixes**
  * Digest cleanup now runs reliably after message/assignment changes and is isolated from other background processing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->