### PR TITLE
refactor(api): use new live-state procedure model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ Live-State provides:
 
 ### Live-State authorization
 
-- Prefer **server procedures** (`.withProcedures` / `.withMutations` handlers) for new writes and sensitive reads, and start handlers with **`authorize()`** from `apps/api/src/lib/authorize.ts` using `{ organizationId, role?: "owner", allowPublicApiKey?: true }` instead of repeating `db.find(organizationUser, …)` (see `apps/api/src/live-state/router/message.ts`).
+- Prefer **server procedures** (`.withProcedures` handlers) for new writes and sensitive reads, and start handlers with **`authorize()`** from `apps/api/src/lib/authorize.ts` using `{ organizationId, role?: "owner", allowPublicApiKey?: true }` instead of repeating `db.find(organizationUser, …)` (see `apps/api/src/live-state/router/message.ts`).
 - Keep `collectionRoute` `read` / `insert` / `update` rules only where clients or workers still need filtered sync CRUD; tighten toward procedure-only writes as call sites migrate (`docs/live-state-procedures-migration-plan.md`).
 
 ### Worker Pipeline

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,11 @@ Live-State provides:
 - One-time token authentication (via Better-Auth plugin)
 - Reactive queries with local IndexedDB storage
 
+### Live-State authorization
+
+- Prefer **server procedures** (`.withProcedures` / `.withMutations` handlers) for new writes and sensitive reads, and start handlers with **`authorize()`** from `apps/api/src/lib/authorize.ts` using `{ organizationId, role?: "owner", allowPublicApiKey?: true }` instead of repeating `db.find(organizationUser, …)` (see `apps/api/src/live-state/router/message.ts`).
+- Keep `collectionRoute` `read` / `insert` / `update` rules only where clients or workers still need filtered sync CRUD; tighten toward procedure-only writes as call sites migrate (`docs/live-state-procedures-migration-plan.md`).
+
 ### Worker Pipeline
 
 Thread ingestion runs in 3 stages:

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,13 +2,13 @@ import "./env";
 
 import "./lib/api-key";
 
+import process from "node:process";
 import { Webhooks } from "@dodopayments/express";
 import { expressAdapter, server } from "@live-state/sync/server";
 import expressWs from "@wll8/express-ws";
 import { toNodeHandler } from "better-auth/node";
 import cors from "cors";
 import express from "express";
-import process from "node:process";
 import { publicKeys } from "./lib/api-key";
 import { auth } from "./lib/auth";
 import { reflagClient } from "./lib/feature-flag";
