### PR TITLE
feat(ui): add hashed single-character avatar docs

### DIFF
--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -159,7 +159,8 @@ function getAvatarColorClass(seed: string) {
 
 function Avatar({ className, src, alt, variant, size, fallback }: AvatarProps) {
   const fallbackText = typeof fallback === "string" ? fallback : null;
-  const fallbackCharacter = fallbackText ? getAvatarCharacter(fallbackText) : fallback;
+  const fallbackCharacter =
+    fallbackText !== null ? getAvatarCharacter(fallbackText) : fallback;
   const fallbackColorClass = getAvatarColorClass(
     fallbackText ?? alt ?? src ?? "avatar",
   );

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -7,6 +7,16 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { Pencil } from "lucide-react";
 import { useEffect, useState } from "react";
 
+const avatarColorClasses = [
+  "bg-rose-300 text-white dark:bg-rose-400 dark:text-white",
+  "bg-orange-300 text-white dark:bg-orange-400 dark:text-white",
+  "bg-amber-300 text-white dark:bg-amber-400 dark:text-white",
+  "bg-emerald-300 text-white dark:bg-emerald-400 dark:text-white",
+  "bg-cyan-300 text-white dark:bg-cyan-400 dark:text-white",
+  "bg-indigo-300 text-white dark:bg-indigo-400 dark:text-white",
+  "bg-fuchsia-300 text-white dark:bg-fuchsia-400 dark:text-white",
+];
+
 function BaseAvatar({
   className,
   ...props
@@ -84,40 +94,37 @@ const avatarVariants = cva("", {
   },
 });
 
-const avatarFallbackVariants = cva(
-  "text-black bg-white select-none size-full",
-  {
-    variants: {
-      size: {
-        sm: "text-[0.5rem]",
-        md: "text-[0.6rem]",
-        lg: "text-base",
-        xl: "text-base",
-        xxl: "text-2xl",
-      },
-      variant: {
-        user: "rounded-full",
-        org: "",
-      },
+const avatarFallbackVariants = cva("select-none size-full font-medium", {
+  variants: {
+    size: {
+      sm: "text-[0.5rem]",
+      md: "text-[0.6rem]",
+      lg: "text-base",
+      xl: "text-base",
+      xxl: "text-2xl",
     },
-    compoundVariants: [
-      {
-        variant: "org",
-        size: ["sm", "md"],
-        className: "rounded-sm",
-      },
-      {
-        variant: "org",
-        size: ["lg", "xl", "xxl"],
-        className: "rounded-md",
-      },
-    ],
-    defaultVariants: {
-      size: "md",
-      variant: "user",
+    variant: {
+      user: "rounded-full",
+      org: "",
     },
   },
-);
+  compoundVariants: [
+    {
+      variant: "org",
+      size: ["sm", "md"],
+      className: "rounded-sm",
+    },
+    {
+      variant: "org",
+      size: ["lg", "xl", "xxl"],
+      className: "rounded-md",
+    },
+  ],
+  defaultVariants: {
+    size: "md",
+    variant: "user",
+  },
+});
 
 interface AvatarProps extends VariantProps<typeof avatarVariants> {
   className?: string;
@@ -126,21 +133,47 @@ interface AvatarProps extends VariantProps<typeof avatarVariants> {
   fallback: React.ReactNode;
 }
 
-function getInitials(name: string) {
-  return name
-    .split(" ")
-    .map((n) => n[0])
-    .slice(0, 2)
-    .join("")
-    .toUpperCase();
+function getAvatarCharacter(value: string) {
+  const trimmedValue = value.trim();
+  if (!trimmedValue) {
+    return "?";
+  }
+
+  const firstCharacter = Array.from(trimmedValue)[0];
+  if (!firstCharacter) {
+    return "?";
+  }
+
+  return firstCharacter.toUpperCase();
+}
+
+function getAvatarColorClass(seed: string) {
+  let hash = 0;
+  for (const character of seed) {
+    hash = character.charCodeAt(0) + ((hash << 5) - hash);
+  }
+
+  const paletteIndex = Math.abs(hash) % avatarColorClasses.length;
+  return avatarColorClasses[paletteIndex];
 }
 
 function Avatar({ className, src, alt, variant, size, fallback }: AvatarProps) {
+  const fallbackText = typeof fallback === "string" ? fallback : null;
+  const fallbackCharacter = fallbackText ? getAvatarCharacter(fallbackText) : fallback;
+  const fallbackColorClass = getAvatarColorClass(
+    fallbackText ?? alt ?? src ?? "avatar",
+  );
+
   return (
     <BaseAvatar className={avatarVariants({ size, variant, className })}>
       <BaseAvatarImage src={src ?? undefined} alt={alt ?? undefined} />
-      <BaseAvatarFallback className={avatarFallbackVariants({ size, variant })}>
-        {typeof fallback === "string" ? getInitials(fallback) : fallback}
+      <BaseAvatarFallback
+        className={cn(
+          avatarFallbackVariants({ size, variant }),
+          fallbackColorClass,
+        )}
+      >
+        {fallbackCharacter}
       </BaseAvatarFallback>
     </BaseAvatar>
   );

--- a/packages/ui/src/routeTree.gen.ts
+++ b/packages/ui/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as StatusIndicatorRouteImport } from './routes/status-indicator'
 import { Route as CompositeRouteImport } from './routes/composite'
 import { Route as CommandRouteImport } from './routes/command'
 import { Route as ButtonsRouteImport } from './routes/buttons'
+import { Route as AvatarRouteImport } from './routes/avatar'
 import { Route as IndexRouteImport } from './routes/index'
 
 const StatusIndicatorRoute = StatusIndicatorRouteImport.update({
@@ -35,6 +36,11 @@ const ButtonsRoute = ButtonsRouteImport.update({
   path: '/buttons',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AvatarRoute = AvatarRouteImport.update({
+  id: '/avatar',
+  path: '/avatar',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -43,6 +49,7 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/avatar': typeof AvatarRoute
   '/buttons': typeof ButtonsRoute
   '/command': typeof CommandRoute
   '/composite': typeof CompositeRoute
@@ -50,6 +57,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/avatar': typeof AvatarRoute
   '/buttons': typeof ButtonsRoute
   '/command': typeof CommandRoute
   '/composite': typeof CompositeRoute
@@ -58,6 +66,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/avatar': typeof AvatarRoute
   '/buttons': typeof ButtonsRoute
   '/command': typeof CommandRoute
   '/composite': typeof CompositeRoute
@@ -65,12 +74,25 @@ export interface FileRoutesById {
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/buttons' | '/command' | '/composite' | '/status-indicator'
+  fullPaths:
+    | '/'
+    | '/avatar'
+    | '/buttons'
+    | '/command'
+    | '/composite'
+    | '/status-indicator'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/buttons' | '/command' | '/composite' | '/status-indicator'
+  to:
+    | '/'
+    | '/avatar'
+    | '/buttons'
+    | '/command'
+    | '/composite'
+    | '/status-indicator'
   id:
     | '__root__'
     | '/'
+    | '/avatar'
     | '/buttons'
     | '/command'
     | '/composite'
@@ -79,6 +101,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AvatarRoute: typeof AvatarRoute
   ButtonsRoute: typeof ButtonsRoute
   CommandRoute: typeof CommandRoute
   CompositeRoute: typeof CompositeRoute
@@ -115,6 +138,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ButtonsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/avatar': {
+      id: '/avatar'
+      path: '/avatar'
+      fullPath: '/avatar'
+      preLoaderRoute: typeof AvatarRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -127,6 +157,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AvatarRoute: AvatarRoute,
   ButtonsRoute: ButtonsRoute,
   CommandRoute: CommandRoute,
   CompositeRoute: CompositeRoute,

--- a/packages/ui/src/routes/-components/sidebar.tsx
+++ b/packages/ui/src/routes/-components/sidebar.tsx
@@ -71,6 +71,16 @@ export const RootSidebar = () => {
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  data-active={matches.at(-1)?.pathname === "/avatar"}
+                  asChild
+                >
+                  <Link to="/avatar">
+                    <span>Avatar</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>

--- a/packages/ui/src/routes/avatar.tsx
+++ b/packages/ui/src/routes/avatar.tsx
@@ -1,0 +1,60 @@
+import { Avatar } from "@/components/avatar";
+import { createFileRoute } from "@tanstack/react-router";
+
+const avatarNames = [
+  "Pedro Costa",
+  "Anna Smith",
+  "Liam Johnson",
+  "Maya Patel",
+  "Diego Alvarez",
+  "Sofia Rossi",
+  "Noah Chen",
+  "Olivia Brown",
+];
+
+export const Route = createFileRoute(
+  // biome-ignore lint/suspicious/noExplicitAny: route tree is generated after adding new route files
+  "/avatar" as any,
+)({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="text-lg">Avatar</div>
+
+      <div className="flex flex-col gap-4">
+        <div className="text-sm">Single-character fallback (all sizes)</div>
+        <div className="border rounded-md p-4 border-dashed flex items-center gap-4 flex-wrap">
+          <Avatar fallback="Pedro Costa" size="sm" />
+          <Avatar fallback="Pedro Costa" size="md" />
+          <Avatar fallback="Pedro Costa" size="lg" />
+          <Avatar fallback="Pedro Costa" size="xl" />
+          <Avatar fallback="Pedro Costa" size="xxl" />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        <div className="text-sm">Deterministic color palette (hashed)</div>
+        <div className="border rounded-md p-4 border-dashed grid grid-cols-2 md:grid-cols-4 gap-4">
+          {avatarNames.map((name) => (
+            <div key={name} className="flex items-center gap-3">
+              <Avatar fallback={name} size="lg" />
+              <div className="text-sm text-foreground-secondary">{name}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        <div className="text-sm">Organizations variant</div>
+        <div className="border rounded-md p-4 border-dashed flex items-center gap-4 flex-wrap">
+          <Avatar fallback="FrontDesk" variant="org" size="md" />
+          <Avatar fallback="Acme Corp" variant="org" size="lg" />
+          <Avatar fallback="Support Team" variant="org" size="xl" />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- update `Avatar` fallback behavior to always render a single character when fallback is a string
- add deterministic hash-based fallback color selection using a constrained palette with white text
- add a dedicated `/avatar` UI studio page and sidebar entry to document avatar sizes and variants

## Test plan
- [x] Run `bun run --filter @workspace/ui typecheck`
- [ ] Open UI studio and verify `/avatar` examples render as expected
- [ ] Confirm fallback color is stable for the same name across refreshes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes the `Avatar` fallback to a single uppercase character with a stable, hashed background color. Adds an `/avatar` docs page in the UI studio with examples of sizes and org variant.

- **New Features**
  - Single-character fallback when `fallback` is a string (first character, Unicode-safe; "?" if blank).
  - Deterministic hashed color palette with white text (light/dark), seeded by `fallback` text or `alt`/`src` when `fallback` is a node.
  - New `/avatar` page and sidebar link documenting sizes, org variant, and color behavior.

- **Migration**
  - If you used two-letter initials, pass a custom React node to `fallback` to keep that behavior.
  - Fallback backgrounds are now colored; update visual snapshots if needed.

<sup>Written for commit b2745b17a4b2cbac8a260ef6f06e04480e569bbb. Summary will update on new commits. <a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/255?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

