### PR TITLE
fix(web): make sure thread toolbar is always at the bottom of the page

### DIFF
--- a/apps/web/src/routes/app/_workspace/_main/threads/$id/index.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/threads/$id/index.tsx
@@ -333,8 +333,8 @@ function RouteComponent() {
               onScroll={disableAutoScroll}
               onTouchMove={disableAutoScroll}
             >
-              <div ref={contentRef}>
-                <div className="flex flex-col gap-4 p-8 w-full max-w-5xl mx-auto">
+              <div ref={contentRef} className="flex flex-col min-h-full">
+                <div className="flex flex-col gap-4 p-8 w-full max-w-5xl mx-auto flex-1">
                   {thread &&
                     (firstItem?.itemType === "message" ? (
                       <ThreadHeader title={thread.name} message={firstItem} />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Keep the thread toolbar pinned to the bottom of the page, even when threads have little content. Converted the thread view to a full-height flex column and made the content container flex-1 so the toolbar stays anchored.

<sup>Written for commit e34cf4ef0404f8d45bd43f0008497a0e764e1662. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

