### PR TITLE
feat(web): show thread shortId across main app surfaces

### DIFF
--- a/apps/web/src/components/chips.tsx
+++ b/apps/web/src/components/chips.tsx
@@ -46,7 +46,12 @@ export function BaseThreadChip({
         fallback={thread.author?.name}
         src={thread.author?.user?.image ?? undefined}
       />
-      {thread.name}
+      <span className="text-foreground-primary">{thread.name}</span>
+      {thread.shortId != null && (
+        <span className="text-foreground-secondary tabular-nums">
+          #{thread.shortId}
+        </span>
+      )}
     </BaseButton>
   );
 }
@@ -77,7 +82,14 @@ export function ThreadChip({
       />
       <HoverCardContent className="max-w-96 w-full flex flex-col gap-3">
         <div className="flex flex-col gap-1">
-          <div className="font-medium text-sm">{thread.name}</div>
+          <div className="font-medium text-sm flex items-center gap-1.5">
+            <span className="text-foreground-primary">{thread.name}</span>
+            {thread.shortId != null && (
+              <span className="text-foreground-secondary tabular-nums font-normal">
+                #{thread.shortId}
+              </span>
+            )}
+          </div>
           <div className="flex items-center gap-2">
             <Avatar
               variant="user"

--- a/apps/web/src/components/threads/related-threads-section.tsx
+++ b/apps/web/src/components/threads/related-threads-section.tsx
@@ -44,6 +44,11 @@ const RelatedThreadResult = ({ result }: { result: SimilarThreadResult }) => {
         src={thread.author.user?.image}
       />
       <div className="grow shrink truncate">{thread.name}</div>
+      {thread.shortId != null && (
+        <span className="text-foreground-secondary text-sm tabular-nums">
+          #{thread.shortId}
+        </span>
+      )}
       <div className="flex gap-1 ml-auto">
         <ChevronRightIcon className="size-4" />
       </div>

--- a/apps/web/src/routes/app/_workspace/_main/playground/index.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/playground/index.tsx
@@ -103,20 +103,29 @@ function PlaygroundPage() {
             Threads
           </div>
           <div className="flex-1 overflow-y-auto">
-            {(threads as any[])?.map((thread: { id: string; name: string }) => (
-              <button
-                key={thread.id}
-                type="button"
-                onClick={() => handleSelectThread(thread.id)}
-                className={`w-full text-left px-4 py-2.5 text-sm border-b hover:bg-foreground-tertiary/10 transition-colors ${
-                  selectedThreadId === thread.id
-                    ? "bg-foreground-tertiary/15 font-medium"
-                    : ""
-                }`}
-              >
-                <div className="truncate">{thread.name}</div>
-              </button>
-            ))}
+            {(threads as any[])?.map(
+              (thread: { id: string; name: string; shortId: number | null }) => (
+                <button
+                  key={thread.id}
+                  type="button"
+                  onClick={() => handleSelectThread(thread.id)}
+                  className={`w-full text-left px-4 py-2.5 text-sm border-b hover:bg-foreground-tertiary/10 transition-colors ${
+                    selectedThreadId === thread.id
+                      ? "bg-foreground-tertiary/15 font-medium"
+                      : ""
+                  }`}
+                >
+                  <div className="truncate flex items-center gap-1.5">
+                    <span className="truncate">{thread.name}</span>
+                    {thread.shortId != null && (
+                      <span className="text-foreground-secondary tabular-nums font-normal shrink-0">
+                        #{thread.shortId}
+                      </span>
+                    )}
+                  </div>
+                </button>
+              ),
+            )}
             {(!threads || (threads as any[]).length === 0) && (
               <div className="px-4 py-8 text-sm text-foreground-secondary text-center">
                 No threads found

--- a/apps/web/src/routes/app/_workspace/_main/playground/index.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/playground/index.tsx
@@ -103,30 +103,28 @@ function PlaygroundPage() {
             Threads
           </div>
           <div className="flex-1 overflow-y-auto">
-            {(threads as any[])?.map(
-              (thread: { id: string; name: string; shortId: number | null }) => (
-                <button
-                  key={thread.id}
-                  type="button"
-                  onClick={() => handleSelectThread(thread.id)}
-                  className={`w-full text-left px-4 py-2.5 text-sm border-b hover:bg-foreground-tertiary/10 transition-colors ${
-                    selectedThreadId === thread.id
-                      ? "bg-foreground-tertiary/15 font-medium"
-                      : ""
-                  }`}
-                >
-                  <div className="truncate flex items-center gap-1.5">
-                    <span className="truncate">{thread.name}</span>
-                    {thread.shortId != null && (
-                      <span className="text-foreground-secondary tabular-nums font-normal shrink-0">
-                        #{thread.shortId}
-                      </span>
-                    )}
-                  </div>
-                </button>
-              ),
-            )}
-            {(!threads || (threads as any[]).length === 0) && (
+            {threads?.map((thread) => (
+              <button
+                key={thread.id}
+                type="button"
+                onClick={() => handleSelectThread(thread.id)}
+                className={`w-full text-left px-4 py-2.5 text-sm border-b hover:bg-foreground-tertiary/10 transition-colors ${
+                  selectedThreadId === thread.id
+                    ? "bg-foreground-tertiary/15 font-medium"
+                    : ""
+                }`}
+              >
+                <div className="truncate flex items-center gap-1.5">
+                  <span className="truncate">{thread.name}</span>
+                  {thread.shortId != null && (
+                    <span className="text-foreground-secondary tabular-nums font-normal shrink-0">
+                      #{thread.shortId}
+                    </span>
+                  )}
+                </div>
+              </button>
+            ))}
+            {(threads?.length ?? 0) === 0 && (
               <div className="px-4 py-8 text-sm text-foreground-secondary text-center">
                 No threads found
               </div>

--- a/apps/web/src/routes/app/_workspace/_main/search/index.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/search/index.tsx
@@ -67,6 +67,11 @@ const SearchResultItem = ({ messageId }: SearchResultItemProps) => {
           <div className="flex items-center gap-2">
             <Avatar variant="user" size="md" fallback={thread?.author?.name} />
             <div>{thread?.name}</div>
+            {thread?.shortId != null && (
+              <span className="text-foreground-secondary text-sm tabular-nums">
+                #{thread.shortId}
+              </span>
+            )}
           </div>
           <div className="flex items-center gap-2">
             <div className="flex items-center gap-1.5 mr-1">

--- a/apps/web/src/routes/app/_workspace/_main/threads/$id/index.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/threads/$id/index.tsx
@@ -267,7 +267,14 @@ function RouteComponent() {
                     </BreadcrumbItem>
                     <BreadcrumbSeparator />
                     <BreadcrumbItem>
-                      <BreadcrumbPage>{thread.name}</BreadcrumbPage>
+                      <BreadcrumbPage className="flex items-center gap-1.5">
+                        <span>{thread.name}</span>
+                        {thread.shortId != null && (
+                          <span className="text-foreground-secondary tabular-nums font-normal">
+                            #{thread.shortId}
+                          </span>
+                        )}
+                      </BreadcrumbPage>
                     </BreadcrumbItem>
                   </BreadcrumbList>
                 </Breadcrumb>

--- a/apps/web/src/routes/app/_workspace/_main/threads/archive/$id.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/threads/archive/$id.tsx
@@ -160,7 +160,14 @@ function RouteComponent() {
                     </BreadcrumbItem>
                     <BreadcrumbSeparator />
                     <BreadcrumbItem>
-                      <BreadcrumbPage>{thread.name}</BreadcrumbPage>
+                      <BreadcrumbPage className="flex items-center gap-1.5">
+                        <span>{thread.name}</span>
+                        {thread.shortId != null && (
+                          <span className="text-foreground-secondary tabular-nums font-normal">
+                            #{thread.shortId}
+                          </span>
+                        )}
+                      </BreadcrumbPage>
                     </BreadcrumbItem>
                   </BreadcrumbList>
                 </Breadcrumb>

--- a/apps/web/src/routes/app/_workspace/_main/threads/index.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/threads/index.tsx
@@ -347,6 +347,11 @@ export function ThreadsList({ fixedFilters = {}, subTitle }: ThreadsListProps) {
                 >
                   <div className="flex justify-between">
                     <div className="flex items-center gap-2">
+                      {thread?.shortId != null && (
+                        <span className="text-foreground-secondary text-sm tabular-nums">
+                          #{thread.shortId}
+                        </span>
+                      )}
                       <Avatar
                         variant="user"
                         size="md"


### PR DESCRIPTION
## Summary
- Surface per-org thread `shortId` in the main-app UI now that it's used in URLs but never visible.
- Inbox list item shows `#123` muted before the avatar; chips, breadcrumbs (thread + archive), related threads, search results, and the playground sidebar show it muted after the title.
- Threads with a null `shortId` (legacy rows) render nothing — no placeholder, no extra spacing.

## Test plan
- [ ] Threads inbox: `#123` appears muted before the avatar; legacy threads render cleanly.
- [ ] Open a thread: breadcrumb shows `Thread name  #123`.
- [ ] Open an archived thread: breadcrumb shows `Thread name  #123`.
- [ ] Hover/inline ThreadChip shows `Name  #123`.
- [ ] Related Threads sidebar on the thread page shows `#123` after each name.
- [ ] Search results page shows `#123` after each thread name.
- [ ] Playground sidebar shows `#123` after each thread name.
- [ ] `bun run --filter web typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the per-org thread shortId across the app so the URL ID is visible. Displays a muted “#123” near thread titles and hides it for legacy threads.

- **New Features**
  - Threads inbox: show `#123` before the avatar.
  - Breadcrumbs (thread and archive), thread chips, related threads, search results, and playground sidebar: show after the name.
  - Do not render anything when `shortId` is null.

- **Bug Fixes**
  - Playground threads list: correct empty state when there are no threads.

<sup>Written for commit e072ce9198999f661bd145657f2092fa5e21520d. Summary will update on new commits. <a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/254?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thread short identifiers now display throughout the application, including in thread chips, search results, thread lists, breadcrumbs, and related threads sections. When available, identifiers appear with a # prefix, providing users with a quick, consistent way to reference and identify threads across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->