### PR TITLE
feat(api): per-org thread shortId + live-state migration runner

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,7 @@ import { publicKeys } from "./lib/api-key";
 import { auth } from "./lib/auth";
 import { reflagClient } from "./lib/feature-flag";
 import { portalAuth } from "./lib/portal-auth";
+import { runMigrations } from "./live-state/migrations";
 import { router } from "./live-state/router";
 import { schema } from "./live-state/schema";
 import { storage } from "./live-state/storage";
@@ -27,6 +28,14 @@ const corsOptions = {
 };
 
 app.use(cors(corsOptions));
+
+// Ensure live-state has synced the schema (creating any new tables/columns)
+// before we run data migrations or start the server. The Server constructor
+// fires storage.init asynchronously without awaiting it, so we pre-init here
+// to guarantee tables exist by the time runMigrations runs.
+await (storage as unknown as {
+  init: (schema: unknown) => Promise<void>;
+}).init(schema);
 
 const lsServer = server({
   router,
@@ -261,6 +270,8 @@ expressAdapter(app as any, lsServer, {
 reflagClient.initialize().then(() => {
   console.log("Reflag client initialized");
 });
+
+await runMigrations(storage);
 
 app.listen(process.env.PORT || 3333, () => {
   console.log(`Server running on port ${process.env.PORT || 3333}`);

--- a/apps/api/src/lib/thread-short-id.ts
+++ b/apps/api/src/lib/thread-short-id.ts
@@ -4,9 +4,15 @@ import type { schema } from "../live-state/schema";
 type DB = ServerDB<typeof schema>;
 
 /**
- * Atomically reserve the next per-organization thread shortId.
- * Must be called inside a transaction that also performs the thread insert,
- * so a rolled-back insert doesn't burn a number.
+ * Returns the next per-organization thread shortId by reading the current
+ * counter, incrementing it, and writing the new value back.
+ *
+ * NOT atomic: the read/compute/write happens through live-state's ServerDB
+ * without row-level locking, so two concurrent callers for the same org can
+ * observe the same counter and produce duplicate shortIds. Callers should
+ * invoke this inside a transaction that also performs the thread insert so
+ * a rolled-back insert doesn't burn a number, but the transaction alone
+ * does not prevent cross-transaction collisions.
  */
 export async function nextThreadShortId(
   db: DB,

--- a/apps/api/src/lib/thread-short-id.ts
+++ b/apps/api/src/lib/thread-short-id.ts
@@ -1,0 +1,24 @@
+import type { ServerDB } from "@live-state/sync/server";
+import type { schema } from "../live-state/schema";
+
+type DB = ServerDB<typeof schema>;
+
+/**
+ * Atomically reserve the next per-organization thread shortId.
+ * Must be called inside a transaction that also performs the thread insert,
+ * so a rolled-back insert doesn't burn a number.
+ */
+export async function nextThreadShortId(
+  db: DB,
+  organizationId: string,
+): Promise<number> {
+  const org = await db.organization.one(organizationId).get();
+  if (!org) {
+    throw new Error(
+      `nextThreadShortId: organization ${organizationId} not found`,
+    );
+  }
+  const next = (org.shortIdCounter ?? 0) + 1;
+  await db.organization.update(organizationId, { shortIdCounter: next });
+  return next;
+}

--- a/apps/api/src/live-state/migrations/files/001_backfill_thread_short_id.ts
+++ b/apps/api/src/live-state/migrations/files/001_backfill_thread_short_id.ts
@@ -1,0 +1,27 @@
+import type { Migration } from "../types";
+
+const migration: Migration = {
+  name: "001_backfill_thread_short_id",
+  up: async ({ db }) => {
+    const orgs = await db.organization.where({}).get();
+
+    for (const org of orgs) {
+      const threads = await db.thread
+        .where({ organizationId: org.id })
+        .orderBy("createdAt", "asc")
+        .get();
+
+      const unnumbered = threads.filter((t) => t.shortId == null);
+      if (unnumbered.length === 0) continue;
+
+      let n = org.shortIdCounter ?? 0;
+      for (const t of unnumbered) {
+        n += 1;
+        await db.thread.update(t.id, { shortId: n });
+      }
+      await db.organization.update(org.id, { shortIdCounter: n });
+    }
+  },
+};
+
+export default migration;

--- a/apps/api/src/live-state/migrations/files/001_backfill_thread_short_id.ts
+++ b/apps/api/src/live-state/migrations/files/001_backfill_thread_short_id.ts
@@ -11,15 +11,24 @@ const migration: Migration = {
         .orderBy("createdAt", "asc")
         .get();
 
-      const unnumbered = threads.filter((t) => t.shortId == null);
-      if (unnumbered.length === 0) continue;
+      // Seed from the max of counter and any existing shortIds so we never
+      // reassign a value that collides with a thread already numbered by
+      // nextThreadShortId (e.g. from an earlier partial run).
+      const maxExisting = threads.reduce(
+        (acc, t) => (t.shortId != null && t.shortId > acc ? t.shortId : acc),
+        0,
+      );
+      let n = Math.max(org.shortIdCounter ?? 0, maxExisting);
 
-      let n = org.shortIdCounter ?? 0;
+      const unnumbered = threads.filter((t) => t.shortId == null);
       for (const t of unnumbered) {
         n += 1;
         await db.thread.update(t.id, { shortId: n });
       }
-      await db.organization.update(org.id, { shortIdCounter: n });
+
+      if (n !== (org.shortIdCounter ?? 0)) {
+        await db.organization.update(org.id, { shortIdCounter: n });
+      }
     }
   },
 };

--- a/apps/api/src/live-state/migrations/files/index.ts
+++ b/apps/api/src/live-state/migrations/files/index.ts
@@ -1,0 +1,4 @@
+import type { Migration } from "../types";
+import m001 from "./001_backfill_thread_short_id";
+
+export const migrations: Migration[] = [m001];

--- a/apps/api/src/live-state/migrations/index.ts
+++ b/apps/api/src/live-state/migrations/index.ts
@@ -1,0 +1,19 @@
+import { createServerDB, type Storage } from "@live-state/sync/server";
+import { schema } from "../schema";
+import { migrations } from "./files";
+
+export async function runMigrations(storage: Storage) {
+  const db = createServerDB(storage, schema);
+  const appliedRows = await db.migration.where({}).get();
+  const applied = new Set(appliedRows.map((m) => m.id));
+
+  for (const m of migrations) {
+    if (applied.has(m.name)) continue;
+    console.log(`[migrations] running ${m.name}`);
+    await db.transaction(async ({ trx }) => {
+      await m.up({ db: trx });
+      await trx.migration.insert({ id: m.name, appliedAt: new Date() });
+    });
+    console.log(`[migrations] applied ${m.name}`);
+  }
+}

--- a/apps/api/src/live-state/migrations/types.ts
+++ b/apps/api/src/live-state/migrations/types.ts
@@ -1,0 +1,9 @@
+import type { ServerDB } from "@live-state/sync/server";
+import type { schema } from "../schema";
+
+export type MigrationDB = ServerDB<typeof schema>;
+
+export type Migration = {
+  name: string;
+  up: (opts: { db: MigrationDB }) => Promise<void>;
+};

--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -752,6 +752,15 @@ export const router = createRouter({
         postMutation: ({ ctx }) => !!ctx?.internalApiKey,
       },
     }),
+    // Server-only: migration bookkeeping managed by the boot-time runner.
+    migration: publicRoute.collectionRoute(schema.migration, {
+      read: () => false,
+      insert: () => false,
+      update: {
+        preMutation: () => false,
+        postMutation: () => false,
+      },
+    }),
   },
 });
 

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -845,6 +845,13 @@ export default publicRoute
     }),
   }))
   .withHooks({
+    // TODO: Migrate this logic into a custom `create` mutation and have the
+    // integration apps (slack/discord/devtools) call that mutation instead of
+    // inserting threads via the default `store.mutate.thread.insert(...)` path.
+    // This hook runs post-commit, so shortId assignment isn't in the same
+    // transaction as the insert — a failure here leaves the thread without a
+    // shortId with no retry. A custom mutation can do the insert + shortId
+    // assignment atomically (like the `create` mutation above already does).
     afterInsert: async ({ value, db }) => {
       if (value.shortId != null) return;
       try {

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -10,6 +10,7 @@ import { createReadThroughCache } from "../../lib/cache/read-through.js";
 import { deactivateDigestSignals } from "../../lib/digest-signals";
 import { publicRoute } from "../factories";
 import { schema } from "../schema";
+import { nextThreadShortId } from "../../lib/thread-short-id";
 
 const GITHUB_SERVER_URL =
   process.env.BASE_GITHUB_SERVER_URL || "http://localhost:3334";
@@ -366,6 +367,8 @@ export default publicRoute
           throw new Error("MISSING_AUTHOR_INFO");
         }
 
+        const shortId = await nextThreadShortId(trx, organizationId);
+
         // Create thread
         await trx.insert(schema.thread, {
           id: threadId,
@@ -383,6 +386,7 @@ export default publicRoute
           externalId: null,
           externalOrigin: null,
           externalMetadataStr: null,
+          shortId,
         });
 
         // Create first message
@@ -841,6 +845,18 @@ export default publicRoute
     }),
   }))
   .withHooks({
+    afterInsert: async ({ value, db }) => {
+      if (value.shortId != null) return;
+      try {
+        const shortId = await nextThreadShortId(db, value.organizationId);
+        await db.thread.update(value.id, { shortId });
+      } catch (error) {
+        console.error(
+          `Failed to assign shortId to thread ${value.id}:`,
+          error,
+        );
+      }
+    },
     afterUpdate: ({ value, previousValue, db }) => {
       const CLOSED_STATUSES = [2, 3, 4]; // Resolved, Closed, Duplicated
       if (

--- a/apps/api/src/live-state/schema.ts
+++ b/apps/api/src/live-state/schema.ts
@@ -21,6 +21,7 @@ const organization = object("organization", {
   socials: string().nullable(),
   customInstructions: string().nullable(),
   settings: json<OrganizationSettings>().nullable(),
+  shortIdCounter: number().default(0),
 });
 
 const subscription = object("subscription", {
@@ -60,6 +61,7 @@ const thread = object("thread", {
   externalId: string().nullable(),
   externalOrigin: string().nullable(),
   externalMetadataStr: string().nullable(),
+  shortId: number().nullable(),
 });
 
 const message = object("message", {
@@ -331,6 +333,11 @@ const pipelineJob = object("pipelineJob", {
   updatedAt: timestamp(),
 });
 
+const migration = object("migration", {
+  id: id(),
+  appliedAt: timestamp(),
+});
+
 export const schema = createSchema({
   // models
   organization,
@@ -353,6 +360,7 @@ export const schema = createSchema({
   documentationSource,
   agentChat,
   agentChatMessage,
+  migration,
   // relations
   organizationUserRelations,
   organizationRelations,

--- a/apps/web/src/components/devtools/devtools-menu/duplicate-thread-command.tsx
+++ b/apps/web/src/components/devtools/devtools-menu/duplicate-thread-command.tsx
@@ -10,7 +10,7 @@ export const DuplicateThreadMenuItem = () => {
   const navigate = useNavigate();
   const { id: threadId } = (() => {
     try {
-      return getRouteApi("/app/_workspace/_main/threads/$id").useParams();
+      return getRouteApi("/app/_workspace/_main/threads/$id/").useParams();
     } catch {
       return { id: null };
     }


### PR DESCRIPTION
## Summary

- Adds `thread.shortId` — a per-organization incrementing number — for human-friendly thread references (e.g. `#42`). Counter lives on `organization.shortIdCounter`; generation goes through a shared `nextThreadShortId(db, orgId)` helper called inside the transaction of the `thread.create` custom mutation, and via an `afterInsert` hook for integration-app flows (Slack/Discord/devtools) that use the default INSERT path.
- Introduces an **up-only** migration system that runs at server startup via the live-state `ServerDB` API (no raw Kysely, no DDL — schema changes still live in the live-state schema). Applied migrations are tracked in a new server-only `migration` collection.
- Ships migration `001_backfill_thread_short_id` that assigns `shortId` to pre-existing threads per org (ordered by `createdAt`) and seeds `organization.shortIdCounter`.
- Pre-awaits `storage.init(schema)` in `index.ts` before creating the live-state `Server` — the Server constructor fires init asynchronously without awaiting, so without this the migration runner can race against schema sync and hit "relation does not exist".

## Why

Threads are currently only referenceable by ULID. A short numeric ID makes them citeable in conversation, email, CLI, etc. The migration runner is the scaffolding we need to backfill it (and future data migrations) without ad-hoc scripts.

## Notes for reviewers

- **Concurrency caveat**: the `shortIdCounter` increment is read-then-update through live-state, not a DB-level atomic UPSERT. Concurrent thread inserts for the same org could theoretically collide on `shortId`. Fine for current usage patterns; worth stress-testing before we rely on uniqueness (e.g. add `.unique()` + retry).
- Schema additions: `thread.shortId` (nullable, populated on insert/backfill), `organization.shortIdCounter` (default 0), new `migration` object.
- The `migration` route is registered with all access denied — it's managed entirely by the server-side runner.
- UI is intentionally out of scope for this PR.
- `web` typecheck has a pre-existing error on `duplicate-thread-command.tsx` unrelated to this change (verified by stashing).

## Test plan

- [ ] `bun run --filter api typecheck` passes
- [ ] `bun run --filter api dev` boots and logs `[migrations] applied 001_backfill_thread_short_id` on first run
- [ ] Existing threads have non-null `shortId` after first boot; counter per org equals max `shortId` for that org
- [ ] Creating a thread via the devtools menu assigns the next number and increments the org counter
- [ ] Creating a thread via the Slack/Discord integration flows also gets a `shortId` (via `afterInsert`)
- [ ] Restarting the API does not re-run migration 001

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-organization numeric thread shortId (e.g. #42) and a boot-time, up-only migration runner using `@live-state/sync/server`. Also fixes a devtools route id typo that broke the Duplicate Thread menu item.

- **New Features**
  - `thread.shortId` auto-assigned on create via `nextThreadShortId(...)`; also via an `afterInsert` hook for default INSERT flows.
  - `organization.shortIdCounter` stores the next number per org.
  - `migration` collection is server-only (all access denied).

- **Migration**
  - Boot-time runner tracks applied migrations in `migration`.
  - `001_backfill_thread_short_id`: assigns `shortId` by `createdAt` per org and seeds the counter from `max(counter, maxExistingShortId)`; skips no-op counter updates.
  - Pre-awaits `storage.init(schema)` and runs migrations before accepting requests.

<sup>Written for commit f2259dad56518dcae512c490e563de3a009a6e27. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Threads now receive per-organization short IDs automatically on creation.
  * Existing threads are backfilled with short IDs during upgrade.

* **Infrastructure**
  * Database migration system added to run and track schema/data migrations.
  * Server startup now ensures the live-state storage is schema-synced and migrations run before accepting requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->