### PR TITLE
feat(web,worker): signals v2 milestone 2 — autonomy settings & activity log

### DIFF
--- a/apps/api/src/lib/signals.ts
+++ b/apps/api/src/lib/signals.ts
@@ -1,23 +1,14 @@
 import type { ServerDB } from "@live-state/sync/server";
 import {
   type AutonomousActionMetadata,
-  type AutonomyLevel,
-  LOCKED_SIGNAL_TYPES,
   type SignalType,
 } from "@workspace/schemas/signals";
 import { ulid } from "ulid";
 import type { schema } from "../live-state/schema";
 
-type DB = ServerDB<typeof schema>;
+export { canDoAutonomously } from "@workspace/schemas/signals";
 
-export function canDoAutonomously(
-  signalType: SignalType,
-  level: AutonomyLevel,
-): boolean {
-  if (level !== "auto") return false;
-  if (LOCKED_SIGNAL_TYPES.includes(signalType)) return false;
-  return true;
-}
+type DB = ServerDB<typeof schema>;
 
 export async function listPendingSignals(db: DB, organizationId: string) {
   const rows = await db.suggestion

--- a/apps/api/src/live-state/router/autonomous-action.ts
+++ b/apps/api/src/live-state/router/autonomous-action.ts
@@ -2,6 +2,7 @@ import {
   autonomousActionMetadataSchema,
   parseAutonomousActionMetadata,
   signalTypeSchema,
+  STATUS_LABELS,
 } from "@workspace/schemas/signals";
 import { ulid } from "ulid";
 import z from "zod";
@@ -105,12 +106,14 @@ export default privateRoute
           source: "autonomous_undo",
         };
       } else if (metadata?.kind === "linked_pr") {
+        const threads = await db.thread.where({ id: threadId }).get();
+        const oldPrId = threads[0]?.externalPrId ?? null;
         await db.thread.update(threadId, { externalPrId: null });
         activityType = "pr_changed";
         activityMetadata = {
-          oldPrId: null,
+          oldPrId,
           newPrId: null,
-          oldPrLabel: "linked PR",
+          oldPrLabel: oldPrId ? "linked PR" : null,
           newPrLabel: null,
           source: "autonomous_undo",
         };
@@ -126,7 +129,7 @@ export default privateRoute
         activityType = "status_changed";
         activityMetadata = {
           newStatus: metadata.previousStatus,
-          newStatusLabel: null,
+          newStatusLabel: STATUS_LABELS[metadata.previousStatus] ?? null,
           source: "autonomous_undo",
         };
       }

--- a/apps/api/src/live-state/router/autonomous-action.ts
+++ b/apps/api/src/live-state/router/autonomous-action.ts
@@ -81,6 +81,7 @@ export default privateRoute
       if (row.undoneAt) return row;
 
       const metadata = parseAutonomousActionMetadata(row.metadataStr);
+      if (!metadata) throw new Error("AUTONOMOUS_ACTION_METADATA_INVALID");
       const threadId = row.entityId;
       const now = new Date();
 

--- a/apps/api/src/live-state/router/autonomous-action.ts
+++ b/apps/api/src/live-state/router/autonomous-action.ts
@@ -1,5 +1,6 @@
 import {
   autonomousActionMetadataSchema,
+  parseAutonomousActionMetadata,
   signalTypeSchema,
 } from "@workspace/schemas/signals";
 import { ulid } from "ulid";
@@ -76,11 +77,72 @@ export default privateRoute
         .get();
       const row = rows[0];
       if (!row) throw new Error("AUTONOMOUS_ACTION_NOT_FOUND");
-
       if (row.undoneAt) return row;
 
