### PR TITLE
feat(digest): implement digest delivery system with force trigger and Slack integration

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -246,6 +246,10 @@ if (process.env.NODE_ENV !== "production") {
       return;
     }
     const jobId = await enqueueForceDigestDeliver(orgId);
+    if (!jobId) {
+      res.status(503).json({ error: "Digest queue unavailable" });
+      return;
+    }
     res.json({ jobId });
   });
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -2,13 +2,13 @@ import "./env";
 
 import "./lib/api-key";
 
+import process from "node:process";
 import { Webhooks } from "@dodopayments/express";
 import { expressAdapter, server } from "@live-state/sync/server";
 import expressWs from "@wll8/express-ws";
 import { toNodeHandler } from "better-auth/node";
 import cors from "cors";
 import express from "express";
-import process from "node:process";
 import { publicKeys } from "./lib/api-key";
 import { auth } from "./lib/auth";
 import { reflagClient } from "./lib/feature-flag";
@@ -236,6 +236,19 @@ process.env.DODO_PAYMENTS_WEBHOOK_KEY &&
       },
     }) as any,
   );
+
+if (process.env.NODE_ENV !== "production") {
+  const { enqueueForceDigestDeliver } = await import("./lib/queue");
+  app.post("/api/dev/force-digest", async (req, res) => {
+    const { orgId } = req.body;
+    if (!orgId) {
+      res.status(400).json({ error: "orgId required" });
+      return;
+    }
+    const jobId = await enqueueForceDigestDeliver(orgId);
+    res.json({ jobId });
+  });
+}
 
 expressAdapter(app as any, lsServer, {
   basePath: "/api/ls",

--- a/apps/api/src/lib/queue.ts
+++ b/apps/api/src/lib/queue.ts
@@ -19,12 +19,14 @@ export type IngestThreadJobData = {
   options?: IngestThreadJobOptions;
 };
 
-const INGEST_THREAD_JOB_PRIORITY_VALUES: Record<IngestThreadJobPriority, number> =
-  {
-    high: 1,
-    normal: 10,
-    low: 100,
-  };
+const INGEST_THREAD_JOB_PRIORITY_VALUES: Record<
+  IngestThreadJobPriority,
+  number
+> = {
+  high: 1,
+  normal: 10,
+  low: 100,
+};
 
 let connection: Redis | null = null;
 let queue: Queue<IngestThreadJobData> | null = null;
@@ -88,13 +90,16 @@ export const enqueueIngestThreadJob = async (params: {
     return null;
   }
 
-  const job = await ingestThreadQueue.add("ingest-thread", {
-    threadIds: params.threadIds,
-    options: params.options,
-  }, {
-    priority:
-      INGEST_THREAD_JOB_PRIORITY_VALUES[params.priority ?? "normal"],
-  });
+  const job = await ingestThreadQueue.add(
+    "ingest-thread",
+    {
+      threadIds: params.threadIds,
+      options: params.options,
+    },
+    {
+      priority: INGEST_THREAD_JOB_PRIORITY_VALUES[params.priority ?? "normal"],
+    },
+  );
 
   return job.id ?? null;
 };
@@ -199,6 +204,47 @@ export const enqueueEmbedPrJob = async (
   const payload = embedPrJobDataSchema.parse(data);
   const job = await queue.add("embed-pr", payload, {
     jobId: `embed-pr-${data.organizationId}:${data.owner}/${data.repo}#${data.prNumber}`,
+  });
+
+  return job.id ?? null;
+};
+
+// Digest Deliver Queue (force trigger)
+
+const DIGEST_DELIVER_QUEUE = "digest-deliver";
+
+export type DigestDeliverJobData = {
+  forceOrgId?: string;
+};
+
+let digestDeliverQueue: Queue<DigestDeliverJobData> | null = null;
+
+const getDigestDeliverQueue = (): Queue<DigestDeliverJobData> | null => {
+  if (digestDeliverQueue) {
+    return digestDeliverQueue;
+  }
+
+  connection ??= createRedisConnection();
+  if (!connection) {
+    return null;
+  }
+
+  digestDeliverQueue = new Queue<DigestDeliverJobData>(DIGEST_DELIVER_QUEUE, {
+    connection,
+  });
+  return digestDeliverQueue;
+};
+
+export const enqueueForceDigestDeliver = async (
+  orgId: string,
+): Promise<string | null> => {
+  const queue = getDigestDeliverQueue();
+  if (!queue) {
+    return null;
+  }
+
+  const job = await queue.add("digest-deliver-force", {
+    forceOrgId: orgId,
   });
 
   return job.id ?? null;

--- a/apps/slack/package.json
+++ b/apps/slack/package.json
@@ -18,6 +18,7 @@
     "api": "workspace:*",
     "bullmq": "^5.67.1",
     "dotenv": "^16.6.1",
+    "ioredis": "^5.3.2",
     "ulid": "^3.0.0",
     "zod": "catalog:"
   },

--- a/apps/slack/src/index.ts
+++ b/apps/slack/src/index.ts
@@ -16,6 +16,7 @@ import { ulid } from "ulid";
 import { reflagClient } from "./lib/feature-flag";
 import { installationStore } from "./lib/installation-store";
 import { fetchClient, store } from "./lib/live-state";
+import { closeDigestWorker, initializeDigestWorker } from "./lib/digest-queue";
 import {
   addChannelBackfillJob,
   addThreadBackfillJob,
@@ -1302,6 +1303,9 @@ const handleUpdates = async (
     },
   });
 
+  // Initialize the digest delivery worker
+  initializeDigestWorker(getClientForTeam);
+
   setTimeout(async () => {
     // TODO Subscribe callback is not being triggered with current values - track https://github.com/pedroscosta/live-state/issues/82
     await handleMessages(
@@ -1364,6 +1368,7 @@ const shutdown = async () => {
   console.log("[Slack] Shutting down...");
   await reflagClient.flush();
   await closeBackfillQueue();
+  await closeDigestWorker();
   process.exit(0);
 };
 

--- a/apps/slack/src/lib/digest-queue.ts
+++ b/apps/slack/src/lib/digest-queue.ts
@@ -1,0 +1,205 @@
+import type { KnownBlock, WebClient } from "@slack/web-api";
+import type { DigestNotifyJobData } from "@workspace/schemas/digest";
+import { formatRelativeTime } from "@workspace/utils/format";
+import { type Job, Worker } from "bullmq";
+import "../env";
+
+const DIGEST_NOTIFY_QUEUE = "digest-notify";
+const MAX_ITEMS_PER_SECTION = 5;
+
+const getRedisConnection = () => {
+  if (process.env.REDIS_URL) {
+    return { url: process.env.REDIS_URL };
+  }
+
+  return {
+    host: process.env.REDIS_HOST ?? "localhost",
+    port: process.env.REDIS_PORT
+      ? Number.parseInt(process.env.REDIS_PORT, 10)
+      : 6379,
+    password: process.env.REDIS_PASSWORD,
+    db: process.env.REDIS_DB ? Number.parseInt(process.env.REDIS_DB, 10) : 0,
+  };
+};
+
+let digestWorker: Worker<DigestNotifyJobData> | null = null;
+
+export const initializeDigestWorker = (
+  getClientForTeam: (teamId: string) => Promise<WebClient | null>,
+) => {
+  if (digestWorker) {
+    console.log("[Slack] Digest worker already initialized");
+    return digestWorker;
+  }
+
+  digestWorker = new Worker<DigestNotifyJobData>(
+    DIGEST_NOTIFY_QUEUE,
+    async (job: Job<DigestNotifyJobData>) => {
+      const { orgId, teamId, channelId, payload } = job.data;
+
+      console.log(
+        `[Slack] Digest job ${job.id} received for org ${payload.orgName} (${orgId}), team ${teamId}, channel ${channelId}`,
+      );
+      console.log(
+        `[Slack] Digest payload: metrics=${JSON.stringify(payload.metrics)}, pendingReply=${payload.pendingReply.length}, loopToClose=${payload.loopToClose.length}`,
+      );
+
+      const client = await getClientForTeam(teamId);
+      if (!client) {
+        console.error(
+          `[Slack] Could not get Slack client for team ${teamId} (org ${payload.orgName})`,
+        );
+        throw new Error(`Could not get Slack client for team ${teamId}`);
+      }
+      console.log(`[Slack] Obtained WebClient for team ${teamId}`);
+
+      const blocks = buildBlockKitMessage(payload);
+      const text = buildFallbackText(payload);
+      console.log(
+        `[Slack] Built ${blocks.length} blocks, fallback text length=${text.length}`,
+      );
+
+      try {
+        const result = await client.chat.postMessage({
+          channel: channelId,
+          blocks,
+          text,
+        });
+        console.log(
+          `[Slack] Digest posted to channel ${channelId} (ts=${result.ts}) for org ${payload.orgName}`,
+        );
+      } catch (err) {
+        console.error(
+          `[Slack] chat.postMessage failed for channel ${channelId} (org ${payload.orgName}):`,
+          err,
+        );
+        throw err;
+      }
+    },
+    {
+      connection: getRedisConnection(),
+      concurrency: 1,
+    },
+  );
+
+  digestWorker.on("completed", (job) => {
+    console.log(`[Slack] Digest job ${job.id} completed`);
+  });
+
+  digestWorker.on("failed", (job, err) => {
+    console.error(`[Slack] Digest job ${job?.id} failed:`, err.message);
+  });
+
+  digestWorker.on("error", (err) => {
+    console.error("[Slack] Digest worker error:", err);
+  });
+
+  console.log("[Slack] Digest worker initialized");
+  return digestWorker;
+};
+
+export const closeDigestWorker = async () => {
+  if (digestWorker) {
+    await digestWorker.close();
+    console.log("[Slack] Digest worker closed");
+  }
+};
+
+function buildBlockKitMessage(
+  payload: DigestNotifyJobData["payload"],
+): KnownBlock[] {
+  const blocks: KnownBlock[] = [];
+  const { metrics, pendingReply, loopToClose, orgName, orgSlug } = payload;
+
+  blocks.push({
+    type: "header",
+    text: {
+      type: "plain_text",
+      text: `📊 Yesterday — ${orgName}`,
+      emoji: true,
+    },
+  });
+
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: `• ${metrics.newThreads} new threads\n• ${metrics.resolved} resolved\n• ${metrics.currentlyOpen} currently open`,
+    },
+  });
+
+  if (pendingReply.length > 0) {
+    blocks.push({ type: "divider" });
+
+    const capped = pendingReply.slice(0, MAX_ITEMS_PER_SECTION);
+    const lines = capped.map(
+      (item) =>
+        `• ${item.threadName} — ${formatRelativeTime(new Date(Date.now() - item.waitTimeMs))} (${item.customerName})`,
+    );
+
+    if (pendingReply.length > MAX_ITEMS_PER_SECTION) {
+      lines.push(
+        `_+ ${pendingReply.length - MAX_ITEMS_PER_SECTION} more in FrontDesk_`,
+      );
+    }
+
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*⚠️ Waiting for reply (${pendingReply.length})*\n${lines.join("\n")}`,
+      },
+    });
+  }
+
+  if (loopToClose.length > 0) {
+    blocks.push({ type: "divider" });
+
+    const capped = loopToClose.slice(0, MAX_ITEMS_PER_SECTION);
+    const lines = capped.map(
+      (item) =>
+        `• ${item.threadName} — fix merged ${formatRelativeTime(new Date(Date.now() - item.timeSinceMergeMs))} (${item.prDisplayName})`,
+    );
+
+    if (loopToClose.length > MAX_ITEMS_PER_SECTION) {
+      lines.push(
+        `_+ ${loopToClose.length - MAX_ITEMS_PER_SECTION} more in FrontDesk_`,
+      );
+    }
+
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*✅ Loop to close (${loopToClose.length})*\n${lines.join("\n")}`,
+      },
+    });
+  }
+
+  blocks.push({ type: "divider" });
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: `→ <https://${orgSlug}.tryfrontdesk.app/app/signal|Open FrontDesk>`,
+    },
+  });
+
+  return blocks;
+}
+
+function buildFallbackText(payload: DigestNotifyJobData["payload"]): string {
+  const parts = [`📊 Yesterday — ${payload.orgName}`];
+  parts.push(
+    `${payload.metrics.newThreads} new, ${payload.metrics.resolved} resolved, ${payload.metrics.currentlyOpen} open`,
+  );
+
+  if (payload.pendingReply.length > 0) {
+    parts.push(`⚠️ ${payload.pendingReply.length} waiting for reply`);
+  }
+  if (payload.loopToClose.length > 0) {
+    parts.push(`✅ ${payload.loopToClose.length} to loop to close`);
+  }
+
+  return parts.join(" | ");
+}

