### PR TITLE
chore: add shared evlog utility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -370,6 +370,7 @@
         "@tiptap/extension-heading": "^3.4.1",
         "@tiptap/react": "^3.4.1",
         "date-fns": "^4.1.0",
+        "evlog": "^2.14.1",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
@@ -2441,6 +2442,8 @@
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "evlog": ["evlog@2.14.1", "", { "peerDependencies": { "@nestjs/common": ">=11.1.19", "@nuxt/kit": "^4.4.2", "@tanstack/start-client-core": "^1.167.20", "ai": ">=6.0.168", "elysia": ">=1.4.28", "express": ">=5.2.1", "fastify": ">=5.8.5", "h3": "^1.15.11", "hono": "", "next": ">=16.2.4", "nitro": "^3.0.260311-beta", "nitropack": "^2.13.3", "ofetch": "^1.5.1", "react": ">=19.2.5", "react-router": ">=7.14.2", "vite": "^7.0.0 || ^8.0.0" }, "optionalPeers": ["@nestjs/common", "@nuxt/kit", "@tanstack/start-client-core", "ai", "elysia", "express", "fastify", "h3", "hono", "next", "nitro", "nitropack", "ofetch", "react", "react-router", "vite"] }, "sha512-fLLPLsio6BOb6sjbecB5AkikW5KzmLXj8fMxp/PauaZrrwzmzA6J1J5II+BMQIrosh/nPN6snF1mqsbwkajfYQ=="],
 
     "evt": ["evt@2.5.9", "", { "dependencies": { "minimal-polyfills": "^2.2.3", "run-exclusive": "^2.2.19", "tsafe": "^1.8.5" } }, "sha512-GpjX476FSlttEGWHT8BdVMoI8wGXQGbEOtKcP4E+kggg+yJzXBZN2n4x7TS/zPBJ1DZqWI+rguZZApjjzQ0HpA=="],
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,12 +10,14 @@
     "./tiptap": "./src/lib/tiptap.ts",
     "./tiptap-md": "./src/lib/tiptap-md.ts",
     "./md-tiptap": "./src/lib/md-tiptap.ts",
-    "./format": "./src/lib/format.ts"
+    "./format": "./src/lib/format.ts",
+    "./logging": "./src/lib/logging.ts"
   },
   "dependencies": {
     "@tiptap/extension-heading": "^3.4.1",
-    "date-fns": "^4.1.0",
     "@tiptap/react": "^3.4.1",
+    "date-fns": "^4.1.0",
+    "evlog": "^2.14.1",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",

--- a/packages/utils/src/lib/logging.ts
+++ b/packages/utils/src/lib/logging.ts
@@ -1,0 +1,84 @@
+import { initLogger, type LoggerConfig } from "evlog";
+import { createAxiomDrain, type AxiomConfig } from "evlog/axiom";
+
+type EnvMap = Record<string, string | undefined>;
+
+export type SharedLoggerOptions = {
+  service: string;
+  environment?: string;
+  enabled?: boolean;
+  pretty?: boolean;
+  silent?: boolean;
+  minLevel?: LoggerConfig["minLevel"];
+  axiom?: {
+    dataset?: string;
+    token?: string;
+    orgId?: string;
+    edgeUrl?: string;
+    baseUrl?: string;
+    timeout?: number;
+    retries?: number;
+  };
+  env?: EnvMap;
+};
+
+const getRuntimeEnv = (): EnvMap => {
+  const processLike = globalThis as {
+    process?: {
+      env?: EnvMap;
+    };
+  };
+
+  return processLike.process?.env ?? {};
+};
+
+const getAxiomDrain = (options: SharedLoggerOptions): LoggerConfig["drain"] => {
+  const env = options.env ?? getRuntimeEnv();
+  const dataset = options.axiom?.dataset ?? env.AXIOM_DATASET;
+  const token = options.axiom?.token ?? env.AXIOM_TOKEN;
+
+  if (!dataset || !token) {
+    return undefined;
+  }
+
+  const config: Partial<AxiomConfig> = {
+    dataset,
+    token,
+    orgId: options.axiom?.orgId ?? env.AXIOM_ORG_ID,
+    timeout: options.axiom?.timeout,
+    retries: options.axiom?.retries,
+  };
+
+  const edgeUrl = options.axiom?.edgeUrl ?? env.AXIOM_EDGE_URL;
+  const baseUrl = options.axiom?.baseUrl ?? env.AXIOM_URL;
+
+  if (edgeUrl) {
+    config.edgeUrl = edgeUrl;
+  } else if (baseUrl) {
+    config.baseUrl = baseUrl;
+  }
+
+  return createAxiomDrain(config);
+};
+
+export const createSharedLoggerConfig = (
+  options: SharedLoggerOptions,
+): LoggerConfig => {
+  const env = options.env ?? getRuntimeEnv();
+
+  return {
+    enabled: options.enabled ?? true,
+    pretty: options.pretty ?? env.NODE_ENV !== "production",
+    silent: options.silent ?? false,
+    minLevel: options.minLevel ?? "info",
+    env: {
+      service: options.service,
+      environment: options.environment ?? env.NODE_ENV ?? "development",
+    },
+    drain: getAxiomDrain(options),
+  };
+};
+
+export const initSharedLogger = (options: SharedLoggerOptions): void => {
+  initLogger(createSharedLoggerConfig(options));
+};


### PR DESCRIPTION
## Summary
- add a new shared logging utility in `@workspace/utils` using `evlog`, with optional Axiom drain wiring via environment variables
- export the new `./logging` entrypoint and add `evlog` dependency support in utils
- include related planning/reference docs and saved prompt updates requested for this branch

## Test plan
- [x] Run `bun run typecheck` in `packages/utils`
- [ ] Validate logger initialization from an app by importing `@workspace/utils/logging`
- [ ] Confirm Axiom drain activates only when `AXIOM_TOKEN` and `AXIOM_DATASET` are set

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared logger in `@workspace/utils` using `evlog`, with an optional Axiom drain configured via env or options. Exposes a `./logging` entrypoint.

- **New Features**
  - `@workspace/utils/logging`: exports `initSharedLogger` and `createSharedLoggerConfig`; supports enabled/pretty/silent/minLevel and sets env metadata (service, environment). Axiom drain is wired only when `AXIOM_TOKEN` and `AXIOM_DATASET` are set; also reads `AXIOM_ORG_ID`, `AXIOM_EDGE_URL` or `AXIOM_URL`, all overridable via options.

- **Dependencies**
  - Added `evlog` to `packages/utils`.

<sup>Written for commit 75fcd191c2e1fea6cdf6cd7f2b7af7e78a29162c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

