### PR TITLE
feat(web): use thread shortId + slug in URLs

### DIFF
--- a/apps/web/src/components/devtools/devtools-menu/duplicate-thread-command.tsx
+++ b/apps/web/src/components/devtools/devtools-menu/duplicate-thread-command.tsx
@@ -4,11 +4,14 @@ import { getRouteApi, useNavigate } from "@tanstack/react-router";
 import { MenuItem } from "@workspace/ui/components/menu";
 import { toast } from "sonner";
 import { ulid } from "ulid";
+import { getDefaultStore } from "jotai/vanilla";
+import { activeOrganizationAtom } from "~/lib/atoms";
 import { fetchClient } from "~/lib/live-state";
+import { parseThreadParam } from "~/utils/thread";
 
 export const DuplicateThreadMenuItem = () => {
   const navigate = useNavigate();
-  const { id: threadId } = (() => {
+  const { id: rawParam } = (() => {
     try {
       return getRouteApi("/app/_workspace/_main/threads/$id/").useParams();
     } catch {
@@ -17,14 +20,31 @@ export const DuplicateThreadMenuItem = () => {
   })();
 
   const handleDuplicateThread = async () => {
-    if (!threadId) {
+    if (!rawParam) {
       toast.error("Open a thread first to duplicate it");
       return;
     }
 
+    const parsed = parseThreadParam(rawParam);
+    if (!parsed) {
+      toast.error("Invalid thread");
+      return;
+    }
+
     try {
+      let where: { id: string } | { shortId: number; organizationId: string };
+      if (parsed.kind === "ulid") {
+        where = { id: parsed.id };
+      } else {
+        const activeOrgId = getDefaultStore().get(activeOrganizationAtom)?.id;
+        if (!activeOrgId) {
+          toast.error("No active organization");
+          return;
+        }
+        where = { shortId: parsed.shortId, organizationId: activeOrgId };
+      }
       const thread = await fetchClient.query.thread
-        .first({ id: threadId })
+        .first(where)
         .include({
           author: true,
           messages: { include: { author: true } },

--- a/apps/web/src/components/threads/create-thread-dialog.tsx
+++ b/apps/web/src/components/threads/create-thread-dialog.tsx
@@ -23,6 +23,7 @@ import { useState } from "react";
 import { fetchClient } from "~/lib/live-state";
 import { portalAuthClient } from "~/lib/portal-auth-client";
 import type { GetSupportAuthUserResponse } from "~/lib/server-funcs/get-portal-auth-user";
+import { buildThreadParam } from "~/utils/thread";
 
 type ThreadContent = JSONContent[];
 
@@ -104,7 +105,10 @@ export function CreateThreadDialog({
       resetForm();
       router.navigate({
         to: "/support/$slug/threads/$id",
-        params: { slug: organization.slug, id: thread.id },
+        params: {
+          slug: organization.slug,
+          id: buildThreadParam(thread),
+        },
       });
     } catch (err) {
       console.error("Failed to create thread:", err);

--- a/apps/web/src/components/threads/related-threads-section.tsx
+++ b/apps/web/src/components/threads/related-threads-section.tsx
@@ -5,6 +5,7 @@ import { Button } from "@workspace/ui/components/button";
 import { ChevronRightIcon } from "lucide-react";
 import { useMemo } from "react";
 import { query } from "~/lib/live-state";
+import { buildThreadParam } from "~/utils/thread";
 
 type SimilarThreadResult = {
   threadId: string;
@@ -29,7 +30,12 @@ const RelatedThreadResult = ({ result }: { result: SimilarThreadResult }) => {
       variant="ghost"
       className="text-foreground-secondary hover:text-foreground px-1.5 cursor-default"
       key={result.threadId}
-      render={<Link to="/app/threads/$id" params={{ id: thread.id }} />}
+      render={
+        <Link
+          to="/app/threads/$id"
+          params={{ id: buildThreadParam(thread) }}
+        />
+      }
     >
       <Avatar
         variant="user"

--- a/apps/web/src/components/threads/support-related-threads-section.tsx
+++ b/apps/web/src/components/threads/support-related-threads-section.tsx
@@ -4,10 +4,12 @@ import { Avatar } from "@workspace/ui/components/avatar";
 import { Button } from "@workspace/ui/components/button";
 import { ChevronRightIcon } from "lucide-react";
 import { fetchClient } from "~/lib/live-state";
+import { buildThreadParam } from "~/utils/thread";
 
 type RelatedThread = {
   id: string;
   name: string;
+  shortId: number | null;
   deletedAt?: Date | null;
   author?: {
     name?: string | null;
@@ -67,7 +69,7 @@ export const SupportRelatedThreadsSection = ({
             render={
               <Link
                 to="/support/$slug/threads/$id"
-                params={{ slug, id: relatedThread.id }}
+                params={{ slug, id: buildThreadParam(relatedThread) }}
               />
             }
           >

--- a/apps/web/src/components/threads/thread-toolbar/agent-message-content.tsx
+++ b/apps/web/src/components/threads/thread-toolbar/agent-message-content.tsx
@@ -4,6 +4,7 @@ import { type Components, Streamdown } from "streamdown";
 import "streamdown/styles.css";
 import { BaseThreadChip } from "~/components/chips";
 import { query } from "~/lib/live-state";
+import { buildThreadParam } from "~/utils/thread";
 
 const THREAD_LINK_PROXY_PREFIX = "https://frontdesk-thread.local/";
 
@@ -24,7 +25,12 @@ function ThreadMention({ threadId }: { threadId: string }) {
     <BaseThreadChip
       thread={thread}
       className="inline-flex align-middle"
-      render={<Link to="/app/threads/$id" params={{ id: thread.id }} />}
+      render={
+        <Link
+          to="/app/threads/$id"
+          params={{ id: buildThreadParam(thread) }}
+        />
+      }
     />
   );
 }

--- a/apps/web/src/components/threads/thread-toolbar/index.tsx
+++ b/apps/web/src/components/threads/thread-toolbar/index.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { updateThreadStatus } from "~/actions/threads";
 import { query } from "~/lib/live-state";
+import { buildThreadParam } from "~/utils/thread";
 import { QuickActionsPanel, useQuickActionsSuggestions } from "./quick-actions";
 import { ReplyEditor } from "./reply-editor";
 import { SupportIntelligenceChat } from "./support-intelligence-chat";
@@ -92,7 +93,7 @@ export const ThreadToolbar = ({
     if (nextIndex < threads.length && nextIndex) {
       navigate({
         to: "/app/threads/$id",
-        params: { id: threads[nextIndex].id },
+        params: { id: buildThreadParam(threads[nextIndex]) },
       });
     } else {
       toast("No more threads");

--- a/apps/web/src/components/threads/thread-toolbar/quick-actions.tsx
+++ b/apps/web/src/components/threads/thread-toolbar/quick-actions.tsx
@@ -27,6 +27,7 @@ import {
   usePendingStatusSuggestions,
 } from "~/components/threads/thread-toolbar/support-intelligence";
 import { mutate, query } from "~/lib/live-state";
+import { buildThreadParam } from "~/utils/thread";
 
 type UseQuickActionsSuggestionsProps = {
   threadId: string;
@@ -558,7 +559,9 @@ export const QuickActionsPanel = ({
                             <div className="flex flex-col gap-1">
                               <Link
                                 to="/app/threads/$id"
-                                params={{ id: duplicateSuggestion.thread.id }}
+                                params={{
+                                  id: buildThreadParam(duplicateSuggestion.thread),
+                                }}
                                 className="text-sm font-medium text-foreground hover:underline"
                               >
                                 {duplicateSuggestion.thread.name}

--- a/apps/web/src/components/threads/thread-toolbar/support-intelligence.tsx
+++ b/apps/web/src/components/threads/thread-toolbar/support-intelligence.tsx
@@ -24,6 +24,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { ulid } from "ulid";
 import { BaseThreadChip } from "~/components/chips";
 import { mutate, query } from "~/lib/live-state";
+import { buildThreadParam } from "~/utils/thread";
 
 type SuggestionRow = {
   id: string;
@@ -688,7 +689,9 @@ export const Suggestions = ({
                         <div className="flex flex-col gap-1">
                           <Link
                             to="/app/threads/$id"
-                            params={{ id: duplicateSuggestion.thread.id }}
+                            params={{
+                              id: buildThreadParam(duplicateSuggestion.thread),
+                            }}
                             className="text-sm font-medium text-foreground hover:underline"
                           >
                             {duplicateSuggestion.thread.name}

--- a/apps/web/src/components/threads/updates.tsx
+++ b/apps/web/src/components/threads/updates.tsx
@@ -11,6 +11,7 @@ import type { schema } from "api/schema";
 import { CircleUserIcon, CopySlash, Github } from "lucide-react";
 import { ThreadChip } from "~/components/chips";
 import { query } from "~/lib/live-state";
+import { buildThreadParam } from "~/utils/thread";
 
 export function Update({
   update,
@@ -163,7 +164,7 @@ export function Update({
                 <Link
                   to="/app/threads/$id"
                   params={{
-                    id: duplicateThread.id,
+                    id: buildThreadParam(duplicateThread),
                   }}
                 />
               }

--- a/apps/web/src/routes/app/_workspace/_main/search/index.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/search/index.tsx
@@ -28,6 +28,7 @@ import {
 import { useEffect, useState } from "react";
 import { activeOrganizationAtom } from "~/lib/atoms";
 import { fetchClient, query } from "~/lib/live-state";
+import { buildThreadParam } from "~/utils/thread";
 
 type SearchResultItemProps = {
   messageId: string;
@@ -59,7 +60,7 @@ const SearchResultItem = ({ messageId }: SearchResultItemProps) => {
     <div className="flex flex-col gap-2 relative">
       <Link
         to="/app/threads/$id"
-        params={{ id: thread.id }}
+        params={{ id: buildThreadParam(thread) }}
         className="w-full flex flex-col py-2 gap-2 rounded-md hover:underline"
       >
         <div className="flex justify-between">
@@ -95,7 +96,11 @@ const SearchResultItem = ({ messageId }: SearchResultItemProps) => {
       </Link>
 
       {/* TODO add link directly to the message */}
-      <Link to="/app/threads/$id" params={{ id: thread.id }} className="w-full">
+      <Link
+        to="/app/threads/$id"
+        params={{ id: buildThreadParam(thread) }}
+        className="w-full"
+      >
         <Card className="relative before:w-px before:h-4 before:left-4 before:absolute before:-top-4 not-first:before:bg-border ml-7 group">
           <CardHeader size="sm">
             <CardTitle>

--- a/apps/web/src/routes/app/_workspace/_main/signal/index.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/signal/index.tsx
@@ -34,6 +34,7 @@ import { ulid } from "ulid";
 import { ThreadChip } from "~/components/chips";
 import { activeOrganizationAtom } from "~/lib/atoms";
 import { mutate, query } from "~/lib/live-state";
+import { buildThreadParam } from "~/utils/thread";
 
 export const Route = createFileRoute("/app/_workspace/_main/signal/")({
   component: RouteComponent,
@@ -1424,7 +1425,7 @@ function SuggestionItem({
       <div className="absolute left-[13px] -top-[64px] w-[13px] h-19 border-[#5C5C5C] border-b border-l rounded-bl-lg" />
       <ThreadChip
         thread={thread}
-        render={<Link to="/app/threads/$id" params={{ id: thread.id }} />}
+        render={<Link to="/app/threads/$id" params={{ id: buildThreadParam(thread) }} />}
       />
       {!isAccepted && onAccept && onDismiss && (
         <div className="flex gap-1 opacity-0 group-hover/nested-item:opacity-100 transition-opacity group-hover/nested-item:duration-0">
@@ -1534,7 +1535,7 @@ function DuplicateSignalCard({
             <ThreadChip
               thread={targetThread}
               render={
-                <Link to="/app/threads/$id" params={{ id: targetThread.id }} />
+                <Link to="/app/threads/$id" params={{ id: buildThreadParam(targetThread) }} />
               }
             />
           )}
@@ -1611,7 +1612,7 @@ function DuplicateSuggestionItem({
       <div className="absolute left-[13px] -top-[64px] w-[13px] h-19 border-[#5C5C5C] border-b border-l rounded-bl-lg" />
       <ThreadChip
         thread={thread}
-        render={<Link to="/app/threads/$id" params={{ id: thread.id }} />}
+        render={<Link to="/app/threads/$id" params={{ id: buildThreadParam(thread) }} />}
       />
       {!isAccepted && onAccept && onDismiss && (
         <div className="flex gap-1 opacity-0 group-hover/nested-item:opacity-100 transition-opacity group-hover/nested-item:duration-0">
@@ -1803,7 +1804,7 @@ function LinkedPrSuggestionItem({
       <div className="absolute left-[13px] -top-[64px] w-[13px] h-19 border-[#5C5C5C] border-b border-l rounded-bl-lg" />
       <ThreadChip
         thread={thread}
-        render={<Link to="/app/threads/$id" params={{ id: thread.id }} />}
+        render={<Link to="/app/threads/$id" params={{ id: buildThreadParam(thread) }} />}
       />
       {!isAccepted && onAccept && onDismiss && (
         <div className="flex gap-1 opacity-0 group-hover/nested-item:opacity-100 transition-opacity group-hover/nested-item:duration-0">
@@ -1904,7 +1905,7 @@ function PendingReplySignalCard({
                   <ThreadChip
                     thread={thread}
                     render={
-                      <Link to="/app/threads/$id" params={{ id: thread.id }} />
+                      <Link to="/app/threads/$id" params={{ id: buildThreadParam(thread) }} />
                     }
                   />
                   <span className="text-xs text-foreground-secondary tabular-nums ml-auto">
@@ -1991,7 +1992,7 @@ function LoopToCloseSignalCard({
                   <ThreadChip
                     thread={thread}
                     render={
-                      <Link to="/app/threads/$id" params={{ id: thread.id }} />
+                      <Link to="/app/threads/$id" params={{ id: buildThreadParam(thread) }} />
                     }
                   />
                   <span className="inline-flex size-6 shrink-0 items-center justify-center text-foreground-secondary -ml-0.75">

--- a/apps/web/src/routes/app/_workspace/_main/threads/$id/index.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/threads/$id/index.tsx
@@ -122,17 +122,6 @@ function RouteComponent() {
   const [highlightAnswer, setHighlightAnswer] = useState(false);
 
   useEffect(() => {
-    const canonical = buildThreadParam(loadedThread);
-    if (rawParam !== canonical) {
-      navigate({
-        to: "/app/threads/$id",
-        params: { id: canonical },
-        replace: true,
-      });
-    }
-  }, [rawParam, loadedThread, navigate]);
-
-  useEffect(() => {
     const checkHash = () => {
       const hasHash = window.location.hash === "#answer-message";
       setHighlightAnswer(hasHash);
@@ -158,6 +147,18 @@ function RouteComponent() {
       updates: { include: { user: true } },
     }),
   )?.[0];
+
+  useEffect(() => {
+    const canonical = buildThreadParam(thread ?? loadedThread);
+    if (rawParam !== canonical) {
+      navigate({
+        to: "/app/threads/$id",
+        params: { id: canonical },
+        hash: (prev) => prev ?? "",
+        replace: true,
+      });
+    }
+  }, [rawParam, thread, loadedThread, navigate]);
 
   const { captureThreadEvent } = useThreadAnalytics(thread);
 

--- a/apps/web/src/routes/app/_workspace/_main/threads/$id/index.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/threads/$id/index.tsx
@@ -49,20 +49,40 @@ import { RelatedThreadsSection } from "~/components/threads/related-threads-sect
 import { ThreadToolbar } from "~/components/threads/thread-toolbar";
 import { ThreadCommands } from "~/lib/commands/commands/thread";
 import { useThreadAnalytics } from "~/lib/hooks/use-thread-analytics";
+import { getDefaultStore } from "jotai/vanilla";
+import { activeOrganizationAtom } from "~/lib/atoms";
 import { fetchClient, mutate, query } from "~/lib/live-state";
 import { seo } from "~/utils/seo";
-import { calculateDeletionDate, DAYS_UNTIL_DELETION } from "~/utils/thread";
+import {
+  buildThreadParam,
+  calculateDeletionDate,
+  DAYS_UNTIL_DELETION,
+  parseThreadParam,
+} from "~/utils/thread";
 import { ThreadHeader } from "./-components/thread-header";
 import { ThreadReply } from "./-components/thread-reply";
 import { ThreadUpdates } from "./-components/thread-updates";
 
 export const Route = createFileRoute("/app/_workspace/_main/threads/$id/")({
   component: RouteComponent,
-  loader: async ({ params }) => {
-    const { id } = params;
+  loader: async ({ params, context }) => {
+    const parsed = parseThreadParam(params.id);
+    if (!parsed) throw notFound();
+
+    let where: { id: string } | { shortId: number; organizationId: string };
+    if (parsed.kind === "ulid") {
+      where = { id: parsed.id };
+    } else {
+      const activeOrgId =
+        getDefaultStore().get(activeOrganizationAtom)?.id ??
+        context.organizationUsers?.[0]?.organization?.id;
+      if (!activeOrgId) throw notFound();
+      where = { shortId: parsed.shortId, organizationId: activeOrgId };
+    }
+
     const thread = (
       await fetchClient.query.thread
-        .where({ id })
+        .where(where)
         .include({
           organization: true,
           author: true,
@@ -94,10 +114,23 @@ export const Route = createFileRoute("/app/_workspace/_main/threads/$id/")({
 
 function RouteComponent() {
   const { user } = getRouteApi("/app").useRouteContext();
-  const { id } = Route.useParams();
+  const { id: rawParam } = Route.useParams();
+  const { thread: loadedThread } = Route.useLoaderData();
+  const id = loadedThread.id;
   const navigate = useNavigate();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [highlightAnswer, setHighlightAnswer] = useState(false);
+
+  useEffect(() => {
+    const canonical = buildThreadParam(loadedThread);
+    if (rawParam !== canonical) {
+      navigate({
+        to: "/app/threads/$id",
+        params: { id: canonical },
+        replace: true,
+      });
+    }
+  }, [rawParam, loadedThread, navigate]);
 
   useEffect(() => {
     const checkHash = () => {

--- a/apps/web/src/routes/app/_workspace/_main/threads/archive/$id.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/threads/archive/$id.tsx
@@ -39,7 +39,11 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { fetchClient, mutate, query } from "~/lib/live-state";
 import { seo } from "~/utils/seo";
-import { DAYS_UNTIL_DELETION, getDaysUntilDeletion } from "~/utils/thread";
+import {
+  buildThreadParam,
+  DAYS_UNTIL_DELETION,
+  getDaysUntilDeletion,
+} from "~/utils/thread";
 
 export const Route = createFileRoute(
   "/app/_workspace/_main/threads/archive/$id",
@@ -120,7 +124,11 @@ function RouteComponent() {
       duration: 10000,
       action: {
         label: "See thread",
-        onClick: () => navigate({ to: "/app/threads/$id", params: { id } }),
+        onClick: () =>
+          navigate({
+            to: "/app/threads/$id",
+            params: { id: thread ? buildThreadParam(thread) : id },
+          }),
       },
       // TODO: Analyse this when working on the design system
       actionButtonStyle: {

--- a/apps/web/src/routes/app/_workspace/_main/threads/index.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/threads/index.tsx
@@ -64,6 +64,7 @@ import { useRef, useState } from "react";
 import { activeOrganizationAtom } from "~/lib/atoms";
 import { query } from "~/lib/live-state";
 import { seo } from "~/utils/seo";
+import { buildThreadParam } from "~/utils/thread";
 
 export type FixedFilters = {
   status?: { $not: { $in: number[] } } | { $in: number[] };
@@ -330,7 +331,10 @@ export function ThreadsList({ fixedFilters = {}, subTitle }: ThreadsListProps) {
                   ref={virtualizer.measureElement}
                   data-index={virtualItem.index}
                   render={
-                    <Link to={"/app/threads/$id"} params={{ id: thread.id }} />
+                    <Link
+                      to={"/app/threads/$id"}
+                      params={{ id: buildThreadParam(thread) }}
+                    />
                   }
                   className="max-w-5xl flex flex-col p-3 gap-2 mx-auto data-[active=true]:bg-muted"
                   style={{

--- a/apps/web/src/routes/support/$slug/threads/$id.tsx
+++ b/apps/web/src/routes/support/$slug/threads/$id.tsx
@@ -115,6 +115,7 @@ function RouteComponent() {
       route.navigate({
         to: "/support/$slug/threads/$id",
         params: { slug: organization.slug, id: canonical },
+        hash: (prev) => prev ?? "",
         replace: true,
       });
     }

--- a/apps/web/src/routes/support/$slug/threads/$id.tsx
+++ b/apps/web/src/routes/support/$slug/threads/$id.tsx
@@ -48,19 +48,23 @@ import { SupportRelatedThreadsSection } from "~/components/threads/support-relat
 import { Update } from "~/components/threads/updates";
 import { fetchClient } from "~/lib/live-state";
 import { seo } from "~/utils/seo";
+import { buildThreadParam, parseThreadParam } from "~/utils/thread";
 
 export const Route = createFileRoute("/support/$slug/threads/$id")({
   component: RouteComponent,
 
   loader: async ({ params, context }) => {
-    const { id } = params;
+    const parsed = parseThreadParam(params.id);
+    if (!parsed) throw notFound();
+
+    const where =
+      parsed.kind === "ulid"
+        ? { id: parsed.id, organizationId: context.organization.id }
+        : { shortId: parsed.shortId, organizationId: context.organization.id };
 
     const thread = (
       await fetchClient.query.thread
-        .where({
-          id,
-          organizationId: context.organization.id,
-        })
+        .where(where)
         .include({
           author: true,
           messages: { include: { author: true } },
@@ -103,6 +107,18 @@ function RouteComponent() {
   const route = useRouter();
   const { organization } = Route.useRouteContext();
   const { thread } = Route.useLoaderData();
+  const { id: rawParam } = Route.useParams();
+
+  useEffect(() => {
+    const canonical = buildThreadParam(thread);
+    if (rawParam !== canonical) {
+      route.navigate({
+        to: "/support/$slug/threads/$id",
+        params: { slug: organization.slug, id: canonical },
+        replace: true,
+      });
+    }
+  }, [rawParam, thread, organization.slug, route]);
 
   const { portalSession } = getRouteApi("/support/$slug").useRouteContext();
   const user = portalSession?.user;
@@ -324,7 +340,7 @@ function RouteComponent() {
                                     to="/support/$slug/threads/$id"
                                     params={{
                                       slug: organization.slug,
-                                      id: thread.id,
+                                      id: buildThreadParam(thread),
                                     }}
                                     hash="answer-message"
                                     onClick={() => {

--- a/apps/web/src/routes/support/$slug/threads/index.tsx
+++ b/apps/web/src/routes/support/$slug/threads/index.tsx
@@ -38,6 +38,7 @@ import { createStandardSchemaV1, parseAsStringEnum } from "nuqs";
 import { useEffect, useRef } from "react";
 import { fetchClient } from "~/lib/live-state";
 import { seo } from "~/utils/seo";
+import { buildThreadParam } from "~/utils/thread";
 
 const PAGE_SIZE = 20;
 
@@ -232,7 +233,10 @@ function RouteComponent() {
                       ref={virtualizer.measureElement}
                       data-index={virtualItem.index}
                       to={"/support/$slug/threads/$id"}
-                      params={{ slug: organization.slug, id: thread.id }}
+                      params={{
+                        slug: organization.slug,
+                        id: buildThreadParam(thread),
+                      }}
                       className="w-full flex flex-col p-3 gap-2 hover:bg-muted"
                       resetScroll={false}
                       style={{

--- a/apps/web/src/utils/thread.ts
+++ b/apps/web/src/utils/thread.ts
@@ -10,3 +10,43 @@ export function getDaysUntilDeletion(deletedAt: Date | null): number | null {
   if (!deletedAt) return null;
   return Math.ceil(differenceInDays(deletedAt, new Date()));
 }
+
+const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/i;
+
+export type ParsedThreadParam =
+  | { kind: "ulid"; id: string }
+  | { kind: "shortId"; shortId: number };
+
+export function parseThreadParam(raw: string): ParsedThreadParam | null {
+  if (ULID_RE.test(raw)) return { kind: "ulid", id: raw.toLowerCase() };
+  const m = raw.match(/^(\d+)(?:-.*)?$/);
+  if (m) return { kind: "shortId", shortId: Number(m[1]) };
+  return null;
+}
+
+export function slugifyThreadName(name: string): string {
+  const words = name
+    .normalize("NFKD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .split(/[\s-]+/)
+    .filter(Boolean);
+  let out = "";
+  for (let i = 0; i < Math.min(words.length, 8); i++) {
+    const next = out ? `${out}-${words[i]}` : words[i];
+    if (next.length > 64) break;
+    out = next;
+  }
+  return out;
+}
+
+export function buildThreadParam(thread: {
+  id: string;
+  shortId: number | null;
+  name: string;
+}): string {
+  if (thread.shortId == null) return thread.id;
+  const slug = slugifyThreadName(thread.name);
+  return slug ? `${thread.shortId}-${slug}` : String(thread.shortId);
+}


### PR DESCRIPTION
## Summary
- Thread URLs now accept `123`, `123-some-slug`, or the existing ULID; loaders parse the param and scope shortId lookups by active org (shortId is per-org, not globally unique).
- After load, the URL is canonicalized to `{shortId}-{slug}` via `replace: true`. Slug is lowercase, hyphen-joined, diacritics stripped, capped at 8 words OR 64 chars (whichever hits first).
- Shared helpers in `apps/web/src/utils/thread.ts`: `parseThreadParam`, `slugifyThreadName`, `buildThreadParam`. All thread-link/navigate call sites build params via `buildThreadParam(thread)` — covers threads list, search, signal, archive restore, related threads (app + portal), updates duplicate chip, thread toolbar next-thread, quick-actions / support-intelligence duplicate hovers, agent mentions, create-thread-dialog, portal list, and the portal "Go to answer" link.
- Applied to both `/app/threads/$id` and the public portal `/support/$slug/threads/$id`.

## Test plan
- [ ] `/app/threads/{shortId}` → loads, URL upgrades to `{shortId}-{slug}`.
- [ ] `/app/threads/{shortId}-wrong-slug` → loads (shortId wins), URL upgrades.
- [ ] `/app/threads/{ULID}` → loads, URL upgrades.
- [ ] `/app/threads/garbage` → 404.
- [ ] Same four cases for `/support/{orgSlug}/threads/...`.
- [ ] Copy-link button produces canonical URL.
- [ ] Creating a thread in the portal lands on the slug URL.
- [ ] Cross-org check: user in two orgs each with a thread at shortId `1` — detail page resolves to the active org's thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use thread shortId + slug in URLs for cleaner, shareable links. Existing ULID links and raw shortIds still work and redirect to the canonical form; anchors are preserved and slugs update on rename.

- **New Features**
  - Accept `/app/threads/{shortId}`, `{shortId}-{slug}`, or `{ULID}` (same for `/support/{orgSlug}/threads/...`); shortId lookups are scoped to the active org (or portal org).
  - Redirect to `{shortId}-{slug}` via `replace: true`. Slug: lowercase, hyphenated, diacritics stripped, max 8 words or 64 chars.
  - Added `parseThreadParam`, `slugifyThreadName`, and `buildThreadParam` in `apps/web/src/utils/thread.ts`. All thread links now use `buildThreadParam(...)` across the app and portal (lists, search, signal, toolbar, related threads, updates, devtools duplicate, archive toast, create-thread, and “Go to answer”).

- **Bug Fixes**
  - Preserve the current URL hash during canonicalization.
  - Canonicalize against live thread data (with loader fallback) so slug updates after thread renames.

<sup>Written for commit 12f2e9165fca2d9fdb217e69e8b21255c51fcdb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thread URLs now use a canonical format that includes thread slugs alongside identifiers for improved consistency and readability across the application.

* **Bug Fixes**
  * Enhanced thread lookup to handle multiple identifier formats (ULID and short IDs), improving reliability when navigating between threads.
  * Added automatic URL canonicalization to redirect users to the correct thread URL format when accessing threads via alternative identifier formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->