### PR TITLE
refactor(web): load thread via live-state in component, drop route loader

### DIFF
--- a/apps/web/src/routes/app/_workspace/_main/threads/$id/index.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/threads/$id/index.tsx
@@ -242,6 +242,10 @@ function RouteComponent() {
     (message) => message.markedAsAnswer,
   );
 
+  // TODO: distinguish "still syncing" from "genuinely not found" here.
+  // useLiveQuery currently has no status signal, so an invalid thread URL
+  // renders a blank loading state forever instead of triggering notFound().
+  // Tracked upstream: https://github.com/pedroscosta/live-state/issues/149
   if (!thread) {
     return <div className="flex size-full" />;
   }

--- a/apps/web/src/routes/app/_workspace/_main/threads/$id/index.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/threads/$id/index.tsx
@@ -9,6 +9,7 @@ import {
   notFound,
   useNavigate,
 } from "@tanstack/react-router";
+import { useAtomValue } from "jotai";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -49,9 +50,8 @@ import { RelatedThreadsSection } from "~/components/threads/related-threads-sect
 import { ThreadToolbar } from "~/components/threads/thread-toolbar";
 import { ThreadCommands } from "~/lib/commands/commands/thread";
 import { useThreadAnalytics } from "~/lib/hooks/use-thread-analytics";
-import { getDefaultStore } from "jotai/vanilla";
 import { activeOrganizationAtom } from "~/lib/atoms";