-      return db.autonomousAction.update(row.id, {
-        undoneAt: new Date(),
-      });
+      const metadata = parseAutonomousActionMetadata(row.metadataStr);
+      const threadId = row.entityId;
+      const now = new Date();
+
+      let activityType: string | null = null;
+      let activityMetadata: Record<string, unknown> = {
+        source: "autonomous_undo",
+      };
+
+      if (metadata?.kind === "label") {
+        const tls = await db.threadLabel
+          .where({ threadId, labelId: metadata.labelId })
+          .get();
+        const tl = tls[0];
+        if (tl?.enabled) {
+          await db.threadLabel.update(tl.id, { enabled: false });
+        }
+        const labels = await db.label.where({ id: metadata.labelId }).get();
+        activityType = "label_changed";
+        activityMetadata = {
+          action: "removed",
+          labelId: metadata.labelId,
+          labelName: labels[0]?.name ?? null,
+          source: "autonomous_undo",
+        };
+      } else if (metadata?.kind === "linked_pr") {
+        await db.thread.update(threadId, { externalPrId: null });
+        activityType = "pr_changed";
+        activityMetadata = {
+          oldPrId: null,
+          newPrId: null,
+          oldPrLabel: "linked PR",
+          newPrLabel: null,
+          source: "autonomous_undo",
+        };
+      } else if (metadata?.kind === "duplicate") {
+        await db.thread.update(threadId, { status: metadata.previousStatus });
+        activityType = "marked_duplicate";
+        activityMetadata = {
+          duplicateOfThreadId: metadata.relatedThreadId,
+          source: "autonomous_undo",
+        };
+      } else if (metadata?.kind === "status") {
+        await db.thread.update(threadId, { status: metadata.previousStatus });
+        activityType = "status_changed";
+        activityMetadata = {
+          newStatus: metadata.previousStatus,
+          newStatusLabel: null,
+          source: "autonomous_undo",
+        };
+      }
+
+      if (activityType) {
+        await db.update.insert({
+          id: ulid().toLowerCase(),
+          threadId,
+          userId: req.context?.session?.userId ?? null,
+          type: activityType,
+          createdAt: now,
+          metadataStr: JSON.stringify(activityMetadata),
+          replicatedStr: JSON.stringify({}),
+        });
+      }
+
+      return db.autonomousAction.update(row.id, { undoneAt: now });
     }),
   }));

--- a/apps/web/src/components/threads/updates.tsx
+++ b/apps/web/src/components/threads/updates.tsx
@@ -8,7 +8,7 @@ import {
 } from "@workspace/ui/components/indicator";
 import { formatRelativeTime } from "@workspace/ui/lib/utils";
 import type { schema } from "api/schema";
-import { CircleUserIcon, CopySlash, Github } from "lucide-react";
+import { Bot, CircleUserIcon, CopySlash, Github, Tag } from "lucide-react";
 import { ThreadChip } from "~/components/chips";
 import { query } from "~/lib/live-state";
 import { buildThreadParam } from "~/utils/thread";