@@ -121,6 +121,17 @@ const lsServer = server({
       const orgUsers = Object.values(
         await storage.find(schema.organizationUser, {
           where: { userId: session.user.id, enabled: true },
+        }),
+      );
+      return { ...session, portalSession, orgUsers };
+    }
+
+    const portalUserId =
+      portalSession?.user?.id ?? portalSession?.session?.userId;
+    if (portalUserId) {
+      const orgUsers = Object.values(
+        await storage.find(schema.organizationUser, {
+          where: { userId: portalUserId, enabled: true },
         }),
       );
       return { ...session, portalSession, orgUsers };

--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -4,14 +4,12 @@ import { addDays, addYears } from "date-fns";
 import { ulid } from "ulid";
 import { z } from "zod";
 import { publicKeys } from "../lib/api-key";
+import { authorize } from "../lib/authorize";
 import { dodopayments } from "../lib/payment";
 import { resend } from "../lib/resend";
 import { sendWelcomeEmail } from "../trigger/send-welcome-email";
 import { privateRoute, publicRoute } from "./factories";
-import {
-  agentChatMessageRoute,
-  agentChatRoute,
-} from "./router/agent-chat";
+import { agentChatMessageRoute, agentChatRoute } from "./router/agent-chat";
 import documentationSourcesRoute from "./router/documentation-sources";
 import labelsRoute from "./router/labels";
 import messageRoute from "./router/message";
@@ -143,8 +141,7 @@ export const router = createRouter({
           );
 
           if (userMemberships.length === 1) {
-            const delayMinutes =
-              Math.floor(Math.random() * 21) + 20;
+            const delayMinutes = Math.floor(Math.random() * 21) + 20;
 
             sendWelcomeEmail
               .trigger(
@@ -170,31 +167,13 @@ export const router = createRouter({
             expiresAt: z.iso.datetime().optional(),
             name: z.string().optional(),
           }),
-        ).handler(async ({ req, db }) => {
+        ).handler(async ({ req }) => {
           const organizationId = req.input.organizationId;
 
-          let authorized = !!req.context?.internalApiKey;
-
-          if (!authorized && req.context?.session?.userId) {
-            const selfOrgUser = Object.values(
-              await db.find(schema.organizationUser, {
-                where: {
-                  organizationId,
-                  userId: req.context.session.userId,
-                },
-                include: {
-                  user: true,
-                  organization: true,
-                },
-              }),
-            )[0] as any;
-
-            authorized = selfOrgUser && selfOrgUser.role === "owner";
-          }
-
-          if (!authorized) {
-            throw new Error("UNAUTHORIZED");
-          }
+          authorize(req.context, {
+            organizationId,
+            role: "owner",
+          });
 
           const publicApiKey = await publicKeys.create({
             ownerId: organizationId,
@@ -215,29 +194,17 @@ export const router = createRouter({
           z.object({
             id: z.string(),
           }),
-        ).handler(async ({ req, db }) => {
-          if (!req.context?.session?.userId) {
-            throw new Error("UNAUTHORIZED");
-          }
-
+        ).handler(async ({ req }) => {
           const publicApiKey = await publicKeys.findById(req.input.id);
 
           if (!publicApiKey) {
             throw new Error("PUBLIC_API_KEY_NOT_FOUND");
           }
 
-          const selfOrgUser = Object.values(
-            await db.find(schema.organizationUser, {
-              where: {
-                organizationId: publicApiKey.metadata.ownerId,
-                userId: req.context.session.userId,
-              },
-            }),
-          )[0] as any;
-
-          if (!selfOrgUser || selfOrgUser.role !== "owner") {
-            throw new Error("UNAUTHORIZED");
-          }
+          authorize(req.context, {
+            organizationId: publicApiKey.metadata.ownerId,
+            role: "owner",
+          });
 
           await publicKeys.revoke(publicApiKey.id).catch((error) => {
             console.error("Error revoking public API key", error);
@@ -252,27 +219,13 @@ export const router = createRouter({
           z.object({
             organizationId: z.string(),
           }),
-        ).handler(async ({ req, db }) => {
+        ).handler(async ({ req }) => {
           const organizationId = req.input.organizationId;
 
-          let authorized = !!req.context?.internalApiKey;
-
-          if (!authorized && req.context?.session?.userId) {
-            const selfOrgUser = Object.values(
-              await db.find(schema.organizationUser, {
-                where: {
-                  organizationId,
-                  userId: req.context.session.userId,
-                },
-              }),
-            )[0] as any;
-
-            authorized = selfOrgUser && selfOrgUser.role === "owner";
-          }
-
-          if (!authorized) {
-            throw new Error("UNAUTHORIZED");
-          }
+          authorize(req.context, {
+            organizationId,
+            role: "owner",
+          });
 
           const apiKeys = await publicKeys.list(organizationId);
 

--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -53,7 +53,7 @@ export const router = createRouter({
           },
         },
       })
-      .withMutations(({ mutation }) => ({
+      .withProcedures(({ mutation }) => ({
         create: mutation(
           z.object({
             name: z.string(),
@@ -275,7 +275,7 @@ export const router = createRouter({
           },
         },
       })
-      .withMutations(({ mutation }) => ({
+      .withProcedures(({ mutation }) => ({
         inviteUser: mutation(
           z.object({
             organizationId: z.string(),
@@ -466,7 +466,7 @@ export const router = createRouter({
           },
         },
       })
-      .withMutations(({ mutation }) => ({
+      .withProcedures(({ mutation }) => ({
         accept: mutation(z.object({ id: z.string() })).handler(
           async ({ req, db }) => {
             await db.transaction(async ({ trx }) => {

--- a/apps/api/src/live-state/router/agent-chat.ts
+++ b/apps/api/src/live-state/router/agent-chat.ts
@@ -38,7 +38,7 @@ export const agentChatRoute = privateRoute
       postMutation: () => false,
     },
   })
-  .withMutations(({ mutation }) => ({
+  .withProcedures(({ mutation }) => ({
     create: mutation(
       z.object({
         organizationId: z.string(),

--- a/apps/api/src/live-state/router/documentation-sources.ts
+++ b/apps/api/src/live-state/router/documentation-sources.ts
@@ -174,7 +174,7 @@ export default privateRoute
       postMutation: ({ ctx }) => !!ctx?.internalApiKey,
     },
   })
-  .withMutations(({ mutation }) => ({
+  .withProcedures(({ mutation }) => ({
     validateDocumentationSource: mutation(
       z.object({
         organizationId: z.string(),

--- a/apps/api/src/live-state/router/documentation-sources.ts
+++ b/apps/api/src/live-state/router/documentation-sources.ts
@@ -1,6 +1,7 @@
 import dns from "node:dns/promises";
 import { ulid } from "ulid";
 import { z } from "zod";
+import { authorize } from "../../lib/authorize";
 import { reflagClient } from "../../lib/feature-flag";
 import { enqueueCrawlDocumentation } from "../../lib/queue";
 import { privateRoute } from "../factories";
@@ -51,7 +52,9 @@ async function assertPublicUrl(url: string): Promise<void> {
   }
   for (const addr of allAddresses) {
     if (isPrivateIP(addr)) {
-      throw new Error("URLs resolving to private or reserved IP addresses are not allowed");
+      throw new Error(
+        "URLs resolving to private or reserved IP addresses are not allowed",
+      );
     }
   }
 }
@@ -64,7 +67,10 @@ async function validateDocumentationUrl(baseUrl: string): Promise<{
   try {
     await assertPublicUrl(baseUrl);
   } catch (err) {
-    return { valid: false, error: err instanceof Error ? err.message : "Invalid URL" };
+    return {
+      valid: false,
+      error: err instanceof Error ? err.message : "Invalid URL",
+    };
   }
 
   // 1. Check sitemap.xml exists
@@ -76,7 +82,10 @@ async function validateDocumentationUrl(baseUrl: string): Promise<{
       signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok) {
-      return { valid: false, error: `Sitemap not found at ${sitemapUrl} (HTTP ${res.status})` };
+      return {
+        valid: false,
+        error: `Sitemap not found at ${sitemapUrl} (HTTP ${res.status})`,
+      };
     }
     sitemapText = await res.text();
   } catch {
@@ -171,28 +180,10 @@ export default privateRoute
         organizationId: z.string(),
         baseUrl: z.string().url(),
       }),
-    ).handler(async ({ req, db }) => {
+    ).handler(async ({ req }) => {
       const { organizationId, baseUrl } = req.input;
 
-      // Authorization check
-      if (!req.context?.internalApiKey && req.context?.session?.userId) {
-        const selfOrgUser = Object.values(
-          await db.find(schema.organizationUser, {
-            where: {
-              organizationId,
-              userId: req.context.session.userId,
-              enabled: true,
-              role: "owner",
-            },
-          }),
-        )[0];
-
-        if (!selfOrgUser) {
-          throw new Error("UNAUTHORIZED");
-        }
-      } else if (!req.context?.internalApiKey) {
-        throw new Error("UNAUTHORIZED");
-      }
+      authorize(req.context, { organizationId, role: "owner" });
 
       await checkFeatureFlag(organizationId);
 
@@ -214,25 +205,7 @@ export default privateRoute
     ).handler(async ({ req, db }) => {
       const { organizationId, name, baseUrl } = req.input;
 
-      // Authorization check
-      if (!req.context?.internalApiKey && req.context?.session?.userId) {
-        const selfOrgUser = Object.values(
-          await db.find(schema.organizationUser, {
-            where: {
-              organizationId,
-              userId: req.context.session.userId,
-              enabled: true,
-              role: "owner",
-            },
-          }),
-        )[0];
-
-        if (!selfOrgUser) {
-          throw new Error("UNAUTHORIZED");
-        }
-      } else if (!req.context?.internalApiKey) {
-        throw new Error("UNAUTHORIZED");
-      }
+      authorize(req.context, { organizationId, role: "owner" });
 
       // Feature flag check
       await checkFeatureFlag(organizationId);
@@ -264,12 +237,15 @@ export default privateRoute
           baseUrl,
         });
         if (!jobId) {
-          throw new Error("Queue unavailable: crawl job could not be scheduled");
+          throw new Error(
+            "Queue unavailable: crawl job could not be scheduled",
+          );
         }
       } catch (err) {
         await db.update(schema.documentationSource, id, {
           status: "failed",
-          errorStr: err instanceof Error ? err.message : "Failed to schedule crawl",
+          errorStr:
+            err instanceof Error ? err.message : "Failed to schedule crawl",
           updatedAt: new Date(),
         });
         throw err;
@@ -290,25 +266,10 @@ export default privateRoute
         throw new Error("DOCUMENTATION_SOURCE_NOT_FOUND");
       }
 
-      // Authorization check
-      if (!req.context?.internalApiKey && req.context?.session?.userId) {
-        const selfOrgUser = Object.values(
-          await db.find(schema.organizationUser, {
-            where: {
-              organizationId: source.organizationId,
-              userId: req.context.session.userId,
-              enabled: true,
-              role: "owner",
-            },
-          }),
-        )[0];
-
-        if (!selfOrgUser) {
-          throw new Error("UNAUTHORIZED");
-        }
-      } else if (!req.context?.internalApiKey) {
-        throw new Error("UNAUTHORIZED");
-      }
+      authorize(req.context, {
+        organizationId: source.organizationId,
+        role: "owner",
+      });
 
       // Feature flag check
       await checkFeatureFlag(source.organizationId);
@@ -331,12 +292,15 @@ export default privateRoute
           baseUrl: source.baseUrl,
         });
         if (!jobId) {
-          throw new Error("Queue unavailable: crawl job could not be scheduled");
+          throw new Error(
+            "Queue unavailable: crawl job could not be scheduled",
+          );
         }
       } catch (err) {
         await db.update(schema.documentationSource, id, {
           status: previousStatus,
-          errorStr: err instanceof Error ? err.message : "Failed to schedule crawl",
+          errorStr:
+            err instanceof Error ? err.message : "Failed to schedule crawl",
           updatedAt: new Date(),
         });
         throw err;
@@ -357,25 +321,10 @@ export default privateRoute
         throw new Error("DOCUMENTATION_SOURCE_NOT_FOUND");
       }
 
-      // Authorization check
-      if (!req.context?.internalApiKey && req.context?.session?.userId) {
-        const selfOrgUser = Object.values(
-          await db.find(schema.organizationUser, {
-            where: {
-              organizationId: source.organizationId,
-              userId: req.context.session.userId,
-              enabled: true,
-              role: "owner",
-            },
-          }),
-        )[0];
-
-        if (!selfOrgUser) {
-          throw new Error("UNAUTHORIZED");
-        }
-      } else if (!req.context?.internalApiKey) {
-        throw new Error("UNAUTHORIZED");
-      }
+      authorize(req.context, {
+        organizationId: source.organizationId,
+        role: "owner",
+      });
 
       // Feature flag check
       await checkFeatureFlag(source.organizationId);

--- a/apps/api/src/live-state/router/message.ts
+++ b/apps/api/src/live-state/router/message.ts
@@ -220,6 +220,11 @@ export default publicRoute
         organizationId: z.string(),
       }),
     ).handler(async ({ req }) => {
+      authorize(req.context, {
+        organizationId: req.input.organizationId,
+        allowPublicApiKey: true,
+      });
+
       const results = await searchMessages({
         query: req.input.query,
         organizationId: req.input.organizationId,

--- a/apps/api/src/live-state/router/onboarding.ts
+++ b/apps/api/src/live-state/router/onboarding.ts
@@ -1,5 +1,6 @@
 import { ulid } from "ulid";
 import { z } from "zod";
+import { authorize } from "../../lib/authorize";
 import { privateRoute } from "../factories";
 import { schema } from "../schema";
 
@@ -68,24 +69,7 @@ export default privateRoute
     ).handler(async ({ req, db }) => {
       const organizationId = req.input.organizationId;
 
-      // Check authorization
-      if (!req.context?.internalApiKey && req.context?.session?.userId) {
-        const selfOrgUser = Object.values(
-          await db.find(schema.organizationUser, {
-            where: {
-              organizationId,
-              userId: req.context.session.userId,
-              enabled: true,
-            },
-          }),
-        )[0];
-
-        if (!selfOrgUser) {
-          throw new Error("UNAUTHORIZED");
-        }
-      } else if (!req.context?.internalApiKey) {
-        throw new Error("UNAUTHORIZED");
-      }
+      authorize(req.context, { organizationId });
 
       // Check if onboarding already exists
       const existing = Object.values(
@@ -124,24 +108,7 @@ export default privateRoute
         throw new Error("ONBOARDING_NOT_FOUND");
       }
 
-      // Authorization check
-      if (!req.context?.internalApiKey && req.context?.session?.userId) {
-        const selfOrgUser = Object.values(
-          await db.find(schema.organizationUser, {
-            where: {
-              organizationId: onboarding.organizationId,
-              userId: req.context.session.userId,
-              enabled: true,
-            },
-          }),
-        )[0];
-
-        if (!selfOrgUser) {
-          throw new Error("UNAUTHORIZED");
-        }
-      } else if (!req.context?.internalApiKey) {
-        throw new Error("UNAUTHORIZED");
-      }
+      authorize(req.context, { organizationId: onboarding.organizationId });
 
       const steps = JSON.parse(onboarding.stepsStr || "{}");
       steps[stepId] = { completedAt: new Date().toISOString() };
@@ -166,24 +133,7 @@ export default privateRoute
         throw new Error("ONBOARDING_NOT_FOUND");
       }
 
-      // Authorization check
-      if (!req.context?.internalApiKey && req.context?.session?.userId) {
-        const selfOrgUser = Object.values(
-          await db.find(schema.organizationUser, {
-            where: {
-              organizationId: onboarding.organizationId,
-              userId: req.context.session.userId,
-              enabled: true,
-            },
-          }),
-        )[0];
-
-        if (!selfOrgUser) {
-          throw new Error("UNAUTHORIZED");
-        }
-      } else if (!req.context?.internalApiKey) {
-        throw new Error("UNAUTHORIZED");
-      }
+      authorize(req.context, { organizationId: onboarding.organizationId });
 
       await db.update(schema.onboarding, onboardingId, {
         status: "skipped",
@@ -205,24 +155,7 @@ export default privateRoute
         throw new Error("ONBOARDING_NOT_FOUND");
       }
 
-      // Authorization check
-      if (!req.context?.internalApiKey && req.context?.session?.userId) {
-        const selfOrgUser = Object.values(
-          await db.find(schema.organizationUser, {
-            where: {
-              organizationId: onboarding.organizationId,
-              userId: req.context.session.userId,
-              enabled: true,
-            },
-          }),
-        )[0];
-
-        if (!selfOrgUser) {
-          throw new Error("UNAUTHORIZED");
-        }
-      } else if (!req.context?.internalApiKey) {
-        throw new Error("UNAUTHORIZED");
-      }
+      authorize(req.context, { organizationId: onboarding.organizationId });
 
       await db.update(schema.onboarding, onboardingId, {
         status: "completed",

--- a/apps/api/src/live-state/router/onboarding.ts
+++ b/apps/api/src/live-state/router/onboarding.ts
@@ -61,7 +61,7 @@ export default privateRoute
       },
     },
   })
-  .withMutations(({ mutation }) => ({
+  .withProcedures(({ mutation }) => ({
     initialize: mutation(
       z.object({
         organizationId: z.string(),

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -5,6 +5,7 @@ import {
 } from "@workspace/schemas/external-issue";
 import { ulid } from "ulid";
 import z from "zod";
+import { authorize } from "../../lib/authorize";
 import { createReadThroughCache } from "../../lib/cache/read-through.js";
 import { deactivateDigestSignals } from "../../lib/digest-signals";
 import { publicRoute } from "../factories";
@@ -431,7 +432,10 @@ export default publicRoute
         direction,
       } = req.input;
 
-      // authorize(req.context, { organizationId });
+      authorize(req.context, {
+        organizationId,
+        allowPublicApiKey: true,
+      });
 
       let query = db.thread.where({
         organizationId,
@@ -552,26 +556,7 @@ export default publicRoute
         throw new Error("MISSING_ORGANIZATION_ID");
       }
 
-      // Verify user has access to the organization
-      let authorized = !!req.context?.internalApiKey;
-
-      if (!authorized && req.context?.session?.userId) {
-        const selfOrgUser = Object.values(
-          await db.find(schema.organizationUser, {
-            where: {
-              organizationId,
-              userId: req.context.session.userId,
-              enabled: true,
-            },
-          }),
-        )[0];
-
-        authorized = !!selfOrgUser;
-      }
-
-      if (!authorized) {
-        throw new Error("UNAUTHORIZED");
-      }
+      authorize(req.context, { organizationId });
 
       // Get GitHub integration config
       const integration = Object.values(
@@ -620,25 +605,7 @@ export default publicRoute
         throw new Error("MISSING_ORGANIZATION_ID");
       }
 
-      let authorized = !!req.context?.internalApiKey;
-
-      if (!authorized && req.context?.session?.userId) {
-        const selfOrgUser = Object.values(
-          await db.find(schema.organizationUser, {
-            where: {
-              organizationId,
-              userId: req.context.session.userId,
-              enabled: true,
-            },
-          }),
-        )[0];
-
-        authorized = !!selfOrgUser;
-      }
-
-      if (!authorized) {
-        throw new Error("UNAUTHORIZED");
-      }
+      authorize(req.context, { organizationId });
 
       const integration = Object.values(
         await db.find(schema.integration, {
@@ -690,25 +657,7 @@ export default publicRoute
         throw new Error("MISSING_ORGANIZATION_ID");
       }
 
-      let authorized = !!req.context?.internalApiKey;
-
-      if (!authorized && req.context?.session?.userId) {
-        const selfOrgUser = Object.values(
-          await db.find(schema.organizationUser, {
-            where: {
-              organizationId,
-              userId: req.context.session.userId,
-              enabled: true,
-            },
-          }),
-        )[0];
-
-        authorized = !!selfOrgUser;
-      }
-
-      if (!authorized) {
-        throw new Error("UNAUTHORIZED");
-      }
+      authorize(req.context, { organizationId });
 
       // Get GitHub integration config
       const integration = Object.values(

--- a/apps/api/src/live-state/router/update.ts
+++ b/apps/api/src/live-state/router/update.ts
@@ -1,53 +1,40 @@
+import { z } from "zod";
+import { authorize } from "../../lib/authorize";
 import { publicRoute } from "../factories";
 import { schema } from "../schema";
 
 export default publicRoute.collectionRoute(schema.update, {
   read: () => true,
-  insert: ({ ctx }) => {
-    if (ctx?.internalApiKey) return true;
-    if (!ctx?.session) return false;
-
-    return {
-      thread: {
-        organization: {
-          organizationUsers: {
-            userId: ctx.session.userId,
-            enabled: true,
-          },
-        },
-      },
-    };
-  },
+  insert: ({ ctx }) => !!ctx?.internalApiKey,
   update: {
-    preMutation: ({ ctx }) => {
-      if (ctx?.internalApiKey) return true;
-      if (!ctx?.session) return false;
-
-      return {
-        thread: {
-          organization: {
-            organizationUsers: {
-              userId: ctx.session.userId,
-              enabled: true,
-            },
-          },
-        },
-      };
-    },
-    postMutation: ({ ctx }) => {
-      if (ctx?.internalApiKey) return true;
-      if (!ctx?.session) return false;
-
-      return {
-        thread: {
-          organization: {
-            organizationUsers: {
-              userId: ctx.session.userId,
-              enabled: true,
-            },
-          },
-        },
-      };
-    },
+    preMutation: ({ ctx }) => !!ctx?.internalApiKey,
+    postMutation: ({ ctx }) => !!ctx?.internalApiKey,
   },
-});
+}).withProcedures(({ mutation }) => ({
+  create: mutation(
+    z.object({
+      id: z.string(),
+      threadId: z.string(),
+      userId: z.string().nullable(),
+      type: z.string(),
+      createdAt: z.coerce.date(),
+      metadataStr: z.string().nullable(),
+      replicatedStr: z.string().nullable(),
+    }),
+  ).handler(async ({ req, db }) => {
+    const thread = await db.thread.one(req.input.threadId).get();
+
+    if (!thread) {
+      throw new Error("THREAD_NOT_FOUND");
+    }
+
+    authorize(req.context, {
+      organizationId: thread.organizationId,
+      allowPublicApiKey: true,
+    });
+
+    await db.insert(schema.update, req.input);
+
+    return req.input;
+  }),
+}));

--- a/apps/web/src/components/threads/issues.tsx
+++ b/apps/web/src/components/threads/issues.tsx
@@ -256,7 +256,7 @@ export function IssuesSection({
       externalIssueId: null,
     });
 
-    mutate.update.insert({
+    mutate.update.create({
       id: ulid().toLowerCase(),
       threadId: threadId,
       type: "issue_changed",
@@ -309,7 +309,7 @@ export function IssuesSection({
               mutate.thread.update(threadId, {
                 externalIssueId: newIssueId,
               });
-              mutate.update.insert({
+              mutate.update.create({
                 id: ulid().toLowerCase(),
                 threadId: threadId,
                 type: "issue_changed",

--- a/apps/web/src/components/threads/linked-pr-suggestions-section.tsx
+++ b/apps/web/src/components/threads/linked-pr-suggestions-section.tsx
@@ -80,7 +80,7 @@ export function LinkedPrSuggestionsSection({
 
     mutate.thread.update(threadId, { externalPrId: newExternalPrId });
 
-    mutate.update.insert({
+    mutate.update.create({
       id: ulid().toLowerCase(),
       threadId,
       type: "pr_changed",

--- a/apps/web/src/components/threads/properties.tsx
+++ b/apps/web/src/components/threads/properties.tsx
@@ -69,7 +69,7 @@ export function PropertiesSection({
               status: newStatus,
             });
 
-            mutate.update.insert({
+            mutate.update.create({
               id: ulid().toLowerCase(),
               threadId: id,
               type: "status_changed",
@@ -159,7 +159,7 @@ export function PropertiesSection({
               priority: newPriority,
             });
 
-            mutate.update.insert({
+            mutate.update.create({
               id: ulid().toLowerCase(),
               threadId: id,
               type: "priority_changed",

--- a/apps/web/src/components/threads/pull-requests.tsx
+++ b/apps/web/src/components/threads/pull-requests.tsx
@@ -88,7 +88,7 @@ export function PullRequestsSection({
       externalPrId: null,
     });
 
-    mutate.update.insert({
+    mutate.update.create({
       id: ulid().toLowerCase(),
       threadId: threadId,
       type: "pr_changed",
@@ -137,7 +137,7 @@ export function PullRequestsSection({
               mutate.thread.update(threadId, {
                 externalPrId: newPrId,
               });
-              mutate.update.insert({
+              mutate.update.create({
                 id: ulid().toLowerCase(),
                 threadId: threadId,
                 type: "pr_changed",

--- a/apps/web/src/components/threads/thread-input-area-deprecated/support-intelligence.tsx
+++ b/apps/web/src/components/threads/thread-input-area-deprecated/support-intelligence.tsx
@@ -417,7 +417,7 @@ export const Suggestions = ({
     });
 
     // Create update record
-    mutate.update.insert({
+    mutate.update.create({
       id: ulid().toLowerCase(),
       threadId,
       type: "status_changed",
@@ -478,7 +478,7 @@ export const Suggestions = ({
     mutate.thread.update(threadId, { status: 4 });
 
     // Create update record for the duplicate link
-    mutate.update.insert({
+    mutate.update.create({
       id: ulid().toLowerCase(),
       threadId,
       type: "marked_duplicate",

--- a/apps/web/src/components/threads/thread-toolbar/quick-actions.tsx
+++ b/apps/web/src/components/threads/thread-toolbar/quick-actions.tsx
@@ -273,7 +273,7 @@ export const QuickActionsPanel = ({
       status: newStatus,
     });
 
-    mutate.update.insert({
+    mutate.update.create({
       id: ulid().toLowerCase(),
       threadId,
       type: "status_changed",
@@ -330,7 +330,7 @@ export const QuickActionsPanel = ({
 
     mutate.thread.update(threadId, { status: 4 });
 
-    mutate.update.insert({
+    mutate.update.create({
       id: ulid().toLowerCase(),
       threadId,
       type: "marked_duplicate",

--- a/apps/web/src/routes/app/_workspace/_main/signal/index.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/signal/index.tsx
@@ -580,7 +580,7 @@ function RouteComponent() {
       status: newStatus,
     });
 
-    mutate.update.insert({
+    mutate.update.create({
       id: ulid().toLowerCase(),
       threadId: suggestion.entityId,
       type: "status_changed",
@@ -697,7 +697,7 @@ function RouteComponent() {
     mutate.thread.update(suggestion.entityId, { status: 4 });
 
     // Create update record for the duplicate link
-    mutate.update.insert({
+    mutate.update.create({
       id: ulid().toLowerCase(),
       threadId: suggestion.entityId,
       type: "marked_duplicate",
@@ -783,7 +783,7 @@ function RouteComponent() {
 
     mutate.thread.update(suggestion.entityId, { externalPrId });
 
-    mutate.update.insert({
+    mutate.update.create({
       id: ulid().toLowerCase(),
       threadId: suggestion.entityId,
       type: "pr_changed",

--- a/docs/live-state-procedures-migration-plan.md
+++ b/docs/live-state-procedures-migration-plan.md
@@ -24,7 +24,7 @@ This document plans migrating insert/update/read authorization and business logi
 
 ### `withMutations` vs `withProcedures`
 
-Today both appear in the codebase (`withMutations` in `router.ts`, onboarding, documentation-sources, agent-chat; `withProcedures` in `message.ts`, `threads.ts`). **Unify on `withProcedures`** for new work and when touching existing routes, unless the Live-State version pins different behavior—verify during the first migration PR and align naming project-wide.
+`@live-state/sync@0.0.7-canary-7` exposes both names as the same API; the API router **unifies on `withProcedures`** (see Phase 2). Prefer `withProcedures` for all new routes.
 
 ---
 
@@ -39,7 +39,7 @@ Today both appear in the codebase (`withMutations` in `router.ts`, onboarding, d
 | `router/threads.ts` | `create`, `list` (query), GitHub helpers, etc. Several handlers still use manual `internalApiKey` + `organizationUser` queries; `list` has commented `authorize`. `fetchRelatedThreads` has TODO for auth.                            |
 
 
-### Using `.withMutations` (candidates to rename / align to procedures)
+### Using `.withProcedures` (custom handlers on these routes)
 
 
 | Location                          | Procedures / mutations                                                                                             |
@@ -107,6 +107,14 @@ Defined inline in `router.ts` or split files:
 
 ## Suggested phases (execution order)
 
+### PR checklist (copy into PR description)
+
+- [x] **Phase 0** — Baseline (guideline + `mutate.*` inventory in this doc).
+- [x] **Phase 1** — Low-risk `authorize()` refactors; `threads.list` + `message.search` guarded.
+- [x] **Phase 2** — `withMutations` → `withProcedures` across API router; `bun run typecheck` on `api` passes.
+- [ ] **Phase 3** — High-traffic sync → procedures; lock collection writes per entity (coordinate QA).
+- [ ] **Phase 4** — Optional read-model / query migration.
+
 ### Phase 0 — Baseline
 
 - Add a short **coding guideline** in the PR template or `CLAUDE.md`: new writes go through procedures + `authorize`. *(Done: see **Live-State authorization** in `CLAUDE.md`.)*
@@ -149,9 +157,13 @@ Defined inline in `router.ts` or split files:
 - Uncomment and implement `authorize` on `threads.list` where `organizationId` is passed.
 - Add `authorize` to `message.search`.
 
+*(Done in the migration PR series.)*
+
 ### Phase 2 — Unify mutation APIs
 
 - Rename `withMutations` → `withProcedures` where supported; ensure types and client exports still match.
+
+*(Done: `router.ts`, `router/onboarding.ts`, `router/documentation-sources.ts`, `router/agent-chat.ts`; client call sites unchanged—procedure names and wire protocol are unchanged.)*
 
 ### Phase 3 — High-traffic sync migrations (coordinate with QA)
 
@@ -184,7 +196,7 @@ Order by dependency and blast radius:
 
 1. Should `**portalSession**` load `**orgUsers**` (or a single org membership) server-side so `authorize()` applies uniformly?
 2. For **worker-heavy** tables (`suggestion`, `pipelineJob`), do we prefer **one internal procedure** with batch input vs many small procedures?
-3. Confirm `**withProcedures`** and `**withMutations`** are 100% interchangeable in `@live-state/sync@0.0.7-canary-7` before mass rename.
+3. ~~Confirm `withProcedures` and `withMutations` are interchangeable in `@live-state/sync@0.0.7-canary-7`~~ **Resolved:** same builder API; Phase 2 standardizes on `withProcedures` only in app code.
 
 ---
 

--- a/docs/live-state-procedures-migration-plan.md
+++ b/docs/live-state-procedures-migration-plan.md
@@ -89,11 +89,11 @@ Defined inline in `router.ts` or split files:
   - `router.ts` (API keys),
   - `threads.ts` (GitHub mutations),
   - `onboarding.ts`, `documentation-sources.ts`, and any similar blocks.
-2. **Procedure-first writes**
+2. **Procedure-first writes (all clients)**
   For each entity that still relies on sync `insert` / `update`:
   - Add explicit **mutation** procedures (naming: verb + entity, e.g. `applyLabel`, `recordTypingUpdate`) that perform `db.insert` / `db.update` inside the handler after `authorize`.
-  - Update **web** (`apps/web`) and **worker** (`apps/worker`) call sites from `mutate.<entity>.insert/update` to `mutate.<entity>.<procedure>(...)`.
-  - Then set collection `insert` / `update` to `**false`** (or internal-only) so auth is not split between collection filters and app code.
+  - Update **all client apps** (`apps/web`, `apps/worker`, `apps/discord`, `apps/slack`, `apps/github`) from `mutate.<entity>.insert/update` to `mutate.<entity>.<procedure>(...)`.
+  - Then set collection `insert` / `update` to `**false`** (or strictly internal-only where unavoidable) so auth is not split between collection filters and app code.
 3. **Procedure-first reads where filters are insufficient**
   - Replace or supplement large `read: { … }` graph filters with `**query` procedures** when you need arguments (pagination already uses `threads.list`).  
   - For pure sync subscriptions, **keep** `read` filters until the client can move to queries + local state—treat as a later phase.
@@ -112,15 +112,16 @@ Defined inline in `router.ts` or split files:
 - [x] **Phase 0** — Baseline (guideline + `mutate.*` inventory in this doc).
 - [x] **Phase 1** — Low-risk `authorize()` refactors; `threads.list` + `message.search` guarded.
 - [x] **Phase 2** — `withMutations` → `withProcedures` across API router; `bun run typecheck` on `api` passes.
-- [ ] **Phase 3** — High-traffic sync → procedures; lock collection writes per entity (coordinate QA).
+- [ ] **Phase 3** — High-traffic sync → procedures for all clients; lock collection writes per entity (coordinate QA, in progress).
 - [ ] **Phase 4** — Optional read-model / query migration.
+- [ ] **Definition of done (global)** — no `mutate.<entity>.insert/update` usage remains in client apps (`apps/web`, `apps/worker`, `apps/discord`, `apps/slack`, `apps/github`) except explicitly documented temporary exemptions with owner + removal date.
 
 ### Phase 0 — Baseline
 
 - Add a short **coding guideline** in the PR template or `CLAUDE.md`: new writes go through procedures + `authorize`. *(Done: see **Live-State authorization** in `CLAUDE.md`.)*
-- List all `mutate.*.insert|update` usages in `apps/web` and `apps/worker` (grep) and attach to the ticket. *(Inventory below; regenerate with `rg 'mutate\\.\\w+\\.(insert|update)\\(' apps/web apps/worker`.)*
+- List all `mutate.*.insert|update` usages across **all client apps** and attach to the ticket. *(Inventory below; regenerate with `rg 'mutate\\.\\w+\\.(insert|update)\\(' apps/web apps/worker apps/discord apps/slack apps/github`.)*
 
-#### `mutate.*.insert` / `mutate.*.update` inventory (web + worker)
+#### `mutate.*.insert` / `mutate.*.update` inventory (all clients)
 
 **`apps/web`** — by collection (line counts are grep hits, not runtime frequency):
 
@@ -148,6 +149,75 @@ Defined inline in `router.ts` or split files:
 | `pipelineJob` | `pipeline/core/persistence.ts` |
 | `suggestion` | `pipeline/processors/suggest-*.ts`, `handlers/digest-scan.ts`, `handlers/match-pr-threads.ts`, `lib/database/client.ts` |
 
+**`apps/discord`, `apps/slack`, `apps/github`**
+
+| App | Collections (representative) |
+| --- | --- |
+| `apps/discord` | `author`, `thread`, `message`, `update`, `integration` |
+| `apps/slack` | `author`, `thread`, `message`, `update`, `integration` |
+| `apps/github` | `thread`, `update`, `integration` |
+
+#### Explicit file backlog (must migrate to custom procedures)
+
+These files still contain `mutate.<entity>.insert/update` calls and require migration:
+
+**`apps/web`**
+
+- `apps/web/src/components/threads/thread-toolbar/quick-actions.tsx`
+- `apps/web/src/routes/app/_workspace/settings/organization/integration/slack/redirect.ts`
+- `apps/web/src/components/devtools/devtools-menu/duplicate-thread-command.tsx`
+- `apps/web/src/lib/integrations/activate.ts`
+- `apps/web/src/components/threads/thread-input-area-deprecated/index.tsx`
+- `apps/web/src/routes/app/_workspace/settings/organization/support-intelligence.tsx`
+- `apps/web/src/routes/app/_workspace/settings/organization/integration/github/index.tsx`
+- `apps/web/src/routes/app/_workspace/settings/organization/integration/discord/index.tsx`
+- `apps/web/src/routes/app/_workspace/settings/organization/integration/discord/redirect.ts`
+- `apps/web/src/components/threads/linked-pr-suggestions-section.tsx`
+- `apps/web/src/routes/app/_workspace/_main/signal/index.tsx`
+- `apps/web/src/routes/app/_workspace/settings/organization/labels.tsx`
+- `apps/web/src/routes/app/_workspace/settings/organization/integration/slack/index.tsx`
+- `apps/web/src/components/threads/thread-input-area-deprecated/support-intelligence.tsx`
+- `apps/web/src/routes/app/_workspace/settings/user/index.tsx`
+- `apps/web/src/routes/app/_workspace/settings/organization/index.tsx`
+- `apps/web/src/components/threads/properties.tsx`
+- `apps/web/src/components/threads/issues.tsx`
+- `apps/web/src/routes/app/_workspace/settings/organization/team.tsx`
+- `apps/web/src/components/devtools/devtools-menu/create-thread-dialog.tsx`
+- `apps/web/src/components/threads/labels.tsx`
+- `apps/web/src/components/devtools/devtools-menu/add-pr-suggestion-command.tsx`
+- `apps/web/src/routes/app/_workspace/_main/threads/$id.tsx`
+- `apps/web/src/components/devtools/devtools-menu/create-thread-button.tsx`
+- `apps/web/src/components/threads/pull-requests.tsx`
+- `apps/web/src/routes/app/_workspace/_main/threads/archive/$id.tsx`
+
+**`apps/worker`**
+
+- `apps/worker/src/pipeline/core/persistence.ts`
+- `apps/worker/src/handlers/digest-scan.ts`
+- `apps/worker/src/handlers/crawl-documentation.ts`
+- `apps/worker/src/pipeline/processors/suggest-duplicates.ts`
+- `apps/worker/src/handlers/match-pr-threads.ts`
+- `apps/worker/src/lib/database/client.ts`
+- `apps/worker/src/pipeline/core/idempotency.ts`
+- `apps/worker/src/pipeline/processors/suggest-labels.ts`
+- `apps/worker/src/pipeline/processors/suggest-status.ts`
+
+**`apps/discord`**
+
+- `apps/discord/src/lib/utils.ts`
+- `apps/discord/src/index.ts`
+
+**`apps/slack`**
+
+- `apps/slack/src/lib/installation-store.ts`
+- `apps/slack/src/index.ts`
+- `apps/slack/src/lib/utils.ts`
+
+**`apps/github`**
+
+- `apps/github/src/webhooks/index.ts`
+- `apps/github/src/routes/setup.ts`
+
 ### Phase 1 — Low-risk auth refactors (no client rewrites)
 
 - Swap manual org checks for `authorize()` in:
@@ -169,7 +239,7 @@ Defined inline in `router.ts` or split files:
 
 Order by dependency and blast radius:
 
-1. `**update` collection** (typing / activity) → procedure(s), then lock collection writes.
+1. `**update` collection** (typing / activity) → procedure(s), then lock collection writes. *(Partially done: web/dashboard writes migrated to `update.create`; remaining integration/client call sites must migrate too.)*
 2. `**thread` / `message`** — reduce remaining `mutate.message.insert` call sites to `create` where possible; align portal + app.
 3. `**label` / `threadLabel`** — procedures for add/remove/update; update labels UI.
 4. `**suggestion**` — worker uses many inserts/updates; introduce `internal*` procedures or a single batch API to avoid dozens of round-trips; then restrict collection.
@@ -189,6 +259,7 @@ Order by dependency and blast radius:
 - `x-public-api-key` and WebSocket `publicApiKey` query param.  
 - `internalApiKey` (Discord bot, worker).  
 - Regression: Live-State sync still receives expected rows after tightening `read` (if changed).
+- Repo-wide grep gate: `rg 'mutate\\.\\w+\\.(insert|update)\\(' apps/web apps/worker apps/discord apps/slack apps/github` returns zero matches (or only explicitly approved temporary exemptions).
 
 ---
 

--- a/docs/live-state-procedures-migration-plan.md
+++ b/docs/live-state-procedures-migration-plan.md
@@ -1,0 +1,200 @@
+# Live-State: migrate CRUD + authorization to procedures (`authorize` helper)
+
+This document plans migrating insert/update/read authorization and business logic toward **custom procedures** (`.withProcedures`) and the shared `**authorize()`** helper in `apps/api/src/lib/authorize.ts`, using `**apps/api/src/live-state/router/message.ts`** as the reference implementation.
+
+## Reference pattern (`message.ts`)
+
+
+| Concern                       | What to copy                                                                                                                                                                                                                                                                                         |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Procedures**                | Use `.withProcedures(({ mutation, query }) => ({ ... }))` for server-defined operations with Zod input schemas. (`threads.ts` also uses `query` for `list`.)                                                                                                                                         |
+| **Collection route**          | Keep `.collectionRoute(schema.*, { read, insert, update })` only where Live-State **sync** must still allow filtered CRUD from clients (or internal/worker keys). Tighten over time: `insert: () => false` / `update: { preMutation/postMutation: () => false }` once every caller uses a procedure. |
+| **Authorization in handlers** | Call `authorize(req.context, { organizationId, role?: "owner", allowPublicApiKey?: true })` at the start of procedures instead of ad-hoc `db.find(schema.organizationUser, …)` blocks.                                                                                                               |
+| **Exceptions**                | When rules are not expressible as org membership (e.g. portal thread author vs agent), keep explicit checks **after** `authorize` where needed—see `markAsAnswer` in `message.ts`.                                                                                                                   |
+| **Hooks**                     | Keep `withHooks` (e.g. `afterInsert`) for side effects that should stay tied to sync inserts if those remain.                                                                                                                                                                                        |
+
+
+### `authorize` prerequisites
+
+- `**orgUsers` on context**: Populated in `apps/api/src/index.ts` for authenticated dashboard sessions (`storage.find(organizationUser, …)` by `userId`). Procedures should prefer `authorize()` over repeating that query.
+- **Gaps to address in the same effort**:
+  - **Portal-only** WebSocket sessions may not get `orgUsers` the same way as dashboard sessions. Today, routers use explicit thread/org checks (e.g. `message.create`, `threads.create`). The plan should either attach `orgUsers` for portal when safe, or document which procedures must keep explicit DB checks.
+  - `**publicApiKey`**: Supported via `allowPublicApiKey: true` when `ownerId` matches `organizationId` (see `authorize.ts`). Use consistently on procedures that must accept public API clients.
+  - **Role checks**: Use `role: "owner"` in `authorize()` instead of manual `organizationUser.role === "owner"` queries (`router.ts` API key mutations, documentation flows, etc.).
+
+### `withMutations` vs `withProcedures`
+
+Today both appear in the codebase (`withMutations` in `router.ts`, onboarding, documentation-sources, agent-chat; `withProcedures` in `message.ts`, `threads.ts`). **Unify on `withProcedures`** for new work and when touching existing routes, unless the Live-State version pins different behavior—verify during the first migration PR and align naming project-wide.
+
+---
+
+## Inventory: current state
+
+### Already using `.withProcedures`
+
+
+| File                | Notes                                                                                                                                                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `router/message.ts` | `create`, `markAsAnswer`, `search`. Uses `authorize()` in `create` and conditional org auth in `markAsAnswer`. **Follow-up:** ensure `search` enforces org access (today it forwards `organizationId` to Qdrant without `authorize`). |
+| `router/threads.ts` | `create`, `list` (query), GitHub helpers, etc. Several handlers still use manual `internalApiKey` + `organizationUser` queries; `list` has commented `authorize`. `fetchRelatedThreads` has TODO for auth.                            |
+
+
+### Using `.withMutations` (candidates to rename / align to procedures)
+
+
+| Location                          | Procedures / mutations                                                                                             |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `router.ts` — `organization`      | `create`, `createPublicApiKey`, `revokePublicApiKey`, `listApiKeys`                                                |
+| `router.ts` — `organizationUser`  | `inviteUser`                                                                                                       |
+| `router.ts` — `invite`            | `accept`, `decline`                                                                                                |
+| `router/onboarding.ts`            | `initialize`, `completeStep`, `skip`, `complete`                                                                   |
+| `router/documentation-sources.ts` | `validateDocumentationSource`, `addDocumentationSource`, `recrawlDocumentationSource`, `deleteDocumentationSource` |
+| `router/agent-chat.ts`            | `create`, `sendMessage`, and related (large file)                                                                  |
+
+
+### `collectionRoute` only (sync CRUD + built-in read/insert/update rules)
+
+Defined inline in `router.ts` or split files:
+
+
+| Entity                                  | File                              | Risk / notes                                                          |
+| --------------------------------------- | --------------------------------- | --------------------------------------------------------------------- |
+| `organization`                          | `router.ts`                       | Updates: owner via filters; `create` already a mutation.              |
+| `organizationUser`                      | `router.ts`                       | Sync updates for team; invite flow.                                   |
+| `user`                                  | `router.ts`                       | Self updates.                                                         |
+| `author`                                | `router.ts`                       | Loose insert rules; TODO FRO-68.                                      |
+| `invite`                                | `router.ts`                       | Complex read OR (org member vs email).                                |
+| `integration`                           | `router.ts`                       | Owner-scoped insert/update.                                           |
+| `allowlist`                             | `router.ts`                       | Email-scoped read; internal insert.                                   |
+| `subscription`                          | `router.ts`                       | Owner read; internal update.                                          |
+| `thread`                                | `threads.ts`                      | Sync insert/update for agents; `create` procedure exists.             |
+| `message`                               | `message.ts`                      | Sync insert; internal-only update.                                    |
+| `update`                                | `router/update.ts`                | Typing indicators / activity—sync insert/update.                      |
+| `suggestion`                            | `router/suggestions.ts`           | Worker + dev insert; heavy client `mutate.suggestion.update`.         |
+| `label`, `threadLabel`                  | `router/labels.ts`                | Broad UI usage.                                                       |
+| `onboarding`                            | `router/onboarding.ts`            | Sync + mutations duplicating auth.                                    |
+| `documentationSource`                   | `router/documentation-sources.ts` | Internal-only insert/update on collection; user-facing via mutations. |
+| `agentChat`, `agentChatMessage`         | `router/agent-chat.ts`            | Insert disabled + mutations.                                          |
+| `pipelineIdempotencyKey`, `pipelineJob` | `router.ts`                       | Worker/internal only.                                                 |
+
+
+---
+
+## Migration goals (ordered)
+
+1. **Authorization consistency**
+  Replace repeated patterns:
+  - `let authorized = !!req.context?.internalApiKey` + `db.find(organizationUser, …)`  
+   with `authorize(req.context, { organizationId, role: "owner" })` (or without `role` for any member), including:
+  - `router.ts` (API keys),
+  - `threads.ts` (GitHub mutations),
+  - `onboarding.ts`, `documentation-sources.ts`, and any similar blocks.
+2. **Procedure-first writes**
+  For each entity that still relies on sync `insert` / `update`:
+  - Add explicit **mutation** procedures (naming: verb + entity, e.g. `applyLabel`, `recordTypingUpdate`) that perform `db.insert` / `db.update` inside the handler after `authorize`.
+  - Update **web** (`apps/web`) and **worker** (`apps/worker`) call sites from `mutate.<entity>.insert/update` to `mutate.<entity>.<procedure>(...)`.
+  - Then set collection `insert` / `update` to `**false`** (or internal-only) so auth is not split between collection filters and app code.
+3. **Procedure-first reads where filters are insufficient**
+  - Replace or supplement large `read: { … }` graph filters with `**query` procedures** when you need arguments (pagination already uses `threads.list`).  
+  - For pure sync subscriptions, **keep** `read` filters until the client can move to queries + local state—treat as a later phase.
+4. **Internal / worker paths**
+  - `pipeline*`, worker `suggestion`/`documentationSource` updates: either keep `internalApiKey` bypass in `authorize` (already `true` for internal key) or dedicated `internalOnly` procedures that assert `internalApiKey` once at the top.
+5. **Hardening**
+  - Fix any procedure that takes `organizationId` without `authorize` (e.g. message `search`).  
+  - Resolve TODOs: `threads` `list` + `fetchRelatedThreads` authorization.
+
+---
+
+## Suggested phases (execution order)
+
+### Phase 0 — Baseline
+
+- Add a short **coding guideline** in the PR template or `CLAUDE.md`: new writes go through procedures + `authorize`. *(Done: see **Live-State authorization** in `CLAUDE.md`.)*
+- List all `mutate.*.insert|update` usages in `apps/web` and `apps/worker` (grep) and attach to the ticket. *(Inventory below; regenerate with `rg 'mutate\\.\\w+\\.(insert|update)\\(' apps/web apps/worker`.)*
+
+#### `mutate.*.insert` / `mutate.*.update` inventory (web + worker)
+
+**`apps/web`** — by collection (line counts are grep hits, not runtime frequency):
+
+| Collection | Files (representative) |
+| ---------- | ------------------------ |
+| `author` | `components/devtools/.../create-thread-dialog.tsx`, `create-thread-button.tsx` |
+| `integration` | `lib/integrations/activate.ts`, `settings/organization/integration/*` |
+| `invite` | `settings/organization/team.tsx` |
+| `label` | `settings/organization/labels.tsx`, `components/threads/labels.tsx` |
+| `message` | `thread-input-area-deprecated`, devtools create/duplicate thread |
+| `organization` | `settings/organization/index.tsx`, `support-intelligence.tsx` |
+| `organizationUser` | `settings/organization/team.tsx` |
+| `suggestion` | `signal/index.tsx`, `thread-toolbar/quick-actions.tsx`, `linked-pr-suggestions-section.tsx`, devtools |
+| `thread` | Many thread UI routes and components (`$id.tsx`, `issues.tsx`, `properties.tsx`, devtools, etc.) |
+| `threadLabel` | `labels.tsx`, `quick-actions.tsx`, `support-intelligence.tsx` |
+| `update` | `issues.tsx`, `pull-requests.tsx`, `properties.tsx`, `signal/index.tsx`, quick-actions, linked-pr, etc. |
+| `user` | `settings/user/index.tsx` |
+
+**`apps/worker`**
+
+| Collection | Files |
+| ---------- | ----- |
+| `documentationSource` | `handlers/crawl-documentation.ts` |
+| `pipelineIdempotencyKey` | `pipeline/core/idempotency.ts` |
+| `pipelineJob` | `pipeline/core/persistence.ts` |
+| `suggestion` | `pipeline/processors/suggest-*.ts`, `handlers/digest-scan.ts`, `handlers/match-pr-threads.ts`, `lib/database/client.ts` |
+
+### Phase 1 — Low-risk auth refactors (no client rewrites)
+
+- Swap manual org checks for `authorize()` in:
+  - `router.ts` (public API key mutations),
+  - `threads.ts` (GitHub-related mutations),
+  - `onboarding.ts`, `documentation-sources.ts`.
+- Uncomment and implement `authorize` on `threads.list` where `organizationId` is passed.
+- Add `authorize` to `message.search`.
+
+### Phase 2 — Unify mutation APIs
+
+- Rename `withMutations` → `withProcedures` where supported; ensure types and client exports still match.
+
+### Phase 3 — High-traffic sync migrations (coordinate with QA)
+
+Order by dependency and blast radius:
+
+1. `**update` collection** (typing / activity) → procedure(s), then lock collection writes.
+2. `**thread` / `message`** — reduce remaining `mutate.message.insert` call sites to `create` where possible; align portal + app.
+3. `**label` / `threadLabel`** — procedures for add/remove/update; update labels UI.
+4. `**suggestion**` — worker uses many inserts/updates; introduce `internal*` procedures or a single batch API to avoid dozens of round-trips; then restrict collection.
+5. `**organization` / `organizationUser` / `invite` / `user**` — migrate settings and team flows.
+6. `**integration` / `subscription` / `allowlist**` — settings and billing surfaces.
+
+### Phase 4 — Optional read-model migration
+
+- Only if product needs stricter isolation: narrow `read` filters and/or move list UIs to `query` procedures with explicit `authorize`.
+
+---
+
+## Testing checklist (per entity)
+
+- Dashboard session with `orgUsers` (happy / wrong org / disabled user).  
+- Portal session (support routes) where applicable.  
+- `x-public-api-key` and WebSocket `publicApiKey` query param.  
+- `internalApiKey` (Discord bot, worker).  
+- Regression: Live-State sync still receives expected rows after tightening `read` (if changed).
+
+---
+
+## Open questions
+
+1. Should `**portalSession**` load `**orgUsers**` (or a single org membership) server-side so `authorize()` applies uniformly?
+2. For **worker-heavy** tables (`suggestion`, `pipelineJob`), do we prefer **one internal procedure** with batch input vs many small procedures?
+3. Confirm `**withProcedures`** and `**withMutations`** are 100% interchangeable in `@live-state/sync@0.0.7-canary-7` before mass rename.
+
+---
+
+## File index (quick navigation)
+
+
+| Area                 | Path                                        |
+| -------------------- | ------------------------------------------- |
+| Router composition   | `apps/api/src/live-state/router.ts`         |
+| `authorize` helper   | `apps/api/src/lib/authorize.ts`             |
+| Context (`orgUsers`) | `apps/api/src/index.ts` (`contextProvider`) |
+| Reference            | `apps/api/src/live-state/router/message.ts` |
+| Factories            | `apps/api/src/live-state/factories.ts`      |


### PR DESCRIPTION
## Live-State procedure migration

Working branch for the **Live-State procedure migration** in [`docs/live-state-procedures-migration-plan.md`](docs/live-state-procedures-migration-plan.md): procedures + shared **`authorize()`** (`apps/api/src/lib/authorize.ts`), reference pattern in `apps/api/src/live-state/router/message.ts`.

### Project steps

**Phase 0 — Baseline**

- [x] Add Live-State authorization guideline (`CLAUDE.md`)
- [x] Record `mutate.*.insert` / `mutate.*.update` inventory in the migration doc (refresh: `rg 'mutate\.\w+\.(insert|update)\(' apps/web apps/worker`)

**Phase 1 — Low-risk auth refactors (no client rewrites)**

- [x] `router.ts`: public API key mutations use `authorize()` (`createPublicApiKey`, `listApiKeys`, `revokePublicApiKey`)
- [x] `threads.ts`: GitHub-related procedures use `authorize()`
- [x] `threads.list`: `authorize()` when `organizationId` is passed (`allowPublicApiKey` where applicable)
- [x] `message.search`: `authorize()` on `organizationId`
- [x] `onboarding.ts`: mutations use `authorize()`
- [x] `documentation-sources.ts`: mutations use `authorize()` (owner role)
- [x] Portal-only HTTP Live-State context: load `orgUsers` so support thread listing stays authorized (`apps/api/src/index.ts`)

**Phase 2 — Unify mutation APIs**

- [x] Rename `withMutations` → `withProcedures` in `router.ts` (`organization`, `organizationUser`, `invite`), `onboarding.ts`, `documentation-sources.ts`, and `agent-chat.ts`; procedure names unchanged; no web/worker call-site updates required
- [x] `bun run --filter api typecheck` passes; migration doc includes a copy-paste **PR checklist** section; `CLAUDE.md` references `.withProcedures` only

**Phase 3 — High-traffic sync migrations** *(coordinate with QA)*

- [ ] `update` collection (typing / activity): procedure(s), then restrict collection writes
- [ ] `thread` / `message`: move call sites toward procedures; tighten collection insert/update
- [ ] `label` / `threadLabel`: procedures + web UI
- [ ] `suggestion`: worker-friendly internal or batch procedures; restrict collection
- [ ] `organization` / `organizationUser` / `invite` / `user`: settings and team flows
- [ ] `integration` / `subscription` / `allowlist`: settings and billing surfaces

**Phase 4 — Optional read-model migration**

- [ ] Narrow `read` filters and/or move list UIs to `query` procedures where product needs stricter isolation

**Hardening / follow-ups** *(from migration goals)*

- [ ] `threads.fetchRelatedThreads`: proper authorization (TODO in router)
- [ ] Sweep remaining `organizationId` procedures for missing `authorize()`
- [ ] Internal / worker paths: explicit `internalOnly` procedures or document `internalApiKey` bypass policy

### Reviewer note

`internalApiKey` may now call public API key mutations, and `revokePublicApiKey` no longer requires a dashboard session when an internal key is present—consistent with other `authorize()` call sites.

### Verification (before merge)

- [ ] Dashboard: org settings → create / list / revoke public API keys
- [ ] Portal: `/support/{slug}/threads` loads and paginates
- [ ] Workspace search (`message.search`) works for org members
- [ ] GitHub integration: fetch issues/PRs, create issue from thread
- [ ] Onboarding and documentation-source flows (owner)
- [ ] Worker / integration paths still behave as expected with internal keys


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live-State now supports centralized authorization with public API key handling for message search and certain procedures
  * Dashboard sessions now surface organization memberships to improve auth-aware behavior

* **Documentation**
  * Added a Live-State procedures & authorization migration plan

* **Refactor**
  * Unified authorization across Live-State routers and migrated many collection writes to procedure-based handlers

* **Other**
  * Standardized update-record creation calls in several UI flows (no behavioral changes)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->