--- a/apps/slack/src/lib/digest-queue.ts
+++ b/apps/slack/src/lib/digest-queue.ts
@@ -109,7 +109,7 @@ function buildBlockKitMessage(
   payload: DigestNotifyJobData["payload"],
 ): KnownBlock[] {
   const blocks: KnownBlock[] = [];
-  const { metrics, pendingReply, loopToClose, orgName, orgSlug } = payload;
+  const { metrics, pendingReply, loopToClose, orgName } = payload;
 
   blocks.push({
     type: "header",
@@ -181,7 +181,7 @@ function buildBlockKitMessage(
     type: "section",
     text: {
       type: "mrkdwn",
-      text: `→ <https://${orgSlug}.tryfrontdesk.app/app/signal|Open FrontDesk>`,
+      text: `→ <https://tryfrontdesk.app/app/signal|Open FrontDesk>`,
     },
   });
 

--- a/apps/slack/src/lib/digest-queue.ts
+++ b/apps/slack/src/lib/digest-queue.ts
@@ -7,6 +7,10 @@ import "../env";
 const DIGEST_NOTIFY_QUEUE = "digest-notify";
 const MAX_ITEMS_PER_SECTION = 5;
 
+function escapeMrkdwn(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
 const getRedisConnection = () => {
   if (process.env.REDIS_URL) {
     return { url: process.env.REDIS_URL };
@@ -134,7 +138,7 @@ function buildBlockKitMessage(
     const capped = pendingReply.slice(0, MAX_ITEMS_PER_SECTION);
     const lines = capped.map(
       (item) =>
-        `• ${item.threadName} — ${formatRelativeTime(new Date(Date.now() - item.waitTimeMs))} (${item.customerName})`,
+        `• ${escapeMrkdwn(item.threadName)} — ${formatRelativeTime(new Date(Date.now() - item.waitTimeMs))} (${escapeMrkdwn(item.customerName)})`,
     );
 
     if (pendingReply.length > MAX_ITEMS_PER_SECTION) {
@@ -158,7 +162,7 @@ function buildBlockKitMessage(
     const capped = loopToClose.slice(0, MAX_ITEMS_PER_SECTION);
     const lines = capped.map(
       (item) =>
-        `• ${item.threadName} — fix merged ${formatRelativeTime(new Date(Date.now() - item.timeSinceMergeMs))} (${item.prDisplayName})`,
+        `• ${escapeMrkdwn(item.threadName)} — fix merged ${formatRelativeTime(new Date(Date.now() - item.timeSinceMergeMs))} (${escapeMrkdwn(item.prDisplayName)})`,
     );
 
     if (loopToClose.length > MAX_ITEMS_PER_SECTION) {

--- a/apps/slack/src/lib/digest-queue.ts
+++ b/apps/slack/src/lib/digest-queue.ts
@@ -1,7 +1,11 @@
 import type { KnownBlock, WebClient } from "@slack/web-api";
-import type { DigestNotifyJobData } from "@workspace/schemas/digest";
+import {
+  type DigestNotifyJobData,
+  digestNotifyJobDataSchema,
+} from "@workspace/schemas/digest";
 import { formatRelativeTime } from "@workspace/utils/format";
 import { type Job, Worker } from "bullmq";
+import Redis, { type RedisOptions } from "ioredis";
 import "../env";
 
 const DIGEST_NOTIFY_QUEUE = "digest-notify";
@@ -11,19 +15,28 @@ function escapeMrkdwn(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-const getRedisConnection = () => {
+const getRedisConnection = (): Redis => {
   if (process.env.REDIS_URL) {
-    return { url: process.env.REDIS_URL };
+    return new Redis(process.env.REDIS_URL, { maxRetriesPerRequest: null });
   }
 
-  return {
+  const redisConfig: RedisOptions = {
     host: process.env.REDIS_HOST ?? "localhost",
     port: process.env.REDIS_PORT
       ? Number.parseInt(process.env.REDIS_PORT, 10)
       : 6379,
-    password: process.env.REDIS_PASSWORD,
-    db: process.env.REDIS_DB ? Number.parseInt(process.env.REDIS_DB, 10) : 0,
+    maxRetriesPerRequest: null,
   };
+
+  if (process.env.REDIS_PASSWORD) {
+    redisConfig.password = process.env.REDIS_PASSWORD;
+  }
+
+  if (process.env.REDIS_DB) {
+    redisConfig.db = Number.parseInt(process.env.REDIS_DB, 10);
+  }
+
+  return new Redis(redisConfig);
 };
 
 let digestWorker: Worker<DigestNotifyJobData> | null = null;
@@ -39,7 +52,13 @@ export const initializeDigestWorker = (
   digestWorker = new Worker<DigestNotifyJobData>(
     DIGEST_NOTIFY_QUEUE,
     async (job: Job<DigestNotifyJobData>) => {
-      const { orgId, teamId, channelId, payload } = job.data;
+      const parsed = digestNotifyJobDataSchema.safeParse(job.data);
+      if (!parsed.success) {
+        throw new Error(
+          `[Slack] Invalid digest-notify job payload: ${parsed.error.message}`,
+        );
+      }
+      const { orgId, teamId, channelId, payload } = parsed.data;
 
       console.log(
         `[Slack] Digest job ${job.id} received for org ${payload.orgName} (${orgId}), team ${teamId}, channel ${channelId}`,

--- a/apps/web/src/components/devtools/devtools-menu/signals-submenu.tsx
+++ b/apps/web/src/components/devtools/devtools-menu/signals-submenu.tsx
@@ -122,11 +122,50 @@ const AddLoopToCloseMenuItem = () => {
   );
 };
 
+const ForceDigestMenuItem = () => {
+  const currentOrg = useAtomValue(activeOrganizationAtom);
+
+  const handleForce = async () => {
+    if (!currentOrg?.id) {
+      toast.error("No organization selected");
+      return;
+    }
+
+    try {
+      const res = await fetch("/api/dev/force-digest", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ orgId: currentOrg.id }),
+      });
+
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+
+      const data = await res.json();
+      toast.success(`Digest job enqueued: ${data.jobId}`);
+    } catch (err) {
+      console.error("Failed to force digest:", err);
+      toast.error("Failed to force digest");
+    }
+  };
+
+  return (
+    <MenuItem
+      onClick={handleForce}
+      aria-label="Force send the daily digest for the current organization"
+    >
+      Force send digest
+    </MenuItem>
+  );
+};
+
 export const SignalsSubmenu = () => {
   return (
     <>
       <AddPendingReplyMenuItem />
       <AddLoopToCloseMenuItem />
+      <ForceDigestMenuItem />
     </>
   );
 };

--- a/apps/worker/src/handlers/digest-deliver.ts
+++ b/apps/worker/src/handlers/digest-deliver.ts
@@ -27,6 +27,7 @@ type ThreadRow = {
   status: number;
   createdAt: Date | string;
   deletedAt: Date | string | null;
+  externalPrId?: string | null;
 };
 
 type SuggestionRow = {
@@ -37,7 +38,17 @@ type SuggestionRow = {
   organizationId: string;
   resultsStr: string | null;
   metadataStr: string | null;
+  createdAt: Date | string;
 };
+
+function safeJsonParse(value: string | null): any {
+  if (!value) return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
 
 type AuthorRow = {
   id: string;
@@ -318,7 +329,7 @@ async function enrichPendingReplySignals(
       if (!thread) return null;
 
       const author = authorMap.get(thread.authorId);
-      const results = signal.resultsStr ? JSON.parse(signal.resultsStr) : null;
+      const results = safeJsonParse(signal.resultsStr);
       const lastMessageAt = results?.lastMessageAt
         ? new Date(results.lastMessageAt).getTime()
         : new Date(signal.createdAt).getTime();
@@ -352,7 +363,7 @@ async function enrichLoopToCloseSignals(
       const thread = threadMap.get(signal.entityId);
       if (!thread) return null;
 
-      const results = signal.resultsStr ? JSON.parse(signal.resultsStr) : null;
+      const results = safeJsonParse(signal.resultsStr);
       const prMergedAt = results?.prMergedAt
         ? new Date(results.prMergedAt).getTime()
         : new Date(signal.createdAt).getTime();

--- a/apps/worker/src/handlers/digest-deliver.ts
+++ b/apps/worker/src/handlers/digest-deliver.ts
@@ -1,0 +1,434 @@
+import type {
+  DigestLoopToCloseItem,
+  DigestNotifyJobData,
+  DigestPayload,
+  DigestPendingReplyItem,
+} from "@workspace/schemas/digest";
+import { safeParseOrgSettings } from "@workspace/schemas/organization";
+import type { Job, Queue } from "bullmq";
+import { fetchClient } from "../lib/database/client";
+
+const SUGGESTION_TYPE_PENDING_REPLY = "digest:pending_reply";
+const SUGGESTION_TYPE_LOOP_TO_CLOSE = "digest:loop_to_close";
+const OPEN_STATUSES = [0, 1];
+const RESOLVED_STATUSES = [2, 3, 4];
+
+type OrgRow = {
+  id: string;
+  name: string;
+  slug: string;
+  settings: unknown;
+};
+
+type ThreadRow = {
+  id: string;
+  name: string;
+  authorId: string;
+  status: number;
+  createdAt: Date | string;
+  deletedAt: Date | string | null;
+};
+
+type SuggestionRow = {
+  id: string;
+  type: string;
+  entityId: string;
+  active: boolean;
+  organizationId: string;
+  resultsStr: string | null;
+  metadataStr: string | null;
+};
+
+type AuthorRow = {
+  id: string;
+  name: string;
+  userId: string | null;
+};
+
+type IntegrationRow = {
+  id: string;
+  organizationId: string;
+  type: string;
+  enabled: boolean;
+  configStr: string | null;
+};
+
+type UpdateRow = {
+  id: string;
+  threadId: string;
+  type: string;
+  createdAt: Date | string;
+  metadataStr: string | null;
+};
+
+let notifyQueue: Queue<DigestNotifyJobData> | null = null;
+
+export const setDigestNotifyQueue = (queue: Queue<DigestNotifyJobData>) => {
+  notifyQueue = queue;
+};
+
+export const handleDigestDeliver = async (job: Job) => {
+  const forceOrgId = job.data?.forceOrgId as string | undefined;
+  console.log(
+    forceOrgId
+      ? `\n📬 Digest deliver: force for org ${forceOrgId}`
+      : "\n📬 Digest deliver: starting",
+  );
+
+  if (!notifyQueue) {
+    console.error("Digest deliver: notify queue not initialized");
+    return { sent: 0, skipped: 0 };
+  }
+
+  const organizations =
+    (await fetchClient.query.organization.get()) as OrgRow[];
+
+  let sent = 0;
+  let skipped = 0;
+
+  for (const org of organizations) {
+    if (forceOrgId && org.id !== forceOrgId) continue;
+
+    try {
+      const result = await processOrganization(org, notifyQueue, !!forceOrgId);
+      if (result) {
+        sent++;
+      } else {
+        skipped++;
+      }
+    } catch (error) {
+      console.error(`Digest deliver failed for org ${org.id}:`, error);
+      skipped++;
+    }
+  }
+
+  console.log(`📬 Digest deliver complete: ${sent} sent, ${skipped} skipped`);
+
+  return { sent, skipped };
+};
+
+async function processOrganization(
+  org: OrgRow,
+  queue: Queue<DigestNotifyJobData>,
+  force = false,
+): Promise<boolean> {
+  const tag = `[digest ${org.slug}]`;
+  const settings = safeParseOrgSettings(org.settings);
+
+  const channelRef =
+    settings.digest.slackChannelId ??
+    (settings.digest.slackChannelName
+      ? settings.digest.slackChannelName.startsWith("#")
+        ? settings.digest.slackChannelName
+        : `#${settings.digest.slackChannelName}`
+      : null);
+
+  if (!channelRef) {
+    console.log(`${tag} skip: no slack channel configured`);
+    return false;
+  }
+
+  if (!force) {
+    if (!isDigestTime(settings.timezone, settings.digest.time)) {
+      console.log(
+        `${tag} skip: not digest time (configured=${settings.digest.time} ${settings.timezone})`,
+      );
+      return false;
+    }
+
+    if (
+      hasAlreadySentToday(settings.digest.lastDigestSentAt, settings.timezone)
+    ) {
+      console.log(
+        `${tag} skip: already sent today (lastDigestSentAt=${settings.digest.lastDigestSentAt})`,
+      );
+      return false;
+    }
+  }
+
+  const teamId = await getTeamIdForOrg(org.id);
+  if (!teamId) {
+    console.log(`${tag} skip: no enabled Slack integration / teamId`);
+    return false;
+  }
+
+  console.log(
+    `${tag} processing (force=${force}, channel=${channelRef}, team=${teamId})`,
+  );
+
+  const now = Date.now();
+  const twentyFourHoursAgo = new Date(now - 24 * 60 * 60 * 1000);
+
+  const [metrics, signals] = await Promise.all([
+    computeMetrics(org.id, twentyFourHoursAgo),
+    loadActiveSignals(org.id),
+  ]);
+
+  const pendingReplySignals = signals.filter(
+    (s) => s.type === SUGGESTION_TYPE_PENDING_REPLY,
+  );
+  const loopToCloseSignals = signals.filter(
+    (s) => s.type === SUGGESTION_TYPE_LOOP_TO_CLOSE,
+  );
+
+  console.log(
+    `${tag} metrics=${JSON.stringify(metrics)} pendingReply=${pendingReplySignals.length} loopToClose=${loopToCloseSignals.length}`,
+  );
+
+  if (
+    metrics.newThreads === 0 &&
+    metrics.resolved === 0 &&
+    metrics.currentlyOpen === 0 &&
+    pendingReplySignals.length === 0 &&
+    loopToCloseSignals.length === 0
+  ) {
+    console.log(`${tag} skip: silent day (all metrics and signals zero)`);
+    return false;
+  }
+
+  const [pendingReplyItems, loopToCloseItems] = await Promise.all([
+    enrichPendingReplySignals(pendingReplySignals, now),
+    enrichLoopToCloseSignals(loopToCloseSignals, now),
+  ]);
+
+  const payload: DigestPayload = {
+    orgName: org.name,
+    orgSlug: org.slug,
+    metrics,
+    pendingReply: pendingReplyItems,
+    loopToClose: loopToCloseItems,
+  };
+
+  const notifyJob = await queue.add("digest-notify", {
+    orgId: org.id,
+    teamId,
+    channelId: channelRef,
+    payload,
+  });
+  console.log(
+    `${tag} enqueued digest-notify job ${notifyJob.id} (channel=${channelRef})`,
+  );
+
+  const updatedSettings = {
+    ...((org.settings as Record<string, unknown>) ?? {}),
+    digest: {
+      ...settings.digest,
+      lastDigestSentAt: new Date(now).toISOString(),
+    },
+  };
+  await fetchClient.mutate.organization.update(org.id, {
+    settings: updatedSettings,
+  });
+
+  const nowIso = new Date(now).toISOString();
+  for (const signal of signals) {
+    const metadata = signal.metadataStr
+      ? JSON.parse(signal.metadataStr)
+      : { digestIncludedAt: [] };
+    metadata.digestIncludedAt = [...(metadata.digestIncludedAt ?? []), nowIso];
+    await fetchClient.mutate.suggestion.update(signal.id, {
+      metadataStr: JSON.stringify(metadata),
+      updatedAt: new Date(now),
+    });
+  }
+
+  console.log(`📬 Digest enqueued for org ${org.name} (${org.id})`);
+  return true;
+}
+
+async function computeMetrics(
+  organizationId: string,
+  since: Date,
+): Promise<{ newThreads: number; resolved: number; currentlyOpen: number }> {
+  const allThreads = (await fetchClient.query.thread
+    .where({ organizationId, deletedAt: null })
+    .get()) as ThreadRow[];
+
+  const newThreads = allThreads.filter(
+    (t) => new Date(t.createdAt).getTime() >= since.getTime(),
+  ).length;
+
+  const currentlyOpen = allThreads.filter((t) =>
+    OPEN_STATUSES.includes(t.status),
+  ).length;
+
+  const updates = (await fetchClient.query.update
+    .where({
+      type: "status_changed",
+      thread: { organizationId },
+    })
+    .get()) as UpdateRow[];
+
+  const resolvedThreadIds = new Set<string>();
+  for (const update of updates) {
+    if (new Date(update.createdAt).getTime() < since.getTime()) continue;
+    try {
+      const meta = update.metadataStr ? JSON.parse(update.metadataStr) : null;
+      const newStatus = meta?.newStatus;
+      if (
+        typeof newStatus === "number" &&
+        RESOLVED_STATUSES.includes(newStatus)
+      ) {
+        resolvedThreadIds.add(update.threadId);
+      }
+    } catch {
+      // skip malformed metadata
+    }
+  }
+
+  return { newThreads, resolved: resolvedThreadIds.size, currentlyOpen };
+}
+
+async function loadActiveSignals(
+  organizationId: string,
+): Promise<SuggestionRow[]> {
+  return (await fetchClient.query.suggestion
+    .where({
+      organizationId,
+      type: {
+        $in: [SUGGESTION_TYPE_PENDING_REPLY, SUGGESTION_TYPE_LOOP_TO_CLOSE],
+      },
+      active: true,
+    })
+    .get()) as SuggestionRow[];
+}
+
+async function enrichPendingReplySignals(
+  signals: SuggestionRow[],
+  now: number,
+): Promise<DigestPendingReplyItem[]> {
+  if (signals.length === 0) return [];
+
+  const threadIds = signals.map((s) => s.entityId);
+  const threads = (await fetchClient.query.thread
+    .where({ id: { $in: threadIds } })
+    .get()) as ThreadRow[];
+
+  const threadMap = new Map(threads.map((t) => [t.id, t]));
+
+  const authorIds = new Set(threads.map((t) => t.authorId));
+  const authors = (await fetchClient.query.author
+    .where({ id: { $in: [...authorIds] } })
+    .get()) as AuthorRow[];
+  const authorMap = new Map(authors.map((a) => [a.id, a]));
+
+  return signals
+    .map((signal): DigestPendingReplyItem | null => {
+      const thread = threadMap.get(signal.entityId);
+      if (!thread) return null;
+
+      const author = authorMap.get(thread.authorId);
+      const results = signal.resultsStr ? JSON.parse(signal.resultsStr) : null;
+      const lastMessageAt = results?.lastMessageAt
+        ? new Date(results.lastMessageAt).getTime()
+        : new Date(signal.createdAt).getTime();
+
+      return {
+        threadId: thread.id,
+        threadName: thread.name,
+        customerName: author?.name ?? "Unknown",
+        waitTimeMs: now - lastMessageAt,
+      };
+    })
+    .filter((item): item is DigestPendingReplyItem => item !== null)
+    .sort((a, b) => b.waitTimeMs - a.waitTimeMs);
+}
+
+async function enrichLoopToCloseSignals(
+  signals: SuggestionRow[],
+  now: number,
+): Promise<DigestLoopToCloseItem[]> {
+  if (signals.length === 0) return [];
+
+  const threadIds = signals.map((s) => s.entityId);
+  const threads = (await fetchClient.query.thread
+    .where({ id: { $in: threadIds } })
+    .get()) as ThreadRow[];
+
+  const threadMap = new Map(threads.map((t) => [t.id, t]));
+
+  return signals
+    .map((signal): DigestLoopToCloseItem | null => {
+      const thread = threadMap.get(signal.entityId);
+      if (!thread) return null;
+
+      const results = signal.resultsStr ? JSON.parse(signal.resultsStr) : null;
+      const prMergedAt = results?.prMergedAt
+        ? new Date(results.prMergedAt).getTime()
+        : new Date(signal.createdAt).getTime();
+
+      const linkedPrId = results?.linkedPrId ?? thread.externalPrId ?? "";
+      const prNumber = linkedPrId.match(/#(\d+)/)?.[1];
+
+      return {
+        threadId: thread.id,
+        threadName: thread.name,
+        linkedPrId,
+        prDisplayName: prNumber ? `PR #${prNumber}` : "PR",
+        timeSinceMergeMs: now - prMergedAt,
+      };
+    })
+    .filter((item): item is DigestLoopToCloseItem => item !== null)
+    .sort((a, b) => b.timeSinceMergeMs - a.timeSinceMergeMs);
+}
+
+async function getTeamIdForOrg(orgId: string): Promise<string | null> {
+  const integrations = (await fetchClient.query.integration
+    .where({
+      organizationId: orgId,
+      type: "slack",
+      enabled: true,
+    })
+    .get()) as IntegrationRow[];
+
+  const integration = integrations[0];
+  if (!integration?.configStr) return null;
+
+  try {
+    const config = JSON.parse(integration.configStr);
+    return config.teamId ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function isDigestTime(timezone: string, digestTime: string): boolean {
+  const now = new Date();
+  const formatter = new Intl.DateTimeFormat("en-GB", {
+    timeZone: timezone,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  const currentTime = formatter.format(now);
+
+  const [currentH, currentM] = currentTime.split(":").map(Number);
+  const [digestH, digestM] = digestTime.split(":").map(Number);
+
+  const currentMinutes = currentH * 60 + currentM;
+  const digestMinutes = digestH * 60 + digestM;
+
+  const diff = Math.abs(currentMinutes - digestMinutes);
+  const wrappedDiff = Math.min(diff, 1440 - diff);
+
+  return wrappedDiff <= 1;
+}
+
+function hasAlreadySentToday(
+  lastSentAt: string | null,
+  timezone: string,
+): boolean {
+  if (!lastSentAt) return false;
+
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+
+  const todayStr = formatter.format(new Date());
+  const lastSentStr = formatter.format(new Date(lastSentAt));
+
+  return todayStr === lastSentStr;
+}

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -1,6 +1,7 @@
 import { type Job, Queue, Worker } from "bullmq";
 import Redis from "ioredis";
 import { handleCrawlDocumentation } from "./handlers/crawl-documentation";
+import { handleDigestDeliver, setDigestNotifyQueue } from "./handlers/digest-deliver";
 import { handleDigestScan } from "./handlers/digest-scan";
 import { handleEmbedPr } from "./handlers/embed-pr";
 import { ensureDocumentationCollection } from "./lib/qdrant/documentation";
@@ -14,6 +15,8 @@ const INGEST_THREAD_QUEUE = "ingest-thread";
 const CRAWL_DOCUMENTATION_QUEUE = "crawl-documentation";
 const EMBED_PR_QUEUE = "embed-pr";
 const DIGEST_SCAN_QUEUE = "digest-scan";
+const DIGEST_DELIVER_QUEUE = "digest-deliver";
+const DIGEST_NOTIFY_QUEUE = "digest-notify";
 
 interface IngestThreadJobData {
   threadIds: string[];
@@ -194,6 +197,41 @@ const digestScanWorker = new Worker(
   },
 );
 
+// Create digest-deliver queue (for job scheduler), worker, and notify queue (for Slack app)
+const digestDeliverQueue = new Queue(DIGEST_DELIVER_QUEUE, { connection });
+const digestNotifyQueue = new Queue(DIGEST_NOTIFY_QUEUE, { connection });
+setDigestNotifyQueue(digestNotifyQueue);
+
+const digestDeliverWorker = new Worker(
+  DIGEST_DELIVER_QUEUE,
+  handleDigestDeliver,
+  {
+    connection,
+    autorun: false,
+    concurrency: 1,
+    removeOnComplete: {
+      count: 50,
+      age: 24 * 3600,
+    },
+    removeOnFail: {
+      count: 500,
+    },
+  },
+);
+
+digestDeliverWorker.on("completed", (job) => {
+  console.log(`✅ Digest-deliver job ${job.id} has been completed`);
+});
+
+digestDeliverWorker.on("failed", (job, err) => {
+  console.error(`❌ Digest-deliver job ${job?.id} has failed:`, err.message);
+  console.error(err);
+});
+
+digestDeliverWorker.on("error", (err) => {
+  console.error("Digest-deliver worker error:", err);
+});
+
 digestScanWorker.on("completed", (job) => {
   console.log(`✅ Digest-scan job ${job.id} has been completed`);
 });
@@ -266,11 +304,18 @@ const initialize = async () => {
   });
   console.log("✅ Digest scan scheduler registered (every 5 min)");
 
+  // Register digest deliver scheduler (every 1 minute)
+  await digestDeliverQueue.upsertJobScheduler("digest-deliver", {
+    every: 60_000,
+  });
+  console.log("✅ Digest deliver scheduler registered (every 1 min)");
+
   // Start workers now that collections are ready
   ingestThreadWorker.run();
   crawlDocWorker.run();
   embedPrWorker.run();
   digestScanWorker.run();
+  digestDeliverWorker.run();
 
   console.log("\nListening for jobs...");
 };
@@ -278,7 +323,7 @@ const initialize = async () => {
 // Graceful shutdown
 const handleShutdown = async () => {
   console.log("\nShutting down workers...");
-  await Promise.all([ingestThreadWorker.close(), crawlDocWorker.close(), embedPrWorker.close(), digestScanWorker.close()]);
+  await Promise.all([ingestThreadWorker.close(), crawlDocWorker.close(), embedPrWorker.close(), digestScanWorker.close(), digestDeliverWorker.close()]);
   await connection.quit();
   console.log("Workers shut down successfully");
   process.exit(0);

--- a/bun.lock
+++ b/bun.lock
@@ -146,6 +146,7 @@
         "api": "workspace:*",
         "bullmq": "^5.67.1",
         "dotenv": "^16.6.1",
+        "ioredis": "^5.3.2",
         "ulid": "^3.0.0",
         "zod": "catalog:",
       },
@@ -2042,7 +2043,7 @@
 
     "bullmq": ["bullmq@5.67.2", "", { "dependencies": { "cron-parser": "4.9.0", "ioredis": "5.9.2", "msgpackr": "1.11.5", "node-abort-controller": "3.1.1", "semver": "7.7.3", "tslib": "2.8.1", "uuid": "11.1.0" } }, "sha512-3KYqNqQptKcgksACO1li4YW9/jxEh6XWa1lUg4OFrHa80Pf0C7H9zeb6ssbQQDfQab/K3QCXopbZ40vrvcyrLw=="],
 
-    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -367,6 +367,7 @@
       "dependencies": {
         "@tiptap/extension-heading": "^3.4.1",
         "@tiptap/react": "^3.4.1",
+        "date-fns": "^4.1.0",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -9,7 +9,8 @@
   "exports": {
     "./integration/*": "./src/integration/*.ts",
     "./external-issue": "./src/external-issue.ts",
-    "./organization": "./src/organization.ts"
+    "./organization": "./src/organization.ts",
+    "./digest": "./src/digest.ts"
   },
   "dependencies": {
     "zod": "catalog:"

--- a/packages/schemas/src/digest.ts
+++ b/packages/schemas/src/digest.ts
@@ -1,0 +1,35 @@
+export type DigestMetrics = {
+  newThreads: number;
+  resolved: number;
+  currentlyOpen: number;
+};
+
+export type DigestPendingReplyItem = {
+  threadId: string;
+  threadName: string;
+  customerName: string;
+  waitTimeMs: number;
+};
+
+export type DigestLoopToCloseItem = {
+  threadId: string;
+  threadName: string;
+  linkedPrId: string;
+  prDisplayName: string;
+  timeSinceMergeMs: number;
+};
+
+export type DigestPayload = {
+  orgName: string;
+  orgSlug: string;
+  metrics: DigestMetrics;
+  pendingReply: DigestPendingReplyItem[];
+  loopToClose: DigestLoopToCloseItem[];
+};
+
+export type DigestNotifyJobData = {
+  orgId: string;
+  teamId: string;
+  channelId: string;
+  payload: DigestPayload;
+};

--- a/packages/schemas/src/digest.ts
+++ b/packages/schemas/src/digest.ts
@@ -1,35 +1,43 @@
-export type DigestMetrics = {
-  newThreads: number;
-  resolved: number;
-  currentlyOpen: number;
-};
+import { z } from "zod";
 
-export type DigestPendingReplyItem = {
-  threadId: string;
-  threadName: string;
-  customerName: string;
-  waitTimeMs: number;
-};
+export const digestMetricsSchema = z.object({
+  newThreads: z.number(),
+  resolved: z.number(),
+  currentlyOpen: z.number(),
+});
 
-export type DigestLoopToCloseItem = {
-  threadId: string;
-  threadName: string;
-  linkedPrId: string;
-  prDisplayName: string;
-  timeSinceMergeMs: number;
-};
+export const digestPendingReplyItemSchema = z.object({
+  threadId: z.string(),
+  threadName: z.string(),
+  customerName: z.string(),
+  waitTimeMs: z.number().nonnegative(),
+});
 
-export type DigestPayload = {
-  orgName: string;
-  orgSlug: string;
-  metrics: DigestMetrics;
-  pendingReply: DigestPendingReplyItem[];
-  loopToClose: DigestLoopToCloseItem[];
-};
+export const digestLoopToCloseItemSchema = z.object({
+  threadId: z.string(),
+  threadName: z.string(),
+  linkedPrId: z.string(),
+  prDisplayName: z.string(),
+  timeSinceMergeMs: z.number().nonnegative(),
+});
 
-export type DigestNotifyJobData = {
-  orgId: string;
-  teamId: string;
-  channelId: string;
-  payload: DigestPayload;
-};
+export const digestPayloadSchema = z.object({
+  orgName: z.string(),
+  orgSlug: z.string(),
+  metrics: digestMetricsSchema,
+  pendingReply: z.array(digestPendingReplyItemSchema),
+  loopToClose: z.array(digestLoopToCloseItemSchema),
+});
+
+export const digestNotifyJobDataSchema = z.object({
+  orgId: z.string().min(1),
+  teamId: z.string().min(1),
+  channelId: z.string().min(1),
+  payload: digestPayloadSchema,
+});
+
+export type DigestMetrics = z.infer<typeof digestMetricsSchema>;
+export type DigestPendingReplyItem = z.infer<typeof digestPendingReplyItemSchema>;
+export type DigestLoopToCloseItem = z.infer<typeof digestLoopToCloseItemSchema>;
+export type DigestPayload = z.infer<typeof digestPayloadSchema>;
+export type DigestNotifyJobData = z.infer<typeof digestNotifyJobDataSchema>;

--- a/packages/schemas/src/organization.ts
+++ b/packages/schemas/src/organization.ts
@@ -5,6 +5,7 @@ const digestSettingsDefaults = {
   time: "09:00",
   slackChannelId: null,
   slackChannelName: null,
+  lastDigestSentAt: null,
 } as const;
 
 export const digestSettingsSchema = z.object({
@@ -15,6 +16,7 @@ export const digestSettingsSchema = z.object({
     .default("09:00"),
   slackChannelId: z.string().nullable().default(null),
   slackChannelName: z.string().nullable().default(null),
+  lastDigestSentAt: z.string().nullable().default(null),
 });
 
 export const organizationSettingsSchema = z.object({

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,20 +1,8 @@
 import { type ClassValue, clsx } from "clsx";
-import { differenceInSeconds, formatDistanceToNowStrict } from "date-fns";
 import { twMerge } from "tailwind-merge";
+
+export { formatRelativeTime } from "@workspace/utils/format";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
-}
-
-export function formatRelativeTime(
-  date: Date,
-  options?: { minimumDifference?: number }
-) {
-  const secondsAgo = differenceInSeconds(new Date(), date);
-
-  if (secondsAgo < (options?.minimumDifference ?? 30)) {
-    return "now";
-  }
-
-  return formatDistanceToNowStrict(date, { addSuffix: true });
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,10 +9,12 @@
   "exports": {
     "./tiptap": "./src/lib/tiptap.ts",
     "./tiptap-md": "./src/lib/tiptap-md.ts",
-    "./md-tiptap": "./src/lib/md-tiptap.ts"
+    "./md-tiptap": "./src/lib/md-tiptap.ts",
+    "./format": "./src/lib/format.ts"
   },
   "dependencies": {
     "@tiptap/extension-heading": "^3.4.1",
+    "date-fns": "^4.1.0",
     "@tiptap/react": "^3.4.1",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",

--- a/packages/utils/src/lib/format.ts
+++ b/packages/utils/src/lib/format.ts
@@ -1,0 +1,14 @@
+import { differenceInSeconds, formatDistanceToNowStrict } from "date-fns";
+
+export function formatRelativeTime(
+  date: Date,
+  options?: { minimumDifference?: number },
+) {
+  const secondsAgo = differenceInSeconds(new Date(), date);
+
+  if (secondsAgo < (options?.minimumDifference ?? 30)) {
+    return "now";
+  }
+
+  return formatDistanceToNowStrict(date, { addSuffix: true });
+}

--- a/packages/utils/src/lib/format.ts
+++ b/packages/utils/src/lib/format.ts
@@ -6,7 +6,7 @@ export function formatRelativeTime(
 ) {
   const secondsAgo = differenceInSeconds(new Date(), date);
 
-  if (secondsAgo < (options?.minimumDifference ?? 30)) {
+  if (Math.abs(secondsAgo) < (options?.minimumDifference ?? 30)) {
     return "now";
   }
 


### PR DESCRIPTION
- Added a new digest delivery worker to process and send daily digest notifications to Slack channels.
- Introduced a force trigger endpoint for manual digest delivery via API.
- Enhanced organization settings to include last digest sent timestamp.
- Created utility functions for formatting relative time and managing digest payloads.
- Updated UI components to allow triggering of digest delivery from the frontend.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the daily digest delivery system that computes org metrics and posts a Slack summary. Adds a dev-only force trigger and Slack worker using `ioredis` with Zod-validated job data.

- **New Features**
  - Worker schedules `digest-deliver` jobs every minute, computes metrics/signals, and enqueues `digest-notify` for Slack; skips if already sent today.
  - Slack app runs a `digest-notify` worker (via `ioredis`), validates payloads using `@workspace/schemas/digest`, and posts Block Kit with a text fallback.
  - Dev-only endpoint `/api/dev/force-digest` and a DevTools menu item to trigger a digest for the current org.
  - Organization settings add `lastDigestSentAt`; moved `formatRelativeTime` to `@workspace/utils/format` and added digest types in `@workspace/schemas`.

- **Migration**
  - Ensure Slack integration is enabled with a `teamId` in org Slack config.
  - Set a digest channel (`slackChannelId` or `slackChannelName`) and preferred send time/timezone.
  - Deploy the worker and Slack app with Redis; configure Redis via env (`REDIS_URL` or host/port), and run `digest-deliver` and `digest-notify`.

<sup>Written for commit 3b7836417d7afbb2f2c595ff9992888939888ada. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled Slack digest notifications delivering thread metrics, pending replies, and items needing attention.
  * Developer-facing option in the devtools to manually trigger a digest and receive success/error feedback.

* **Chores**
  * Centralized/refactored relative-time formatting utility (behavior preserved; sourced from shared utils).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->