@@ -41,7 +41,28 @@ export function Update({
       .include({ author: { include: { user: true } }, assignedUser: true }),
   );
 
+  const isAutonomous = metadata?.source === "autonomous";
+  const isAutonomousUndo = metadata?.source === "autonomous_undo";
+  const verbPrefix = isAutonomous
+    ? "auto-"
+    : isAutonomousUndo
+      ? "undid auto-"
+      : "";
+
   const getUpdateText = () => {
+    if (update.type === "label_changed") {
+      const action = metadata?.action === "removed" ? "removed" : "applied";
+      return (
+        <>
+          {verbPrefix}
+          {action === "applied" ? "labeled as " : "removed label "}
+          <span className="text-foreground">
+            {metadata?.labelName ?? "label"}
+          </span>
+        </>
+      );
+    }
+
     if (update.type === "assigned_changed") {
       if (user?.id && metadata?.newAssignedUserId === user.id) {
         return `self-assigned the thread`;
@@ -64,7 +85,7 @@ export function Update({
     if (update.type === "status_changed") {
       return (
         <>
-          changed status to{" "}
+          {verbPrefix}changed status to{" "}
           <span className="text-foreground">{metadata?.newStatusLabel}</span>
         </>
       );
@@ -115,7 +136,7 @@ export function Update({
       if (!metadata?.oldPrLabel && metadata?.newPrLabel) {
         return (
           <>
-            linked PR{" "}
+            {verbPrefix}linked PR{" "}
             <span className="text-foreground">{metadata.newPrLabel}</span>
           </>
         );
@@ -155,7 +176,7 @@ export function Update({
     if (update.type === "marked_duplicate") {
       return (
         <span className="inline-flex items-center gap-1">
-          marked as duplicate of{" "}
+          {verbPrefix}marked as duplicate of{" "}
           {duplicateThread ? (
             <ThreadChip
               thread={duplicateThread}
@@ -179,39 +200,56 @@ export function Update({
     }
   };
 
+  const isFrontDesk = isAutonomous || isAutonomousUndo;
+  const actorName = isFrontDesk
+    ? "FrontDesk"
+    : (update.user?.name ?? metadata?.userName ?? "Someone");
+
   return (
     <div className="flex gap-2 items-center text-xs text-muted-foreground">
       <div className="relative flex items-center justify-center size-4 shrink-0">
         {connectTop && (
           <span className="absolute left-1/2 -top-0.5 h-3 w-px -translate-x-1/2 -translate-y-full bg-border" />
         )}
-        {update.type === "status_changed" && (
-          <StatusIndicator status={metadata?.newStatus as number} />
-        )}
-        {update.type === "priority_changed" && (
-          <PriorityIndicator priority={metadata?.newPriority as number} />
-        )}
-        {update.type === "assigned_changed" &&
-          (assignedUser ? (
-            <Avatar variant="user" size="sm" fallback={assignedUser.name} />
-          ) : (
-            <CircleUserIcon className="size-3.5" />
-          ))}
-        {update.type === "issue_changed" && <Github className="size-3.5" />}
-        {update.type === "pr_changed" && <Github className="size-3.5" />}
-        {update.type === "github_issue_created" && (
-          <Github className="size-3.5" />
-        )}
-        {update.type === "marked_duplicate" && (
-          <CopySlash className="size-3.5" />
+        {isFrontDesk ? (
+          <Bot className="size-3.5" />
+        ) : (
+          <>
+            {update.type === "status_changed" && (
+              <StatusIndicator status={metadata?.newStatus as number} />
+            )}
+            {update.type === "priority_changed" && (
+              <PriorityIndicator priority={metadata?.newPriority as number} />
+            )}
+            {update.type === "assigned_changed" &&
+              (assignedUser ? (
+                <Avatar variant="user" size="sm" fallback={assignedUser.name} />
+              ) : (
+                <CircleUserIcon className="size-3.5" />
+              ))}
+            {update.type === "issue_changed" && <Github className="size-3.5" />}
+            {update.type === "pr_changed" && <Github className="size-3.5" />}
+            {update.type === "github_issue_created" && (
+              <Github className="size-3.5" />
+            )}
+            {update.type === "marked_duplicate" && (
+              <CopySlash className="size-3.5" />
+            )}
+            {update.type === "label_changed" && <Tag className="size-3.5" />}
+          </>
         )}
       </div>
       <span>
-        <span className="text-foreground">
-          {update.user?.name ?? metadata?.userName ?? "Someone"}
-        </span>{" "}
-        {getUpdateText()}
+        <span className="text-foreground">{actorName}</span> {getUpdateText()}
       </span>
+      {isFrontDesk && metadata?.signalId && (
+        <Link
+          to="/app/signal"
+          className="text-foreground underline-offset-2 hover:underline"
+        >
+          [view signal]
+        </Link>
+      )}
       <span>·</span>
       <span>{formatRelativeTime(update.createdAt)}</span>
     </div>

--- a/apps/web/src/lib/live-state.ts
+++ b/apps/web/src/lib/live-state.ts
@@ -5,6 +5,7 @@ import {
 import { createClient as createFetchClient } from "@live-state/sync/client/fetch";
 import { createIsomorphicFn } from "@tanstack/react-start";
 import { getRequestHeaders } from "@tanstack/react-start/server";
+import { parseAutonomousActionMetadata } from "@workspace/schemas/signals";
 import type { Router } from "api/router";
 import { schema } from "api/schema";
 import { ulid } from "ulid";
@@ -157,6 +158,81 @@ const { client, store } = createClient<Router>({
         storage.threadLabel.update(input.threadLabelId, {
           enabled: false,
         });
+      },
+    },
+    autonomousAction: {
+      undo: ({ input, storage }) => {
+        const row = storage.autonomousAction
+          .where({ id: input.id, organizationId: input.organizationId })
+          .get()[0];
+        if (!row || row.undoneAt) return;
+
+        const metadata = parseAutonomousActionMetadata(row.metadataStr);
+        const threadId = row.entityId;
+        const now = new Date();
+
+        let activityType: string | null = null;
+        let activityMetadata: Record<string, unknown> = {
+          source: "autonomous_undo",
+        };
+
+        if (metadata?.kind === "label") {
+          const tl = storage.threadLabel
+            .where({ threadId, labelId: metadata.labelId })
+            .get()[0];
+          if (tl?.enabled) {
+            storage.threadLabel.update(tl.id, { enabled: false });
+          }
+          const label = storage.label
+            .where({ id: metadata.labelId })
+            .get()[0];
+          activityType = "label_changed";
+          activityMetadata = {
+            action: "removed",
+            labelId: metadata.labelId,
+            labelName: label?.name ?? null,
+            source: "autonomous_undo",
+          };
+        } else if (metadata?.kind === "linked_pr") {
+          storage.thread.update(threadId, { externalPrId: null });
+          activityType = "pr_changed";
+          activityMetadata = {
+            oldPrId: null,
+            newPrId: null,
+            oldPrLabel: "linked PR",
+            newPrLabel: null,
+            source: "autonomous_undo",
+          };
+        } else if (metadata?.kind === "duplicate") {
+          storage.thread.update(threadId, { status: metadata.previousStatus });
+          activityType = "marked_duplicate";
+          activityMetadata = {
+            duplicateOfThreadId: metadata.relatedThreadId,
+            source: "autonomous_undo",
+          };
+        } else if (metadata?.kind === "status") {
+          storage.thread.update(threadId, { status: metadata.previousStatus });
+          activityType = "status_changed";
+          activityMetadata = {
+            newStatus: metadata.previousStatus,
+            newStatusLabel: null,
+            source: "autonomous_undo",
+          };
+        }
+
+        if (activityType) {
+          storage.update.insert({
+            id: ulid().toLowerCase(),
+            threadId,
+            userId: null,
+            type: activityType,
+            createdAt: now,
+            metadataStr: JSON.stringify(activityMetadata),
+            replicatedStr: JSON.stringify({}),
+          });
+        }
+
+        storage.autonomousAction.update(row.id, { undoneAt: now });
       },
     },
   }),

--- a/apps/web/src/lib/live-state.ts
+++ b/apps/web/src/lib/live-state.ts
@@ -5,7 +5,10 @@ import {
 import { createClient as createFetchClient } from "@live-state/sync/client/fetch";
 import { createIsomorphicFn } from "@tanstack/react-start";
 import { getRequestHeaders } from "@tanstack/react-start/server";
-import { parseAutonomousActionMetadata } from "@workspace/schemas/signals";
+import {
+  parseAutonomousActionMetadata,
+  STATUS_LABELS,
+} from "@workspace/schemas/signals";
 import type { Router } from "api/router";
 import { schema } from "api/schema";
 import { ulid } from "ulid";
@@ -194,12 +197,14 @@ const { client, store } = createClient<Router>({
             source: "autonomous_undo",
           };
         } else if (metadata?.kind === "linked_pr") {
+          const thread = storage.thread.where({ id: threadId }).get()[0];
+          const oldPrId = thread?.externalPrId ?? null;
           storage.thread.update(threadId, { externalPrId: null });
           activityType = "pr_changed";
           activityMetadata = {
-            oldPrId: null,
+            oldPrId,
             newPrId: null,
-            oldPrLabel: "linked PR",
+            oldPrLabel: oldPrId ? "linked PR" : null,
             newPrLabel: null,
             source: "autonomous_undo",
           };
@@ -215,7 +220,7 @@ const { client, store } = createClient<Router>({
           activityType = "status_changed";
           activityMetadata = {
             newStatus: metadata.previousStatus,
-            newStatusLabel: null,
+            newStatusLabel: STATUS_LABELS[metadata.previousStatus] ?? null,
             source: "autonomous_undo",
           };
         }

--- a/apps/web/src/lib/live-state.ts
+++ b/apps/web/src/lib/live-state.ts
@@ -171,6 +171,7 @@ const { client, store } = createClient<Router>({
         if (!row || row.undoneAt) return;
 
         const metadata = parseAutonomousActionMetadata(row.metadataStr);
+        if (!metadata) return;
         const threadId = row.entityId;
         const now = new Date();
 

--- a/apps/web/src/routes/app/_workspace/settings/organization/support-intelligence.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/support-intelligence.tsx
@@ -1,6 +1,14 @@
 import { useLiveQuery } from "@live-state/sync/client";
 import { useForm, useStore } from "@tanstack/react-form";
 import { createFileRoute } from "@tanstack/react-router";
+import { safeParseOrgSettings } from "@workspace/schemas/organization";
+import {
+  type AutonomyLevel,
+  getDefaultSignalAutonomy,
+  LOCKED_SIGNAL_TYPES,
+  SIGNAL_LABEL,
+  type SignalType,
+} from "@workspace/schemas/signals";
 import { Button } from "@workspace/ui/components/button";
 import { Card, CardContent } from "@workspace/ui/components/card";
 import {
@@ -11,7 +19,17 @@ import {
   FormMessage,
 } from "@workspace/ui/components/form";
 import { Textarea } from "@workspace/ui/components/textarea";
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from "@workspace/ui/components/toggle-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@workspace/ui/components/tooltip";
 import { useAtomValue } from "jotai/react";
+import { useMemo, useState } from "react";
 import { z } from "zod";
 import { activeOrganizationAtom } from "~/lib/atoms";
 import { mutate, query } from "~/lib/live-state";
@@ -26,7 +44,7 @@ export const Route = createFileRoute(
       meta: [
         ...seo({
           title: "Support Intelligence Settings - FrontDesk",
-          description: "Configure your Support Intelligence agent",
+          description: "Configure your Support Intelligence Agent",
         }),
       ],
     };
@@ -73,49 +91,200 @@ function RouteComponent() {
   if (!org) return null;
 
   return (
-    <form
-      className="p-4 flex flex-col gap-4 w-full"
-      onSubmit={(e) => {
-        e.preventDefault();
-        handleSubmit();
-      }}
-      autoComplete="off"
-    >
-      <h2 className="text-base">Support Intelligence</h2>
+    <div className="p-4 flex flex-col gap-8 w-full">
+      <form
+        className="flex flex-col gap-4 w-full"
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit();
+        }}
+        autoComplete="off"
+      >
+        <h2 className="text-base">Agent</h2>
+        <Card className="bg-[#27272A]/30">
+          <CardContent>
+            <Field name="customInstructions">
+              {(field) => (
+                <FormItem field={field} className="flex flex-col gap-4">
+                  <div className="flex flex-col gap-1">
+                    <FormLabel>Custom instructions</FormLabel>
+                    <FormDescription>
+                      Added to the Agent's system prompt for every thread. Use
+                      this to set tone, escalation rules, or product-specific
+                      guidance.
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Textarea
+                      id={field.name}
+                      value={field.state.value}
+                      onChange={(e) => field.setValue(e.target.value)}
+                      placeholder="e.g., Always recommend checking the FAQ before escalating. Use a friendly, casual tone."
+                      rows={6}
+                      disabled={!isUserOwner}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            </Field>
+          </CardContent>
+        </Card>
+        {isUserOwner && (
+          <div className="flex justify-end">
+            <Button disabled={!nonPersistentIsDirty} type="submit">
+              Save
+            </Button>
+          </div>
+        )}
+      </form>
+
+      <AutomationCard
+        organizationId={currentOrg?.id}
+        settings={org.settings}
+        isUserOwner={isUserOwner}
+      />
+    </div>
+  );
+}
+
+// Pattern signals (M3) are intentionally hidden until their detectors ship.
+const HIDDEN_SIGNAL_TYPES: readonly SignalType[] = [
+  "churn_risk",
+  "kb_gap",
+  "trending_issue",
+];
+
+const AUTONOMY_LEVELS: AutonomyLevel[] = ["off", "suggest", "auto"];
+
+function AutomationCard({
+  organizationId,
+  settings,
+  isUserOwner,
+}: {
+  organizationId: string | undefined;
+  settings: unknown;
+  isUserOwner: boolean;
+}) {
+  const initial = useMemo(() => {
+    const parsed = safeParseOrgSettings(settings);
+    return { ...getDefaultSignalAutonomy(), ...(parsed.signalAutonomy ?? {}) };
+  }, [settings]);
+
+  const [pending, setPending] = useState<
+    Partial<Record<SignalType, AutonomyLevel>>
+  >({});
+
+  const visibleTypes = (Object.keys(initial) as SignalType[]).filter(
+    (t) => !HIDDEN_SIGNAL_TYPES.includes(t),
+  );
+
+  const dirty = Object.keys(pending).length > 0;
+
+  const handleChange = (signalType: SignalType, level: AutonomyLevel) => {
+    setPending((prev) => {
+      const next = { ...prev };
+      if (initial[signalType] === level) {
+        delete next[signalType];
+      } else {
+        next[signalType] = level;
+      }
+      return next;
+    });
+  };
+
+  const handleSave = () => {
+    if (!organizationId) return;
+    for (const [signalType, level] of Object.entries(pending) as [
+      SignalType,
+      AutonomyLevel,
+    ][]) {
+      mutate.organization.setSignalAutonomy({
+        organizationId,
+        signalType,
+        level,
+      });
+    }
+    setPending({});
+  };
+
+  const valueFor = (t: SignalType): AutonomyLevel => pending[t] ?? initial[t];
+
+  return (
+    <div className="flex flex-col gap-4 w-full">
+      <h2 className="text-base">Automation</h2>
       <Card className="bg-[#27272A]/30">
-        <CardContent>
-          <Field name="customInstructions">
-            {(field) => (
-              <FormItem field={field} className="flex flex-col gap-2">
-                <FormLabel>Custom instructions</FormLabel>
-                <FormDescription>
-                  Provide custom instructions for the Support Intelligence
-                  agent. These will be included in the agent's system prompt
-                  when assisting with support threads.
-                </FormDescription>
-                <FormControl>
-                  <Textarea
-                    id={field.name}
-                    value={field.state.value}
-                    onChange={(e) => field.setValue(e.target.value)}
-                    placeholder="e.g., Always recommend checking the FAQ before escalating. Use a friendly, casual tone."
-                    rows={6}
+        <CardContent className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1">
+            <span className="text-sm font-medium">Signal autonomy</span>
+            <span className="text-sm text-muted-foreground">
+              Choose the level of autonomy Support Intelligence has when
+              handling each signal.
+            </span>
+          </div>
+          <div
+            className="grid items-center gap-y-2 gap-x-4 text-sm"
+            style={{ gridTemplateColumns: "1fr auto" }}
+            role="table"
+            aria-label="Signal autonomy"
+          >
+            {visibleTypes.map((t) => {
+              const locked = LOCKED_SIGNAL_TYPES.includes(t);
+              const current = valueFor(t);
+              return (
+                <div key={t} className="contents">
+                  <div className="text-foreground">{SIGNAL_LABEL[t]}</div>
+                  <ToggleGroup
+                    type="single"
+                    variant="outline"
+                    value={current}
+                    onValueChange={(v) => {
+                      if (!v) return;
+                      handleChange(t, v as AutonomyLevel);
+                    }}
                     disabled={!isUserOwner}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          </Field>
+                  >
+                    {AUTONOMY_LEVELS.map((lvl) => {
+                      const disabled =
+                        !isUserOwner || (lvl === "auto" && locked);
+                      const item = (
+                        <ToggleGroupItem
+                          key={lvl}
+                          value={lvl}
+                          disabled={disabled}
+                          aria-label={`${SIGNAL_LABEL[t]} ${lvl}`}
+                          className="capitalize px-4 flex-none min-w-fit"
+                        >
+                          {lvl}
+                        </ToggleGroupItem>
+                      );
+                      if (lvl === "auto" && locked) {
+                        return (
+                          <Tooltip key={lvl}>
+                            <TooltipTrigger render={item} />
+                            <TooltipContent>
+                              Destructive or customer-facing — locked to Suggest
+                              at most.
+                            </TooltipContent>
+                          </Tooltip>
+                        );
+                      }
+                      return item;
+                    })}
+                  </ToggleGroup>
+                </div>
+              );
+            })}
+          </div>
         </CardContent>
       </Card>
       {isUserOwner && (
         <div className="flex justify-end">
-          <Button disabled={!nonPersistentIsDirty} type="submit">
+          <Button type="button" disabled={!dirty} onClick={handleSave}>
             Save
           </Button>
         </div>
       )}
-    </form>
+    </div>
   );
 }

--- a/apps/worker/src/lib/autonomy.ts
+++ b/apps/worker/src/lib/autonomy.ts
@@ -1,0 +1,23 @@
+import { safeParseOrgSettings } from "@workspace/schemas/organization";
+import {
+  type AutonomyLevel,
+  getDefaultSignalAutonomy,
+  type SignalType,
+} from "@workspace/schemas/signals";
+import { fetchClient } from "./database/client";
+
+type OrgRow = {
+  id: string;
+  settings: unknown;
+};
+
+export async function getOrgAutonomy(
+  organizationId: string,
+): Promise<Record<SignalType, AutonomyLevel>> {
+  const rows = (await fetchClient.query.organization
+    .where({ id: organizationId })
+    .get()) as OrgRow[];
+  const org = rows[0];
+  const parsed = safeParseOrgSettings(org?.settings);
+  return { ...getDefaultSignalAutonomy(), ...(parsed.signalAutonomy ?? {}) };
+}

--- a/apps/worker/src/pipeline/processors/suggest-labels.ts
+++ b/apps/worker/src/pipeline/processors/suggest-labels.ts
@@ -1,10 +1,11 @@
 import { google } from "@ai-sdk/google";
 import { jsonContentToPlainText, safeParseJSON } from "@workspace/utils/tiptap";
-import { computeUrgency } from "@workspace/schemas/signals";
+import { canDoAutonomously, computeUrgency } from "@workspace/schemas/signals";
 import { generateText, Output } from "ai";
 import { createHash } from "node:crypto";
 import { ulid } from "ulid";
 import z from "zod";
+import { getOrgAutonomy } from "../../lib/autonomy";
 import { fetchClient } from "../../lib/database/client";
 import type {
   ProcessorDefinition,
@@ -174,11 +175,90 @@ export const suggestLabelsProcessor: ProcessorDefinition<SuggestLabelsOutput> =
           allLabels,
         );
 
+        const autonomyMap = await getOrgAutonomy(organizationId);
+        const autoApply = canDoAutonomously("label", autonomyMap.label);
+
+        // Already-applied labels on this thread; we don't auto-apply duplicates.
+        const existingThreadLabels = (await fetchClient.query.threadLabel
+          .where({ threadId })
+          .get()) as { id: string; labelId: string; enabled: boolean }[];
+        const appliedLabelIds = new Set(
+          existingThreadLabels
+            .filter((tl) => tl.enabled)
+            .map((tl) => tl.labelId),
+        );
+
         const now = new Date();
         const filteredSuggestedLabelIds: string[] = [];
 
         for (const labelId of suggestedLabelIds) {
           const existing = existingByLabelId.get(labelId);
+
+          if (autoApply && !appliedLabelIds.has(labelId)) {
+            const label = allLabels.find((l) => l.id === labelId);
+            const suggestionId = existing?.id ?? ulid().toLowerCase();
+
+            await fetchClient.mutate.threadLabel.insert({
+              id: ulid().toLowerCase(),
+              threadId,
+              labelId,
+              enabled: true,
+            });
+
+            await fetchClient.mutate.update.insert({
+              id: ulid().toLowerCase(),
+              threadId,
+              userId: null,
+              type: "label_changed",
+              createdAt: now,
+              metadataStr: JSON.stringify({
+                action: "added",
+                labelId,
+                labelName: label?.name ?? null,
+                source: "autonomous",
+                signalType: "label",
+                signalId: suggestionId,
+              }),
+              replicatedStr: JSON.stringify({}),
+            });
+
+            await fetchClient.mutate.autonomousAction.record({
+              organizationId,
+              signalType: "label",
+              entityId: threadId,
+              metadata: { kind: "label", labelId },
+            });
+
+            if (existing) {
+              await fetchClient.mutate.suggestion.update(existing.id, {
+                active: false,
+                accepted: true,
+                actedAt: now,
+                updatedAt: now,
+              });
+            } else {
+              await fetchClient.mutate.suggestion.insert({
+                id: suggestionId,
+                type: SUGGESTION_TYPE_LABEL,
+                entityId: threadId,
+                relatedEntityId: labelId,
+                organizationId,
+                active: false,
+                accepted: true,
+                resultsStr: null,
+                metadataStr: null,
+                urgencyScore: computeUrgency({
+                  signalType: "label",
+                  ageHours: 0,
+                }),
+                actedAt: now,
+                createdAt: now,
+                updatedAt: now,
+              });
+            }
+            continue;
+          }
+
           if (existing) {
             await fetchClient.mutate.suggestion.update(existing.id, {
               active: existing.active,

--- a/apps/worker/src/pipeline/processors/suggest-labels.ts
+++ b/apps/worker/src/pipeline/processors/suggest-labels.ts
@@ -204,6 +204,7 @@ export const suggestLabelsProcessor: ProcessorDefinition<SuggestLabelsOutput> =
               labelId,
               enabled: true,
             });
+            appliedLabelIds.add(labelId);
 
             await fetchClient.mutate.update.insert({
               id: ulid().toLowerCase(),

--- a/packages/schemas/src/signals.ts
+++ b/packages/schemas/src/signals.ts
@@ -191,7 +191,11 @@ export function parseAutonomousActionMetadata(
   metadataStr: string | null,
 ): AutonomousActionMetadata | null {
   if (!metadataStr) return null;
-  return autonomousActionMetadataSchema.parse(JSON.parse(metadataStr));
+  try {
+    return autonomousActionMetadataSchema.parse(JSON.parse(metadataStr));
+  } catch {
+    return null;
+  }
 }
 
 export const STATUS_LABELS: Record<number, string> = {

--- a/packages/schemas/src/signals.ts
+++ b/packages/schemas/src/signals.ts
@@ -26,6 +26,15 @@ export const LOCKED_SIGNAL_TYPES: readonly SignalType[] = [
 export const autonomyLevelSchema = z.enum(["off", "suggest", "auto"]);
 export type AutonomyLevel = z.infer<typeof autonomyLevelSchema>;
 
+export function canDoAutonomously(
+  signalType: SignalType,
+  level: AutonomyLevel,
+): boolean {
+  if (level !== "auto") return false;
+  if (LOCKED_SIGNAL_TYPES.includes(signalType)) return false;
+  return true;
+}
+
 export const signalAutonomyMapSchema = z.partialRecord(
   signalTypeSchema,
   autonomyLevelSchema,
@@ -170,9 +179,21 @@ export const autonomousActionMetadataSchema = z.discriminatedUnion("kind", [
     kind: z.literal("duplicate"),
     relatedThreadId: z.string(),
     score: z.number().nullable(),
+    previousStatus: z.number(),
   }),
   z.object({ kind: z.literal("status"), previousStatus: z.number() }),
 ]);
 export type AutonomousActionMetadata = z.infer<
   typeof autonomousActionMetadataSchema
 >;
+
+export function parseAutonomousActionMetadata(
+  metadataStr: string | null,
+): AutonomousActionMetadata | null {
+  if (!metadataStr) return null;
+  try {
+    return autonomousActionMetadataSchema.parse(JSON.parse(metadataStr));
+  } catch {
+    return null;
+  }
+}

--- a/packages/schemas/src/signals.ts
+++ b/packages/schemas/src/signals.ts
@@ -191,9 +191,13 @@ export function parseAutonomousActionMetadata(
   metadataStr: string | null,
 ): AutonomousActionMetadata | null {
   if (!metadataStr) return null;
-  try {
-    return autonomousActionMetadataSchema.parse(JSON.parse(metadataStr));
-  } catch {
-    return null;
-  }
+  return autonomousActionMetadataSchema.parse(JSON.parse(metadataStr));
 }
+
+export const STATUS_LABELS: Record<number, string> = {
+  0: "Open",
+  1: "In progress",
+  2: "Resolved",
+  3: "Closed",
+  4: "Duplicated",
+};


### PR DESCRIPTION
## Summary
Milestone 2 of [signals v2](docs/features/signals-v2-tasks.md) — admins can shift signals between Off / Suggest / Auto, auto-applied actions are undoable, and they show up in thread history attributed to FrontDesk.

- **Settings → Support Intelligence → Automation** (M2.1, M2.2, M2.3, M2.6 surface): per-signal-type toggle group; Auto column is disabled with a tooltip on destructive/customer-facing signals; saves go through the existing `setSignalAutonomy` mutation which re-validates on the server.
- **Worker auto-apply** (M2.4): `suggest-labels` checks `getOrgAutonomy` + `canDoAutonomously`; when Auto is allowed it inserts the `threadLabel`, marks the suggestion accepted, records an `autonomous_action` receipt, and emits a `label_changed` activity log entry tagged `source: "autonomous"`.
- **Undo handlers** (M2.6): `autonomous-action.undo` reverses label / linked PR / duplicate / status actions on the server, with a mirrored optimistic handler on the client. Each undo writes a corresponding activity log entry tagged `source: "autonomous_undo"`. (Toast UI from M2.5 stays deferred.)
- **Thread activity log** (M2.7): `<Update />` renders FrontDesk-attributed entries with a Bot icon, "auto-" / "undid auto-" verb prefixes, and a `[view signal]` link.

Schema touch-up: `autonomousActionMetadata.duplicate` now carries `previousStatus` so undo can restore the original status.

## Test plan
- [ ] In Settings → Support Intelligence, change Label autonomy to Auto and save; verify destructive/customer-facing rows show the locked tooltip and disabled Auto button
- [ ] Ingest a thread that should match an existing label; confirm the label is applied automatically, an `autonomous_action` row exists, and the thread shows a "FrontDesk auto-labeled as …" entry with Bot icon + [view signal] link
- [ ] Trigger Undo on the autonomous action row; confirm the label is removed, a "FrontDesk undid auto-labeled …" entry appears, and `autonomousAction.undoneAt` is set
- [ ] Verify with autonomy set to Suggest, the same ingest still produces a pending suggestion (no auto-apply, no activity log entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-signal autonomy controls (Off/Suggest/Auto) for Support Intelligence and shows autonomous actions in thread history with undo. Auto is locked for destructive or customer-facing signals.

- **New Features**
  - Settings → Support Intelligence → Automation: per-signal toggle grid; Auto disabled with tooltip on locked signals; saves via `organization.setSignalAutonomy` with server re-validation; hides pattern signals until detectors ship.
  - Worker: auto-applies label suggestions when `label` autonomy is Auto using `getOrgAutonomy` + `canDoAutonomously`; skips duplicates; records `autonomous_action` and writes `label_changed` updates tagged `source: "autonomous"`.
  - Undo: server and optimistic client reverse label/linked PR/duplicate/status and log updates tagged `source: "autonomous_undo"`.
  - Thread updates UI: shows FrontDesk with Bot icon, "auto-" / "undid auto-" prefixes, label add/remove text, and a `[view signal]` link.

- **Bug Fixes**
  - Safe metadata parsing for undo: `parseAutonomousActionMetadata` returns null on malformed payloads and handlers bail early, preventing crashes and avoiding marking corrupted rows as undone.
  - Linked PR undo now includes the unlinked PR id in the activity entry (server + optimistic).
  - Status undo populates `newStatusLabel` from a shared map to prevent blank labels.
  - Auto-apply updates the in-loop applied set to avoid re-inserting the same label.

<sup>Written for commit 95e6fa5f6ff618d331b9ab57eb6f079e28eb1d27. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automation settings in organization configuration to manage per-signal autonomy.
  * Auto-apply AI label suggestions when org autonomy permits.
  * Organization autonomy retrieval for worker processes.

* **Improvements**
  * Enhanced undo for autonomous actions—restores prior state and records activity logs.
  * UI: clearer bot/autonomous update display with actor name, bot icon, and signal view links.

* **Schema**
  * Added autonomy check helper and structured autonomous-action metadata (duplicate now includes previous status)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->