-import { fetchClient, mutate, query } from "~/lib/live-state";
+import { mutate, query } from "~/lib/live-state";
 import { seo } from "~/utils/seo";
 import {
   buildThreadParam,
@@ -65,69 +65,50 @@ import { ThreadUpdates } from "./-components/thread-updates";
 
 export const Route = createFileRoute("/app/_workspace/_main/threads/$id/")({
   component: RouteComponent,
-  loader: async ({ params, context }) => {
-    const parsed = parseThreadParam(params.id);
-    if (!parsed) throw notFound();
-
-    let where: { id: string } | { shortId: number; organizationId: string };
-    if (parsed.kind === "ulid") {
-      where = { id: parsed.id };
-    } else {
-      const activeOrgId =
-        getDefaultStore().get(activeOrganizationAtom)?.id ??
-        context.organizationUsers?.[0]?.organization?.id;
-      if (!activeOrgId) throw notFound();
-      where = { shortId: parsed.shortId, organizationId: activeOrgId };
-    }
-
-    const thread = (
-      await fetchClient.query.thread
-        .where(where)
-        .include({
-          organization: true,
-          author: true,
-          messages: { include: { author: true } },
-          updates: true,
-        })
-        .get()
-    )[0];
-
-    if (!thread) {
-      throw notFound();
-    }
-
-    return { thread };
-  },
-  head: ({ loaderData }) => {
-    const thread = loaderData?.thread;
-    const threadName = thread?.name ?? "Thread";
-    return {
-      meta: [
-        ...seo({
-          title: `${threadName} - Threads - FrontDesk`,
-          description: `Support thread: ${threadName}`,
-        }),
-      ],
-    };
-  },
+  head: () => ({
+    meta: [
+      ...seo({
+        title: "Thread - FrontDesk",
+        description: "Support thread",
+      }),
+    ],
+  }),
 });
 
 function RouteComponent() {
   const { user } = getRouteApi("/app").useRouteContext();
+  const workspaceCtx = getRouteApi("/app/_workspace").useRouteContext();
   const { id: rawParam } = Route.useParams();
-  const { thread: loadedThread } = Route.useLoaderData();
-  const id = loadedThread.id;
   const navigate = useNavigate();
+  const activeOrg = useAtomValue(activeOrganizationAtom);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [highlightAnswer, setHighlightAnswer] = useState(false);
 
-  useEffect(() => {
-    const checkHash = () => {
-      const hasHash = window.location.hash === "#answer-message";
-      setHighlightAnswer(hasHash);
+  const parsed = parseThreadParam(rawParam);
+  if (!parsed) throw notFound();
 
-      if (hasHash) {
+  // TODO: remove the organizationUsers[0] fallback once activeOrganizationAtom
+  // persists + hydrates the last used org synchronously on reload. See backlog.
+  const orgId =
+    activeOrg?.id ??
+    workspaceCtx.organizationUsers?.[0]?.organization?.id;
+  if (parsed.kind === "shortId" && !orgId) throw notFound();
+
+  const where =
+    parsed.kind === "ulid"
+      ? { id: parsed.id }
+      : { shortId: parsed.shortId, organizationId: orgId! };
+
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    const checkHash = () => {
+      if (timeoutId) clearTimeout(timeoutId);
+      if (window.location.hash === "#answer-message") {
         setHighlightAnswer(true);
+        timeoutId = setTimeout(() => setHighlightAnswer(false), 5000);
+      } else {
+        setHighlightAnswer(false);
       }
     };
 
@@ -136,20 +117,30 @@ function RouteComponent() {
 
     return () => {
       window.removeEventListener("hashchange", checkHash);
+      if (timeoutId) clearTimeout(timeoutId);
     };
   }, []);
 
   const thread = useLiveQuery(
-    query.thread.where({ id }).include({
+    query.thread.where(where).include({
       organization: true,
+      author: true,
       messages: { include: { author: true } },
       assignedUser: true,
       updates: { include: { user: true } },
     }),
   )?.[0];
 
+  const id = thread?.id ?? "";
+
   useEffect(() => {
-    const canonical = buildThreadParam(thread ?? loadedThread);
+    if (!thread) return;
+    document.title = `${thread.name} - Threads - FrontDesk`;
+  }, [thread]);
+
+  useEffect(() => {
+    if (!thread) return;
+    const canonical = buildThreadParam(thread);
     if (rawParam !== canonical) {
       navigate({
         to: "/app/threads/$id",
@@ -158,7 +149,7 @@ function RouteComponent() {
         replace: true,
       });
     }
-  }, [rawParam, thread, loadedThread, navigate]);
+  }, [rawParam, thread, navigate]);
 
   const { captureThreadEvent } = useThreadAnalytics(thread);
 
@@ -251,21 +242,9 @@ function RouteComponent() {
     (message) => message.markedAsAnswer,
   );
 
-  useEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
-    if (highlightAnswer) {
-      timeoutId = setTimeout(() => {
-        setHighlightAnswer(false);
-      }, 5000);
-    }
-
-    return () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-    };
-  }, [highlightAnswer]);
+  if (!thread) {
+    return <div className="flex size-full" />;
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary
- Drop the TanStack route loader on `/app/threads/$id` and query the thread directly with `useLiveQuery`, so the page hydrates from the websocket cache instead of doing an extra fetch.
- `head()` returns a static title; `document.title` is synced via effect once the live thread loads.
- Consolidate the two `highlightAnswer` effects into one.
- Short-id reloads fall back to `organizationUsers[0]` because `activeOrganizationAtom` hydrates async. Tracked in `docs/backlog.md` with a TODO in the code pointing to it.

## Test plan
- [ ] Open a thread by ulid URL — loads correctly.
- [ ] Open a thread by `{shortId}-{slug}` URL — loads correctly.
- [ ] Hard-reload both URLs — no notFound, thread renders once data streams in.
- [ ] `#answer-message` hash still highlights the answer and clears after 5s.
- [ ] Canonical URL redirect still rewrites `12` → `12-some-slug`.
- [ ] Browser tab title updates to the thread name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load the thread in the component via live-state instead of the `@tanstack/react-router` route loader so the page hydrates from the websocket cache and skips an extra fetch. Static SEO head is returned; the title and canonical URL update after the live thread loads.

- **Refactors**
  - Dropped route loader on `/app/threads/$id`; query thread with `useLiveQuery`.
  - Static `head()` SEO; set `document.title` when the thread loads.
  - Preserve canonical URL rewrite when data arrives.
  - Single hashchange effect for `#answer-message` highlight; auto-clears after 5s.
  - For shortId URLs, use `activeOrganizationAtom` or `organizationUsers[0]` on reload; invalid URLs temporarily show a blank loading state pending a status signal upstream.

<sup>Written for commit 6b052384086b15524c8aa269dc9420e6a33f3890. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic page title updates when thread content loads for improved clarity.

* **Bug Fixes**
  * Refined answer highlighting behavior with improved timeout management.
  * Enhanced canonical URL redirection logic for thread pages.

* **Chores**
  * Updated SEO meta handling with static generation for better optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->