### PR TITLE
refactor(live-state): label procedures and authorize(req)

### DIFF
--- a/apps/api/src/lib/authorize.ts
+++ b/apps/api/src/lib/authorize.ts
@@ -3,6 +3,16 @@ const ROLE_HIERARCHY: Record<string, number> = {
   owner: 1,
 };
 
+const getRoleLevel = (role: string): number | undefined => {
+  const level = ROLE_HIERARCHY[role];
+
+  if (level === undefined) {
+    console.warn(`[authorize] Unknown required role "${role}"`);
+  }
+
+  return level;
+};
+
 /** Context injected by live-state (sessions, API keys). */
 export type AuthorizationContext = {
   internalApiKey?: unknown;
@@ -53,7 +63,8 @@ export const isAuthorized = (
     if (!orgUser) return false;
 
     if (opts.role) {
-      const requiredLevel = ROLE_HIERARCHY[opts.role] ?? 0;
+      const requiredLevel = getRoleLevel(opts.role);
+      if (requiredLevel === undefined) return false;
       const userLevel = ROLE_HIERARCHY[orgUser.role] ?? 0;
       return userLevel >= requiredLevel;
     }

--- a/apps/api/src/lib/authorize.ts
+++ b/apps/api/src/lib/authorize.ts
@@ -3,19 +3,40 @@ const ROLE_HIERARCHY: Record<string, number> = {
   owner: 1,
 };
 
-export function isAuthorized(
-  ctx: {
-    internalApiKey?: unknown;
-    publicApiKey?: { ownerId: string };
-    orgUsers?: { organizationId: string; role: string }[];
-  },
-  opts: {
-    organizationId: string;
-    role?: string;
-    allowPublicApiKey?: boolean;
-  },
-): boolean {
-  if (ctx.internalApiKey) return true;
+/** Context injected by live-state (sessions, API keys). */
+export type AuthorizationContext = {
+  internalApiKey?: unknown;
+  publicApiKey?: { ownerId: string };
+  orgUsers?: { organizationId: string; role: string }[];
+};
+
+/** Request-like shape that carries credential context (e.g. mutation/query `req`). */
+export type AuthorizeReq = {
+  context?: AuthorizationContext | null;
+};
+
+export type AuthorizeOptions = {
+  organizationId: string;
+  role?: string;
+  allowPublicApiKey?: boolean;
+  /**
+   * When `true` (default), callers with {@link AuthorizationContext.internalApiKey}
+   * are authorized without org membership checks. Set to `false` to enforce the
+   * same membership rules as regular sessions even when an internal key is present.
+   */
+  allowInternalApiKey?: boolean;
+};
+
+export const isAuthorized = (
+  ctx: AuthorizationContext,
+  opts: AuthorizeOptions,
+): boolean => {
+  if (
+    !!ctx.internalApiKey &&
+    opts.allowInternalApiKey !== false
+  ) {
+    return true;
+  }
 
   if (ctx.publicApiKey) {
     return (
@@ -41,21 +62,10 @@ export function isAuthorized(
   }
 
   return false;
-}
+};
 
-export const authorize = (
-  ctx: {
-    internalApiKey?: unknown;
-    publicApiKey?: { ownerId: string };
-    orgUsers?: { organizationId: string; role: string }[];
-  },
-  opts: {
-    organizationId: string;
-    role?: string;
-    allowPublicApiKey?: boolean;
-  },
-): void => {
-  if (isAuthorized(ctx, opts)) return;
+export const authorize = (req: AuthorizeReq, opts: AuthorizeOptions): void => {
+  if (isAuthorized(req.context ?? {}, opts)) return;
 
   throw new Error("UNAUTHORIZED");
 };

--- a/apps/api/src/live-state/router/labels.ts
+++ b/apps/api/src/live-state/router/labels.ts
@@ -1,100 +1,248 @@
-// TODO refactor with new live-state mental model
+import z from "zod";
+import { ulid } from "ulid";
+import type { ServerDB } from "@live-state/sync/server";
+import { authorize } from "../../lib/authorize";
 import { publicRoute } from "../factories";
 import { schema } from "../schema";
+
+type LabelInsertDb = Pick<ServerDB<typeof schema>, "label">;
+
+const buildInsertLabelRow = (args: {
+  organizationId: string;
+  name: string;
+  color: string;
+  id?: string;
+  enabled?: boolean;
+}) => {
+  const now = new Date();
+
+  return {
+    id: args.id ?? ulid().toLowerCase(),
+    organizationId: args.organizationId,
+    name: args.name,
+    color: args.color,
+    enabled: args.enabled ?? true,
+    createdAt: now,
+    updatedAt: now,
+  };
+};
+
+/** Inserts a label row; works with `db` or transaction `trx`. */
+const insertLabel = async (
+  db: LabelInsertDb,
+  args: Parameters<typeof buildInsertLabelRow>[0],
+) => db.label.insert(buildInsertLabelRow(args));
 
 export default {
   label: publicRoute.collectionRoute(schema.label, {
     read: () => true,
-    insert: ({ ctx }) => {
-      if (ctx?.internalApiKey) return true;
-      if (!ctx?.session) return false;
+    insert: () => false,
+    update: {
+      preMutation: () => false,
+      postMutation: () => false,
+    },
+  }).withProcedures(({ mutation }) => ({
+    create: mutation(
+      z.object({
+        id: z.string().optional(),
+        organizationId: z.string(),
+        name: z.string(),
+        color: z.string(),
+        enabled: z.boolean().optional(),
+      }),
+    ).handler(async ({ req, db }) => {
+      authorize(req, {
+        organizationId: req.input.organizationId,
+      });
+
+      return await insertLabel(db, {
+        id: req.input.id,
+        organizationId: req.input.organizationId,
+        name: req.input.name,
+        color: req.input.color,
+        enabled: req.input.enabled,
+      });
+    }),
+
+    update: mutation(
+      z.object({
+        labelId: z.string(),
+        name: z.string().optional(),
+        color: z.string().optional(),
+        enabled: z.boolean().optional(),
+        updatedAt: z.coerce.date().optional(),
+      }),
+    ).handler(async ({ req, db }) => {
+      const label = await db.label.one(req.input.labelId).get();
+
+      if (!label) {
+        throw new Error("LABEL_NOT_FOUND");
+      }
+
+      authorize(req, {
+        organizationId: label.organizationId,
+      });
+
+      await db.label.update(req.input.labelId, {
+        name: req.input.name,
+        color: req.input.color,
+        enabled: req.input.enabled,
+        updatedAt: req.input.updatedAt ?? new Date(),
+      });
+
+      return (await db.label.one(req.input.labelId).get()) ?? label;
+    }),
+
+    createAndAttachToThread: mutation(
+      z.object({
+        organizationId: z.string(),
+        threadId: z.string(),
+        name: z.string(),
+        color: z.string(),
+        labelId: z.string().optional(),
+        threadLabelId: z.string().optional(),
+      }),
+    ).handler(async ({ req, db }) => {
+      authorize(req, {
+        organizationId: req.input.organizationId,
+      });
+
+      const thread = await db.thread.one(req.input.threadId).get();
+
+      if (!thread || thread.organizationId !== req.input.organizationId) {
+        throw new Error("THREAD_NOT_FOUND");
+      }
+
+      const threadLabelId = req.input.threadLabelId ?? ulid().toLowerCase();
+
+      const { insertedLabel, insertedThreadLabel } = await db.transaction(
+        async ({ trx }) => {
+          const insertedLabel = await insertLabel(trx, {
+            id: req.input.labelId,
+            organizationId: req.input.organizationId,
+            name: req.input.name,
+            color: req.input.color,
+            enabled: true,
+          });
+
+          const insertedThreadLabel = await trx.threadLabel.insert({
+            id: threadLabelId,
+            threadId: req.input.threadId,
+            labelId: insertedLabel.id,
+            enabled: true,
+          });
+
+          return { insertedLabel, insertedThreadLabel };
+        },
+      );
 
       return {
-        organization: {
-          organizationUsers: {
-            userId: ctx.session.userId,
-            enabled: true,
-          },
-        },
+        ...insertedThreadLabel,
+        label: insertedLabel,
       };
-    },
-    update: {
-      preMutation: ({ ctx }) => {
-        if (ctx?.internalApiKey) return true;
-        if (!ctx?.session) return false;
+    }),
 
-        return {
-          organization: {
-            organizationUsers: {
-              userId: ctx.session.userId,
-              enabled: true,
-            },
-          },
-        };
-      },
-      postMutation: ({ ctx }) => {
-        if (ctx?.internalApiKey) return true;
-        if (!ctx?.session) return false;
+    attachToThread: mutation(
+      z.object({
+        threadId: z.string(),
+        labelId: z.string(),
+        id: z.string().optional(),
+      }),
+    ).handler(async ({ req, db }) => {
+      const label = await db.label.one(req.input.labelId).get();
 
-        return {
-          organization: {
-            organizationUsers: {
-              userId: ctx.session.userId,
-              enabled: true,
-            },
-          },
-        };
-      },
-    },
-  }),
+      if (!label) {
+        throw new Error("LABEL_NOT_FOUND");
+      }
+
+      const thread = await db.thread.one(req.input.threadId).get();
+
+      if (!thread) {
+        throw new Error("THREAD_NOT_FOUND");
+      }
+
+      if (label.organizationId !== thread.organizationId) {
+        throw new Error("LABEL_THREAD_ORGANIZATION_MISMATCH");
+      }
+
+      authorize(req, {
+        organizationId: thread.organizationId,
+      });
+
+      const existing = await db.threadLabel
+        .first({
+          threadId: req.input.threadId,
+          labelId: req.input.labelId,
+        })
+        .get();
+
+      if (existing) {
+        if (!existing.enabled) {
+          await db.threadLabel.update(existing.id, { enabled: true });
+        }
+
+        return (
+          (await db.threadLabel
+            .one(existing.id)
+            .include({ label: true })
+            .get()) ?? existing
+        );
+      }
+
+      const id = req.input.id ?? ulid().toLowerCase();
+
+      const created = await db.threadLabel.insert({
+        id,
+        threadId: req.input.threadId,
+        labelId: req.input.labelId,
+        enabled: true,
+      });
+
+      return {
+        ...created,
+        label,
+      };
+    }),
+
+    detachFromThread: mutation(
+      z.object({
+        threadLabelId: z.string(),
+      }),
+    ).handler(async ({ req, db }) => {
+      const tl = await db.threadLabel.one(req.input.threadLabelId).get();
+
+      if (!tl) {
+        throw new Error("THREAD_LABEL_NOT_FOUND");
+      }
+
+      const thread = await db.thread.one(tl.threadId).get();
+
+      if (!thread) {
+        throw new Error("THREAD_NOT_FOUND");
+      }
+
+      authorize(req, {
+        organizationId: thread.organizationId,
+      });
+
+      await db.threadLabel.update(req.input.threadLabelId, { enabled: false });
+
+      const updated =
+        (await db.threadLabel
+          .one(req.input.threadLabelId)
+          .include({ label: true })
+          .get()) ?? { ...tl, enabled: false };
+
+      return updated;
+    }),
+  })),
+
   threadLabel: publicRoute.collectionRoute(schema.threadLabel, {
     read: () => true,
-    insert: ({ ctx }) => {
-      if (ctx?.internalApiKey) return true;
-      if (!ctx?.session) return false;
-
-      return {
-        thread: {
-          organization: {
-            organizationUsers: {
-              userId: ctx.session.userId,
-              enabled: true,
-            },
-          },
-        },
-      };
-    },
+    insert: () => false,
     update: {
-      preMutation: ({ ctx }) => {
-        if (ctx?.internalApiKey) return true;
-        if (!ctx?.session) return false;
-
-        return {
-          thread: {
-            organization: {
-              organizationUsers: {
-                userId: ctx.session.userId,
-                enabled: true,
-              },
-            },
-          },
-        };
-      },
-      postMutation: ({ ctx }) => {
-        if (ctx?.internalApiKey) return true;
-        if (!ctx?.session) return false;
-
-        return {
-          thread: {
-            organization: {
-              organizationUsers: {
-                userId: ctx.session.userId,
-                enabled: true,
-              },
-            },
-          },
-        };
-      },
+      preMutation: () => false,
+      postMutation: () => false,
     },
   }),
 };

--- a/apps/api/src/live-state/router/labels.ts
+++ b/apps/api/src/live-state/router/labels.ts
@@ -1,6 +1,7 @@
 import z from "zod";
 import { ulid } from "ulid";
 import type { ServerDB } from "@live-state/sync/server";
+import type { AuthorizationContext } from "../../lib/authorize";
 import { authorize } from "../../lib/authorize";
 import { publicRoute } from "../factories";
 import { schema } from "../schema";
@@ -32,6 +33,80 @@ const insertLabel = async (
   db: LabelInsertDb,
   args: Parameters<typeof buildInsertLabelRow>[0],
 ) => db.label.insert(buildInsertLabelRow(args));
+
+type RequestWithAuthorizationContext = {
+  context?: AuthorizationContext | null;
+};
+
+const getAuthorizedOrganizationIds = (
+  req: RequestWithAuthorizationContext,
+): string[] | null => {
+  const ctx = req.context ?? {};
+
+  if (ctx.internalApiKey) {
+    return null;
+  }
+
+  if (ctx.publicApiKey) {
+    return [ctx.publicApiKey.ownerId];
+  }
+
+  if (!ctx.orgUsers?.length) {
+    return [];
+  }
+
+  return [...new Set(ctx.orgUsers.map((orgUser) => orgUser.organizationId))];
+};
+
+const findLabelForAuthorizedOrganizations = async (
+  db: Pick<ServerDB<typeof schema>, "label">,
+  labelId: string,
+  organizationIds: string[] | null,
+) => {
+  if (organizationIds === null) {
+    return await db.label.one(labelId).get();
+  }
+
+  for (const organizationId of organizationIds) {
+    const label = await db.label
+      .first({
+        id: labelId,
+        organizationId,
+      })
+      .get();
+
+    if (label) {
+      return label;
+    }
+  }
+
+  return null;
+};
+
+const findThreadForAuthorizedOrganizations = async (
+  db: Pick<ServerDB<typeof schema>, "thread">,
+  threadId: string,
+  organizationIds: string[] | null,
+) => {
+  if (organizationIds === null) {
+    return await db.thread.one(threadId).get();
+  }
+
+  for (const organizationId of organizationIds) {
+    const thread = await db.thread
+      .first({
+        id: threadId,
+        organizationId,
+      })
+      .get();
+
+    if (thread) {
+      return thread;
+    }
+  }
+
+  return null;
+};
 
 export default {
   label: publicRoute.collectionRoute(schema.label, {
@@ -149,13 +224,22 @@ export default {
         id: z.string().optional(),
       }),
     ).handler(async ({ req, db }) => {
-      const label = await db.label.one(req.input.labelId).get();
+      const authorizedOrganizationIds = getAuthorizedOrganizationIds(req);
+      const label = await findLabelForAuthorizedOrganizations(
+        db,
+        req.input.labelId,
+        authorizedOrganizationIds,
+      );
 
       if (!label) {
         throw new Error("LABEL_NOT_FOUND");
       }
 
-      const thread = await db.thread.one(req.input.threadId).get();
+      const thread = await findThreadForAuthorizedOrganizations(
+        db,
+        req.input.threadId,
+        authorizedOrganizationIds,
+      );
 
       if (!thread) {
         throw new Error("THREAD_NOT_FOUND");
@@ -169,38 +253,64 @@ export default {
         organizationId: thread.organizationId,
       });
 
-      const existing = await db.threadLabel
-        .first({
-          threadId: req.input.threadId,
-          labelId: req.input.labelId,
-        })
-        .get();
+      const id = req.input.id ?? ulid().toLowerCase();
+      const threadLabelId = await db.transaction(async ({ trx }) => {
+        const existing = await trx.threadLabel
+          .first({
+            threadId: req.input.threadId,
+            labelId: req.input.labelId,
+          })
+          .get();
 
-      if (existing) {
-        if (!existing.enabled) {
-          await db.threadLabel.update(existing.id, { enabled: true });
+        if (existing) {
+          if (!existing.enabled) {
+            await trx.threadLabel.update(existing.id, { enabled: true });
+          }
+
+          return existing.id;
         }
 
-        return (
-          (await db.threadLabel
-            .one(existing.id)
-            .include({ label: true })
-            .get()) ?? existing
-        );
-      }
+        try {
+          const created = await trx.threadLabel.insert({
+            id,
+            threadId: req.input.threadId,
+            labelId: req.input.labelId,
+            enabled: true,
+          });
 
-      const id = req.input.id ?? ulid().toLowerCase();
+          return created.id;
+        } catch {
+          const concurrent = await trx.threadLabel
+            .first({
+              threadId: req.input.threadId,
+              labelId: req.input.labelId,
+            })
+            .get();
 
-      const created = await db.threadLabel.insert({
-        id,
-        threadId: req.input.threadId,
-        labelId: req.input.labelId,
-        enabled: true,
+          if (concurrent) {
+            if (!concurrent.enabled) {
+              await trx.threadLabel.update(concurrent.id, { enabled: true });
+            }
+
+            return concurrent.id;
+          }
+
+          throw new Error("THREAD_LABEL_ATTACH_FAILED");
+        }
       });
+
+      const created = await db.threadLabel
+        .one(threadLabelId)
+        .include({ label: true })
+        .get();
+
+      if (!created) {
+        throw new Error("THREAD_LABEL_ATTACH_FAILED");
+      }
 
       return {
         ...created,
-        label,
+        label: created.label ?? label,
       };
     }),
 
@@ -209,16 +319,27 @@ export default {
         threadLabelId: z.string(),
       }),
     ).handler(async ({ req, db }) => {
-      const tl = await db.threadLabel.one(req.input.threadLabelId).get();
+      const authorizedOrganizationIds = getAuthorizedOrganizationIds(req);
+      const tl = await db.threadLabel
+        .one(req.input.threadLabelId)
+        .include({ thread: true, label: true })
+        .get();
 
       if (!tl) {
         throw new Error("THREAD_LABEL_NOT_FOUND");
       }
 
-      const thread = await db.thread.one(tl.threadId).get();
+      const thread = tl.thread;
 
       if (!thread) {
         throw new Error("THREAD_NOT_FOUND");
+      }
+
+      if (
+        authorizedOrganizationIds &&
+        !authorizedOrganizationIds.includes(thread.organizationId)
+      ) {
+        throw new Error("THREAD_LABEL_NOT_FOUND");
       }
 
       authorize(req, {
@@ -231,7 +352,13 @@ export default {
         (await db.threadLabel
           .one(req.input.threadLabelId)
           .include({ label: true })
-          .get()) ?? { ...tl, enabled: false };
+          .get()) ?? {
+          id: tl.id,
+          threadId: tl.threadId,
+          labelId: tl.labelId,
+          enabled: false,
+          label: tl.label,
+        };
 
       return updated;
     }),

--- a/apps/api/src/live-state/router/message.ts
+++ b/apps/api/src/live-state/router/message.ts
@@ -54,7 +54,7 @@ export default publicRoute
         organizationId: z.string(),
       }),
     ).handler(async ({ req, db }) => {
-      authorize(req.context, {
+      authorize(req, {
         organizationId: req.input.organizationId,
         allowPublicApiKey: true,
       });
@@ -161,7 +161,7 @@ export default publicRoute
         const isThreadAuthor = threadAuthor?.userId === callerUserId;
 
         if (!isThreadAuthor) {
-          authorize(req.context, {
+          authorize(req, {
             organizationId: thread.organizationId,
           });
         }

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -436,7 +436,7 @@ export default publicRoute
         direction,
       } = req.input;
 
-      // authorize(req.context, { organizationId });
+      // authorize(req, { organizationId });
 
       let query = db.thread.where({
         organizationId,

--- a/apps/web/src/components/threads/labels.tsx
+++ b/apps/web/src/components/threads/labels.tsx
@@ -95,27 +95,17 @@ export function LabelsSection({
               const newItem = creatableSelection.replace("create:", "");
               if (!currentOrg?.id) return;
 
-              const newLabelId = ulid().toLowerCase();
+              const labelId = ulid().toLowerCase();
+              const threadLabelId = ulid().toLowerCase();
 
-              mutate.label.insert({
-                id: newLabelId,
+              mutate.label.createAndAttachToThread({
+                organizationId: currentOrg.id,
+                threadId,
                 name: newItem,
                 color: "var(--label-color-red)",
-                createdAt: new Date(),
-                updatedAt: new Date(),
-                organizationId: currentOrg?.id,
-                enabled: true,
+                labelId,
+                threadLabelId,
               });
-
-              // TODO remove this once we have a proper transaction system
-              setTimeout(() => {
-                mutate.threadLabel.insert({
-                  id: ulid().toLowerCase(),
-                  threadId: threadId,
-                  labelId: newLabelId,
-                  enabled: true,
-                });
-              }, 100);
             } else {
               const nextLabelSet = new Set(
                 next.filter((i) => !i.startsWith("create:")),
@@ -144,23 +134,13 @@ export function LabelsSection({
 
               // Add labels
               for (const labelId of labelsToAdd) {
-                const existingThreadLabel = threadLabelMap.get(labelId);
                 const label = allLabels?.find((l) => l.id === labelId);
 
-                if (existingThreadLabel) {
-                  // Update existing connection
-                  mutate.threadLabel.update(existingThreadLabel.id, {
-                    enabled: true,
-                  });
-                } else {
-                  // Insert new connection
-                  mutate.threadLabel.insert({
-                    id: ulid().toLowerCase(),
-                    threadId: threadId,
-                    labelId: labelId,
-                    enabled: true,
-                  });
-                }
+                mutate.label.attachToThread({
+                  threadId,
+                  labelId,
+                  id: ulid().toLowerCase(),
+                });
 
                 captureThreadEvent("thread:label_add", {
                   label_id: labelId,
@@ -174,8 +154,8 @@ export function LabelsSection({
                 const label = allLabels?.find((l) => l.id === labelId);
 
                 if (existingThreadLabel) {
-                  mutate.threadLabel.update(existingThreadLabel.id, {
-                    enabled: false,
+                  mutate.label.detachFromThread({
+                    threadLabelId: existingThreadLabel.id,
                   });
 
                   captureThreadEvent("thread:label_remove", {

--- a/apps/web/src/components/threads/thread-toolbar/quick-actions.tsx
+++ b/apps/web/src/components/threads/thread-toolbar/quick-actions.tsx
@@ -198,20 +198,11 @@ export const QuickActionsPanel = ({
   const handleAcceptLabel = (labelId: string) => {
     const label = suggestedLabels?.find((l) => l.id === labelId);
 
-    const existingThreadLabel = threadLabels?.find(
-      (tl) => tl.label.id === labelId,
-    );
-
-    if (existingThreadLabel) {
-      mutate.threadLabel.update(existingThreadLabel.id, { enabled: true });
-    } else {
-      mutate.threadLabel.insert({
-        id: ulid().toLowerCase(),
-        threadId: threadId,
-        labelId: labelId,
-        enabled: true,
-      });
-    }
+    mutate.label.attachToThread({
+      threadId,
+      labelId,
+      id: ulid().toLowerCase(),
+    });
 
     updateSuggestionForLabel(labelId, true);
 
@@ -227,20 +218,11 @@ export const QuickActionsPanel = ({
     for (const label of suggestedLabels ?? []) {
       const labelId = label.id;
 
-      const existingThreadLabel = threadLabels?.find(
-        (tl) => tl.label.id === labelId,
-      );
-
-      if (existingThreadLabel) {
-        mutate.threadLabel.update(existingThreadLabel.id, { enabled: true });
-      } else {
-        mutate.threadLabel.insert({
-          id: ulid().toLowerCase(),
-          threadId: threadId,
-          labelId: labelId,
-          enabled: true,
-        });
-      }
+      mutate.label.attachToThread({
+        threadId,
+        labelId: label.id,
+        id: ulid().toLowerCase(),
+      });
 
       updateSuggestionForLabel(labelId, true);
     }

--- a/apps/web/src/components/threads/thread-toolbar/support-intelligence.tsx
+++ b/apps/web/src/components/threads/thread-toolbar/support-intelligence.tsx
@@ -340,20 +340,11 @@ export const Suggestions = ({
   const handleAcceptLabel = async (labelId: string) => {
     const label = suggestedLabels?.find((l) => l.id === labelId);
 
-    const existingThreadLabel = threadLabels?.find(
-      (tl) => tl.label.id === labelId,
-    );
-
-    if (existingThreadLabel) {
-      mutate.threadLabel.update(existingThreadLabel.id, { enabled: true });
-    } else {
-      mutate.threadLabel.insert({
-        id: ulid().toLowerCase(),
-        threadId: threadId,
-        labelId: labelId,
-        enabled: true,
-      });
-    }
+    mutate.label.attachToThread({
+      threadId,
+      labelId,
+      id: ulid().toLowerCase(),
+    });
 
     updateSuggestionForLabel(labelId, true);
 
@@ -369,20 +360,11 @@ export const Suggestions = ({
     for (const label of suggestedLabels ?? []) {
       const labelId = label.id;
 
-      const existingThreadLabel = threadLabels?.find(
-        (tl) => tl.label.id === labelId,
-      );
-
-      if (existingThreadLabel) {
-        mutate.threadLabel.update(existingThreadLabel.id, { enabled: true });
-      } else {
-        mutate.threadLabel.insert({
-          id: ulid().toLowerCase(),
-          threadId: threadId,
-          labelId: labelId,
-          enabled: true,
-        });
-      }
+      mutate.label.attachToThread({
+        threadId,
+        labelId: label.id,
+        id: ulid().toLowerCase(),
+      });
 
       updateSuggestionForLabel(labelId, true);
     }

--- a/apps/web/src/lib/live-state.ts
+++ b/apps/web/src/lib/live-state.ts
@@ -86,6 +86,79 @@ const { client, store } = createClient<Router>({
         });
       },
     },
+    label: {
+      create: ({ input, storage }) => {
+        const now = new Date();
+
+        storage.label.insert({
+          id: input.id ?? ulid().toLowerCase(),
+          organizationId: input.organizationId,
+          name: input.name,
+          color: input.color,
+          enabled: input.enabled ?? true,
+          createdAt: now,
+          updatedAt: now,
+        });
+      },
+      update: ({ input, storage }) => {
+        storage.label.update(input.labelId, {
+          name: input.name,
+          color: input.color,
+          enabled: input.enabled,
+          updatedAt: input.updatedAt ?? new Date(),
+        });
+      },
+      createAndAttachToThread: ({ input, storage }) => {
+        const labelId = input.labelId ?? ulid().toLowerCase();
+        const threadLabelId = input.threadLabelId ?? ulid().toLowerCase();
+        const now = new Date();
+
+        storage.label.insert({
+          id: labelId,
+          organizationId: input.organizationId,
+          name: input.name,
+          color: input.color,
+          enabled: true,
+          createdAt: now,
+          updatedAt: now,
+        });
+
+        storage.threadLabel.insert({
+          id: threadLabelId,
+          threadId: input.threadId,
+          labelId,
+          enabled: true,
+        });
+      },
+      attachToThread: ({ input, storage }) => {
+        const existing =
+          storage.threadLabel
+            .where({
+              threadId: input.threadId,
+              labelId: input.labelId,
+            })
+            .get()[0] ?? null;
+
+        if (existing) {
+          if (!existing.enabled) {
+            storage.threadLabel.update(existing.id, { enabled: true });
+          }
+          return;
+        }
+
+        storage.threadLabel.insert({
+          id: input.id ?? ulid().toLowerCase(),
+          threadId: input.threadId,
+          labelId: input.labelId,
+          enabled: true,
+        });
+      },
+      detachFromThread: ({ input, storage }) => {
+        storage.threadLabel.update(input.threadLabelId, {
+          enabled: false,
+        });
+      },
+    },
   }),
 });
 

--- a/apps/web/src/routes/app/_workspace/settings/organization/labels.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/labels.tsx
@@ -87,7 +87,8 @@ function RouteComponent() {
 
     try {
       // Set enabled to false instead of deleting
-      mutate.label.update(labelId, {
+      mutate.label.update({
+        labelId,
         enabled: false,
         updatedAt: new Date(),
       });
@@ -107,12 +108,10 @@ function RouteComponent() {
     try {
       const colorVar = LABEL_COLOR_VARS[selectedColorIndex];
 
-      mutate.label.insert({
+      mutate.label.create({
         id: ulid().toLowerCase(),
         name: labelName.trim() || "",
         color: colorVar,
-        createdAt: new Date(),
-        updatedAt: new Date(),
         organizationId: currentOrg.id,
         enabled: true,
       });
@@ -136,7 +135,8 @@ function RouteComponent() {
     try {
       const colorVar = LABEL_COLOR_VARS[selectedColorIndex];
 
-      mutate.label.update(editingLabel.id, {
+      mutate.label.update({
+        labelId: editingLabel.id,
         name: labelName,
         color: colorVar,
         updatedAt: new Date(),


### PR DESCRIPTION
## Summary
- Migrate `label` / `threadLabel` to **`withProcedures`**: **`create`**, **`update`**, **`createAndAttachToThread`**, **`attachToThread`**, **`detachFromThread`**; block default insert/update authorization.
- **`authorize`**: request-shaped **`AuthorizeReq`**; handlers use **`authorize(req, opts)`** (see **`message`** / **`threads`** comments).
- **Web**: switch **`mutate.label.*`** / optimistic handlers; simplify **`attachToThread`** call sites where the server upserts by `(threadId, labelId)`.

## Notes
Working tree still has unstaged edits in `labels.tsx` router/components; not part of this commit.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors label management to `withProcedures` with request-based authorization. Simplifies thread labeling on web with optimistic handlers and idempotent attach/soft detach.

- **New Features**
  - Added `label` procedures: `create`, `update`, `createAndAttachToThread`, `attachToThread` (upserts by thread/label), `detachFromThread` (soft-disable).
  - Optimistic client handlers for all `label.*` procedures.

- **Refactors**
  - Introduced `AuthorizeReq` and `authorize(req, opts)` with optional `allowInternalApiKey` (default true).
  - Blocked default `insert`/`update` on `label` and `threadLabel`; all writes go through procedures.
  - Updated web to use `label.createAndAttachToThread`, `label.attachToThread`, and `label.detachFromThread`; `message` router now calls `authorize(req, ...)`.

<sup>Written for commit 845b29b0ad2c62fcb406dd81a3b053c51fc700a7. Summary will update on new commits. <a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/256?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consolidated label creation + attach flow and unified attach/detach actions; optimistic updates make label actions feel faster.

* **Security**
  * Stricter and clearer authorization checks for API operations.

* **Bug Fixes**
  * Stronger validation for label/thread organization consistency and clearer failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->