### PR TITLE
feat(api): signals v2 milestone 0 — schema & foundations

### DIFF
--- a/apps/api/src/lib/signals.ts
+++ b/apps/api/src/lib/signals.ts
@@ -6,7 +6,7 @@ import {
   type SignalType,
 } from "@workspace/schemas/signals";
 import { ulid } from "ulid";
-import { schema } from "../live-state/schema";
+import type { schema } from "../live-state/schema";
 
 type DB = ServerDB<typeof schema>;
 
@@ -20,16 +20,14 @@ export function canDoAutonomously(
 }
 
 export async function listPendingSignals(db: DB, organizationId: string) {
-  const rows = Object.values(
-    await db.find(schema.suggestion, {
-      where: {
-        organizationId,
-        active: true,
-        dismissedAt: null,
-        actedAt: null,
-      },
-    }),
-  );
+  const rows = await db.suggestion
+    .where({
+      organizationId,
+      active: true,
+      dismissedAt: null,
+      actedAt: null,
+    })
+    .get();
   return rows.sort((a, b) => (b.urgencyScore ?? 0) - (a.urgencyScore ?? 0));
 }
 
@@ -38,11 +36,9 @@ export async function listAutonomousActions(
   organizationId: string,
   since: Date,
 ) {
-  const rows = Object.values(
-    await db.find(schema.autonomousAction, {
-      where: { organizationId, undoneAt: null },
-    }),
-  );
+  const rows = await db.autonomousAction
+    .where({ organizationId, undoneAt: null })
+    .get();
   return rows
     .filter((r) => r.appliedAt >= since)
     .sort((a, b) => b.appliedAt.getTime() - a.appliedAt.getTime());
@@ -58,7 +54,7 @@ export async function recordAutonomousAction(
   },
 ) {
   const now = new Date();
-  return db.insert(schema.autonomousAction, {
+  return db.autonomousAction.insert({
     id: ulid().toLowerCase(),
     organizationId: input.organizationId,
     signalType: input.signalType,

--- a/apps/api/src/lib/signals.ts
+++ b/apps/api/src/lib/signals.ts
@@ -1,0 +1,70 @@
+import type { ServerDB } from "@live-state/sync/server";
+import {
+  type AutonomousActionMetadata,
+  type AutonomyLevel,
+  LOCKED_SIGNAL_TYPES,
+  type SignalType,
+} from "@workspace/schemas/signals";
+import { ulid } from "ulid";
+import { schema } from "../live-state/schema";
+
+type DB = ServerDB<typeof schema>;
+
+export function canDoAutonomously(
+  signalType: SignalType,
+  level: AutonomyLevel,
+): boolean {
+  if (level !== "auto") return false;
+  if (LOCKED_SIGNAL_TYPES.includes(signalType)) return false;
+  return true;
+}
+
+export async function listPendingSignals(db: DB, organizationId: string) {
+  const rows = Object.values(
+    await db.find(schema.suggestion, {
+      where: {
+        organizationId,
+        active: true,
+        dismissedAt: null,
+        actedAt: null,
+      },
+    }),
+  );
+  return rows.sort((a, b) => (b.urgencyScore ?? 0) - (a.urgencyScore ?? 0));
+}
+
+export async function listAutonomousActions(
+  db: DB,
+  organizationId: string,
+  since: Date,
+) {
+  const rows = Object.values(
+    await db.find(schema.autonomousAction, {
+      where: { organizationId, undoneAt: null },
+    }),
+  );
+  return rows
+    .filter((r) => r.appliedAt >= since)
+    .sort((a, b) => b.appliedAt.getTime() - a.appliedAt.getTime());
+}
+
+export async function recordAutonomousAction(
+  db: DB,
+  input: {
+    organizationId: string;
+    signalType: SignalType;
+    entityId: string;
+    metadata: AutonomousActionMetadata;
+  },
+) {
+  const now = new Date();
+  return db.insert(schema.autonomousAction, {
+    id: ulid().toLowerCase(),
+    organizationId: input.organizationId,
+    signalType: input.signalType,
+    entityId: input.entityId,
+    appliedAt: now,
+    undoneAt: null,
+    metadataStr: JSON.stringify(input.metadata),
+  });
+}

--- a/apps/api/src/live-state/migrations/files/002_seed_autonomy_settings.ts
+++ b/apps/api/src/live-state/migrations/files/002_seed_autonomy_settings.ts
@@ -1,0 +1,26 @@
+import { safeParseOrgSettings } from "@workspace/schemas/organization";
+import { getDefaultSignalAutonomy } from "@workspace/schemas/signals";
+import type { Migration } from "../types";
+
+const migration: Migration = {
+  name: "002_seed_autonomy_settings",
+  up: async ({ db }) => {
+    const orgs = await db.organization.where({}).get();
+    const defaults = getDefaultSignalAutonomy();
+
+    for (const org of orgs) {
+      const current = safeParseOrgSettings(org.settings);
+      const merged = {
+        ...current,
+        signalAutonomy: {
+          ...defaults,
+          ...(current.signalAutonomy ?? {}),
+        },
+      };
+
+      await db.organization.update(org.id, { settings: merged });
+    }
+  },
+};
+
+export default migration;

--- a/apps/api/src/live-state/migrations/files/002_seed_autonomy_settings.ts
+++ b/apps/api/src/live-state/migrations/files/002_seed_autonomy_settings.ts
@@ -1,5 +1,7 @@
-import { safeParseOrgSettings } from "@workspace/schemas/organization";
-import { getDefaultSignalAutonomy } from "@workspace/schemas/signals";
+import {
+  getDefaultSignalAutonomy,
+  signalAutonomyMapSchema,
+} from "@workspace/schemas/signals";
 import type { Migration } from "../types";
 
 const migration: Migration = {
@@ -9,16 +11,29 @@ const migration: Migration = {
     const defaults = getDefaultSignalAutonomy();
 
     for (const org of orgs) {
-      const current = safeParseOrgSettings(org.settings);
-      const merged = {
-        ...current,
+      // Preserve any unrelated keys on settings — only patch signalAutonomy.
+      const rawSettings =
+        org.settings &&
+        typeof org.settings === "object" &&
+        !Array.isArray(org.settings)
+          ? (org.settings as Record<string, unknown>)
+          : {};
+      const parsedAutonomy = signalAutonomyMapSchema.safeParse(
+        rawSettings.signalAutonomy,
+      );
+
+      const next = {
+        ...rawSettings,
         signalAutonomy: {
           ...defaults,
-          ...(current.signalAutonomy ?? {}),
+          ...(parsedAutonomy.success ? parsedAutonomy.data : {}),
         },
       };
 
-      await db.organization.update(org.id, { settings: merged });
+      await db.organization.update(org.id, {
+        // biome-ignore lint/suspicious/noExplicitAny: settings JSON is opaque to migrations
+        settings: next as any,
+      });
     }
   },
 };

--- a/apps/api/src/live-state/migrations/files/003_backfill_suggestion_urgency.ts
+++ b/apps/api/src/live-state/migrations/files/003_backfill_suggestion_urgency.ts
@@ -1,0 +1,16 @@
+import type { Migration } from "../types";
+
+const migration: Migration = {
+  name: "003_backfill_suggestion_urgency",
+  up: async ({ db }) => {
+    const rows = await db.suggestion.where({}).get();
+
+    for (const row of rows) {
+      if (row.urgencyScore == null) {
+        await db.suggestion.update(row.id, { urgencyScore: 0 });
+      }
+    }
+  },
+};
+
+export default migration;

--- a/apps/api/src/live-state/migrations/files/index.ts
+++ b/apps/api/src/live-state/migrations/files/index.ts
@@ -1,4 +1,6 @@
 import type { Migration } from "../types";
 import m001 from "./001_backfill_thread_short_id";
+import m002 from "./002_seed_autonomy_settings";
+import m003 from "./003_backfill_suggestion_urgency";
 
-export const migrations: Migration[] = [m001];
+export const migrations: Migration[] = [m001, m002, m003];

--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -1,11 +1,11 @@
 // TODO refactor with new live-state mental model
 import { router as createRouter } from "@live-state/sync/server";
 import { InviteUserEmail } from "@workspace/emails/transactional/org-invitation";
-import { safeParseOrgSettings } from "@workspace/schemas/organization";
 import {
   autonomyLevelSchema,
   getDefaultSignalAutonomy,
   type SignalAutonomyMap,
+  signalAutonomyMapSchema,
   signalTypeSchema,
 } from "@workspace/schemas/signals";
 import { addDays, addYears } from "date-fns";
@@ -204,17 +204,31 @@ export const router = createRouter({
           const org = await db.organization.one(req.input.organizationId).get();
           if (!org) throw new Error("ORGANIZATION_NOT_FOUND");
 
-          const currentSettings = safeParseOrgSettings(org.settings);
+          // Preserve raw settings — only touch signalAutonomy. Avoid
+          // safeParseOrgSettings here because it returns the schema defaults
+          // when the existing settings fail validation, which would silently
+          // overwrite unrelated keys we don't know about yet.
+          const rawSettings =
+            org.settings &&
+            typeof org.settings === "object" &&
+            !Array.isArray(org.settings)
+              ? (org.settings as Record<string, unknown>)
+              : {};
+          const parsedAutonomy = signalAutonomyMapSchema.safeParse(
+            rawSettings.signalAutonomy,
+          );
           const nextAutonomy: SignalAutonomyMap = {
-            ...(currentSettings.signalAutonomy ?? getDefaultSignalAutonomy()),
+            ...getDefaultSignalAutonomy(),
+            ...(parsedAutonomy.success ? parsedAutonomy.data : {}),
             [req.input.signalType]: req.input.level,
           };
 
           return db.update(schema.organization, org.id, {
             settings: {
-              ...currentSettings,
+              ...rawSettings,
               signalAutonomy: nextAutonomy,
-            },
+              // biome-ignore lint/suspicious/noExplicitAny: settings JSON shape is open
+            } as any,
           });
         }),
         createPublicApiKey: mutation(

--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -1,15 +1,25 @@
 // TODO refactor with new live-state mental model
 import { router as createRouter } from "@live-state/sync/server";
 import { InviteUserEmail } from "@workspace/emails/transactional/org-invitation";
+import { safeParseOrgSettings } from "@workspace/schemas/organization";
+import {
+  autonomyLevelSchema,
+  getDefaultSignalAutonomy,
+  type SignalAutonomyMap,
+  signalTypeSchema,
+} from "@workspace/schemas/signals";
 import { addDays, addYears } from "date-fns";
 import { ulid } from "ulid";
 import { z } from "zod";
 import { publicKeys } from "../lib/api-key";
+import { authorize } from "../lib/authorize";
 import { dodopayments } from "../lib/payment";
 import { resend } from "../lib/resend";
+import { canDoAutonomously } from "../lib/signals";
 import { sendWelcomeEmail } from "../trigger/send-welcome-email";
 import { privateRoute, publicRoute } from "./factories";
 import { agentChatMessageRoute, agentChatRoute } from "./router/agent-chat";
+import autonomousActionRoute from "./router/autonomous-action";
 import documentationSourcesRoute from "./router/documentation-sources";
 import labelsRoute from "./router/labels";
 import messageRoute from "./router/message";
@@ -111,6 +121,17 @@ export const router = createRouter({
             logoUrl: null,
             socials: null,
             customInstructions: null,
+            settings: {
+              timezone: "UTC",
+              digest: {
+                pendingReplyThresholdMinutes: 30,
+                time: "09:00",
+                slackChannelId: null,
+                slackChannelName: null,
+                lastDigestSentAt: null,
+              },
+              signalAutonomy: getDefaultSignalAutonomy(),
+            },
           });
 
           await db.insert(schema.subscription, {
@@ -161,6 +182,40 @@ export const router = createRouter({
             success: true,
             organization,
           };
+        }),
+        setSignalAutonomy: mutation(
+          z.object({
+            organizationId: z.string(),
+            signalType: signalTypeSchema,
+            level: autonomyLevelSchema,
+          }),
+        ).handler(async ({ req, db }) => {
+          authorize(req.context, {
+            organizationId: req.input.organizationId,
+            role: "owner",
+          });
+
+          if (!canDoAutonomously(req.input.signalType, req.input.level)) {
+            if (req.input.level === "auto") {
+              throw new Error("SIGNAL_TYPE_LOCKED_FROM_AUTO");
+            }
+          }
+
+          const org = await db.organization.one(req.input.organizationId).get();
+          if (!org) throw new Error("ORGANIZATION_NOT_FOUND");
+
+          const currentSettings = safeParseOrgSettings(org.settings);
+          const nextAutonomy: SignalAutonomyMap = {
+            ...(currentSettings.signalAutonomy ?? getDefaultSignalAutonomy()),
+            [req.input.signalType]: req.input.level,
+          };
+
+          return db.update(schema.organization, org.id, {
+            settings: {
+              ...currentSettings,
+              signalAutonomy: nextAutonomy,
+            },
+          });
         }),
         createPublicApiKey: mutation(
           z.object({
@@ -727,6 +782,7 @@ export const router = createRouter({
     update: updateRoute,
     message: messageRoute,
     suggestion: suggestionRoute,
+    autonomousAction: autonomousActionRoute,
     onboarding: onboardingRoute,
     documentationSource: documentationSourcesRoute,
     agentChat: agentChatRoute,

--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -223,7 +223,7 @@ export const router = createRouter({
             [req.input.signalType]: req.input.level,
           };
 
-          return db.update(schema.organization, org.id, {
+          return db.organization.update(org.id, {
             settings: {
               ...rawSettings,
               signalAutonomy: nextAutonomy,

--- a/apps/api/src/live-state/router/autonomous-action.ts
+++ b/apps/api/src/live-state/router/autonomous-action.ts
@@ -39,9 +39,12 @@ export default privateRoute
         metadata: autonomousActionMetadataSchema,
       }),
     ).handler(async ({ req, db }) => {
-      authorize(req.context, {
-        organizationId: req.input.organizationId,
-      });
+      // Receipts are written by the worker only — never by user sessions or
+      // public API keys, otherwise a teammate could forge "FrontDesk handled
+      // X" entries that show up in the leverage report.
+      if (!req.context?.internalApiKey) {
+        throw new Error("UNAUTHORIZED");
+      }
 
       return db.insert(schema.autonomousAction, {
         id: req.input.id ?? ulid().toLowerCase(),
@@ -56,14 +59,25 @@ export default privateRoute
     undo: mutation(
       z.object({
         id: z.string(),
+        organizationId: z.string(),
       }),
     ).handler(async ({ req, db }) => {
-      const row = await db.autonomousAction.one(req.input.id).get();
-      if (!row) throw new Error("AUTONOMOUS_ACTION_NOT_FOUND");
-
+      // Authorize against the caller-supplied org *before* loading the row so
+      // a guessed id can't be probed across tenants.
       authorize(req.context, {
-        organizationId: row.organizationId,
+        organizationId: req.input.organizationId,
       });
+
+      const rows = Object.values(
+        await db.find(schema.autonomousAction, {
+          where: {
+            id: req.input.id,
+            organizationId: req.input.organizationId,
+          },
+        }),
+      );
+      const row = rows[0];
+      if (!row) throw new Error("AUTONOMOUS_ACTION_NOT_FOUND");
 
       if (row.undoneAt) return row;
 

--- a/apps/api/src/live-state/router/autonomous-action.ts
+++ b/apps/api/src/live-state/router/autonomous-action.ts
@@ -46,7 +46,7 @@ export default privateRoute
         throw new Error("UNAUTHORIZED");
       }
 
-      return db.insert(schema.autonomousAction, {
+      return db.autonomousAction.insert({
         id: req.input.id ?? ulid().toLowerCase(),
         organizationId: req.input.organizationId,
         signalType: req.input.signalType,
@@ -68,20 +68,18 @@ export default privateRoute
         organizationId: req.input.organizationId,
       });
 
-      const rows = Object.values(
-        await db.find(schema.autonomousAction, {
-          where: {
-            id: req.input.id,
-            organizationId: req.input.organizationId,
-          },
-        }),
-      );
+      const rows = await db.autonomousAction
+        .where({
+          id: req.input.id,
+          organizationId: req.input.organizationId,
+        })
+        .get();
       const row = rows[0];
       if (!row) throw new Error("AUTONOMOUS_ACTION_NOT_FOUND");
 
       if (row.undoneAt) return row;
 
-      return db.update(schema.autonomousAction, row.id, {
+      return db.autonomousAction.update(row.id, {
         undoneAt: new Date(),
       });
     }),

--- a/apps/api/src/live-state/router/autonomous-action.ts
+++ b/apps/api/src/live-state/router/autonomous-action.ts
@@ -1,0 +1,74 @@
+import {
+  autonomousActionMetadataSchema,
+  signalTypeSchema,
+} from "@workspace/schemas/signals";
+import { ulid } from "ulid";
+import z from "zod";
+import { authorize } from "../../lib/authorize";
+import { privateRoute } from "../factories";
+import { schema } from "../schema";
+
+export default privateRoute
+  .collectionRoute(schema.autonomousAction, {
+    read: ({ ctx }) => {
+      if (ctx?.internalApiKey) return true;
+      if (!ctx?.session) return false;
+
+      return {
+        organization: {
+          organizationUsers: {
+            userId: ctx.session.userId,
+            enabled: true,
+          },
+        },
+      };
+    },
+    insert: () => false,
+    update: {
+      preMutation: () => false,
+      postMutation: () => false,
+    },
+  })
+  .withProcedures(({ mutation }) => ({
+    record: mutation(
+      z.object({
+        id: z.string().optional(),
+        organizationId: z.string(),
+        signalType: signalTypeSchema,
+        entityId: z.string(),
+        metadata: autonomousActionMetadataSchema,
+      }),
+    ).handler(async ({ req, db }) => {
+      authorize(req.context, {
+        organizationId: req.input.organizationId,
+      });
+
+      return db.insert(schema.autonomousAction, {
+        id: req.input.id ?? ulid().toLowerCase(),
+        organizationId: req.input.organizationId,
+        signalType: req.input.signalType,
+        entityId: req.input.entityId,
+        appliedAt: new Date(),
+        undoneAt: null,
+        metadataStr: JSON.stringify(req.input.metadata),
+      });
+    }),
+    undo: mutation(
+      z.object({
+        id: z.string(),
+      }),
+    ).handler(async ({ req, db }) => {
+      const row = await db.autonomousAction.one(req.input.id).get();
+      if (!row) throw new Error("AUTONOMOUS_ACTION_NOT_FOUND");
+
+      authorize(req.context, {
+        organizationId: row.organizationId,
+      });
+
+      if (row.undoneAt) return row;
+
+      return db.update(schema.autonomousAction, row.id, {
+        undoneAt: new Date(),
+      });
+    }),
+  }));

--- a/apps/api/src/live-state/schema.ts
+++ b/apps/api/src/live-state/schema.ts
@@ -158,8 +158,23 @@ const suggestion = object("suggestion", {
   organizationId: reference("organization.id"),
   resultsStr: string().nullable(), // JSON array of results (e.g., label IDs)
   metadataStr: string().nullable(), // Flexible JSON metadata (hash, version, etc.)
+  urgencyScore: number().default(0),
+  dismissedAt: timestamp().nullable(),
+  actedAt: timestamp().nullable(),
   createdAt: timestamp(),
   updatedAt: timestamp(),
+});
+
+// TODO(live-state): composite index (organizationId, appliedAt desc) when supported.
+// Until then, single-column indexes plus query-side orderBy("appliedAt","desc").
+const autonomousAction = object("autonomousAction", {
+  id: id(),
+  organizationId: reference("organization.id").index(),
+  signalType: string(),
+  entityId: string(),
+  appliedAt: timestamp().index(),
+  undoneAt: timestamp().nullable(),
+  metadataStr: string().nullable(),
 });
 
 const onboarding = object("onboarding", {
@@ -213,6 +228,7 @@ const organizationRelations = createRelations(organization, ({ many }) => ({
   labels: many(label, "organizationId"),
   authors: many(author, "organizationId"),
   suggestions: many(suggestion, "organizationId"),
+  autonomousActions: many(autonomousAction, "organizationId"),
   onboardings: many(onboarding, "organizationId"),
   documentationSources: many(documentationSource, "organizationId"),
   agentChats: many(agentChat, "organizationId"),
@@ -275,6 +291,13 @@ const threadLabelRelations = createRelations(threadLabel, ({ one }) => ({
 const suggestionRelations = createRelations(suggestion, ({ one }) => ({
   organization: one(organization, "organizationId"),
 }));
+
+const autonomousActionRelations = createRelations(
+  autonomousAction,
+  ({ one }) => ({
+    organization: one(organization, "organizationId"),
+  }),
+);
 
 const onboardingRelations = createRelations(onboarding, ({ one }) => ({
   organization: one(organization, "organizationId"),
@@ -354,6 +377,7 @@ export const schema = createSchema({
   label,
   threadLabel,
   suggestion,
+  autonomousAction,
   pipelineIdempotencyKey,
   pipelineJob,
   onboarding,
@@ -374,6 +398,7 @@ export const schema = createSchema({
   labelRelations,
   threadLabelRelations,
   suggestionRelations,
+  autonomousActionRelations,
   onboardingRelations,
   documentationSourceRelations,
   agentChatRelations,

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -10,7 +10,8 @@
     "./integration/*": "./src/integration/*.ts",
     "./external-issue": "./src/external-issue.ts",
     "./organization": "./src/organization.ts",
-    "./digest": "./src/digest.ts"
+    "./digest": "./src/digest.ts",
+    "./signals": "./src/signals.ts"
   },
   "dependencies": {
     "zod": "catalog:"

--- a/packages/schemas/src/organization.ts
+++ b/packages/schemas/src/organization.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { signalAutonomyMapSchema } from "./signals";
 
 const digestSettingsDefaults = {
   pendingReplyThresholdMinutes: 30,
@@ -22,6 +23,7 @@ export const digestSettingsSchema = z.object({
 export const organizationSettingsSchema = z.object({
   timezone: z.string().default("UTC"),
   digest: digestSettingsSchema.default(digestSettingsDefaults),
+  signalAutonomy: signalAutonomyMapSchema.optional(),
 });
 
 export type OrganizationSettings = z.infer<typeof organizationSettingsSchema>;

--- a/packages/schemas/src/signals.ts
+++ b/packages/schemas/src/signals.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+
+export const SIGNAL_TYPES = [
+  "label",
+  "duplicate",
+  "duplicate_merge",
+  "linked_pr",
+  "pending_reply",
+  "loop_to_close",
+  "suggested_reply",
+  "status",
+  "churn_risk",
+  "kb_gap",
+  "trending_issue",
+] as const;
+
+export const signalTypeSchema = z.enum(SIGNAL_TYPES);
+export type SignalType = z.infer<typeof signalTypeSchema>;
+
+export const LOCKED_SIGNAL_TYPES: readonly SignalType[] = [
+  "duplicate_merge",
+  "suggested_reply",
+  "loop_to_close",
+] as const;
+
+export const autonomyLevelSchema = z.enum(["off", "suggest", "auto"]);
+export type AutonomyLevel = z.infer<typeof autonomyLevelSchema>;
+
+export const signalAutonomyMapSchema = z.partialRecord(
+  signalTypeSchema,
+  autonomyLevelSchema,
+);
+export type SignalAutonomyMap = z.infer<typeof signalAutonomyMapSchema>;
+
+export function getDefaultSignalAutonomy(): Record<SignalType, AutonomyLevel> {
+  const out = {} as Record<SignalType, AutonomyLevel>;
+  for (const t of SIGNAL_TYPES) {
+    out[t] = LOCKED_SIGNAL_TYPES.includes(t) ? "off" : "suggest";
+  }
+  return out;
+}
+
+export const churnRiskMetadataSchema = z.object({
+  customerId: z.string().nullable(),
+  customerName: z.string().nullable(),
+  tier: z.string().nullable(),
+  arr: z.number().nullable(),
+  triggerPhrases: z.array(
+    z.object({
+      threadId: z.string(),
+      phrase: z.string(),
+      messageId: z.string().nullable(),
+    }),
+  ),
+});
+export type ChurnRiskMetadata = z.infer<typeof churnRiskMetadataSchema>;
+
+export const kbGapMetadataSchema = z.object({
+  topic: z.string(),
+  threadIds: z.array(z.string()),
+  similarityScore: z.number().nullable(),
+  clusterSummary: z.string().nullable(),
+});
+export type KbGapMetadata = z.infer<typeof kbGapMetadataSchema>;
+
+export const trendingIssueMetadataSchema = z.object({
+  topic: z.string(),
+  threadIds: z.array(z.string()),
+  velocity: z.number(),
+  windowHours: z.number(),
+});
+export type TrendingIssueMetadata = z.infer<typeof trendingIssueMetadataSchema>;
+
+export const autonomousActionMetadataSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("label"), labelId: z.string() }),
+  z.object({ kind: z.literal("linked_pr"), prId: z.string() }),
+  z.object({
+    kind: z.literal("duplicate"),
+    relatedThreadId: z.string(),
+    score: z.number().nullable(),
+  }),
+  z.object({ kind: z.literal("status"), previousStatus: z.number() }),
+]);
+export type AutonomousActionMetadata = z.infer<
+  typeof autonomousActionMetadataSchema
+>;


### PR DESCRIPTION
## Summary

Milestone 0 of [Signals v2](../blob/main/docs/features/signals-v2.md) — schema + plumbing only, **nothing user-visible**. Later milestones (page redesign, automation settings, pattern detectors, digest integration) layer on top of this.

- **Schema**: `suggestion` gains `urgencyScore` / `dismissedAt` / `actedAt`; new `autonomousAction` receipts table (composite-index TODO until live-state supports it).
- **Typed metadata**: new `@workspace/schemas/signals` module — `SignalType`, `LOCKED_SIGNAL_TYPES`, `AutonomyLevel`, `getDefaultSignalAutonomy()`, `AutonomousActionMetadata`.
- **Org settings**: per-signal Off/Suggest/Auto map lives on `organization.settings.signalAutonomy` (no new config table). Seeded on org create and via migration `002` for existing orgs. Locked signals (`duplicate_merge`, `suggested_reply`, `loop_to_close`) default to `off`; everything else to `suggest`.
- **Guardrail**: `canDoAutonomously(signalType, level)` in `apps/api/src/lib/signals.ts` — locked types can never return `true` for `auto`.
- **Routes**: `autonomousAction` follows the new `withProcedures` mental model (`record` / `undo`); default insert/update blocked. `setSignalAutonomy` mutation on the organization route enforces `canDoAutonomously` and owner role.
- **Query layer**: `listPendingSignals`, `listAutonomousActions`, `recordAutonomousAction` helpers shared via the API lib (worker call sites use the typed metadata from `@workspace/schemas/signals`).
- **Migrations**: `002_seed_autonomy_settings`, `003_backfill_suggestion_urgency`.

## Test plan

- [ ] `bun run typecheck` passes
- [ ] `bun dev` boots the API; migrations 002 and 003 apply cleanly on a seeded dev DB
- [ ] New org created via UI has `settings.signalAutonomy` populated with one entry per `SignalType` (locked → `off`, others → `suggest`)
- [ ] Calling `setSignalAutonomy({ signalType: "duplicate_merge", level: "auto" })` returns an error
- [ ] Calling `setSignalAutonomy({ signalType: "label", level: "auto" })` succeeds for an owner and is rejected for non-owners
- [ ] `autonomousAction.record` mutation works from a worker context (internal API key) and is readable by org users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organizations can configure autonomy levels per signal type (off, suggest, auto).
  * Autonomous actions are recorded with metadata and can be undone.
  * Suggestions now include urgency scoring plus dismissed/acted status for clearer lifecycle tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->