### PR TITLE
feat(signals): leverage report window fallback and dev autonomous-action seeding

### DIFF
--- a/apps/api/src/live-state/router/autonomous-action.ts
+++ b/apps/api/src/live-state/router/autonomous-action.ts
@@ -1,6 +1,8 @@
 import {
+  type AutonomousActionMetadata,
   autonomousActionMetadataSchema,
   parseAutonomousActionMetadata,
+  type SignalType,
   signalTypeSchema,
   STATUS_LABELS,
 } from "@workspace/schemas/signals";
@@ -148,5 +150,75 @@ export default privateRoute
       }
 
       return db.autonomousAction.update(row.id, { undoneAt: now });
+    }),
+    seedFake: mutation(
+      z.object({
+        organizationId: z.string(),
+        count: z.number().min(1).max(50).default(8),
+      }),
+    ).handler(async ({ req, db }) => {
+      if (process.env.NODE_ENV === "production") {
+        throw new Error("DEV_ONLY");
+      }
+      authorize(req, { organizationId: req.input.organizationId });
+
+      const types: SignalType[] = [
+        "label",
+        "duplicate",
+        "linked_pr",
+        "status",
+        "pending_reply",
+      ];
+      const now = Date.now();
+      const rows = [];
+      for (let i = 0; i < req.input.count; i++) {
+        const signalType = types[Math.floor(Math.random() * types.length)]!;
+        const appliedAt = new Date(
+          now - Math.floor(Math.random() * 24 * 60 * 60 * 1000),
+        );
+        const metadata: AutonomousActionMetadata | null =
+          signalType === "label"
+            ? { kind: "label", labelId: `fake-label-${ulid().toLowerCase()}` }
+            : signalType === "linked_pr"
+              ? { kind: "linked_pr", prId: `fake-pr-${ulid().toLowerCase()}` }
+              : signalType === "duplicate"
+                ? {
+                    kind: "duplicate",
+                    relatedThreadId: `fake-thread-${ulid().toLowerCase()}`,
+                    score: Math.random(),
+                    previousStatus: 0,
+                  }
+                : signalType === "status"
+                  ? { kind: "status", previousStatus: 0 }
+                  : null;
+        const row = await db.autonomousAction.insert({
+          id: ulid().toLowerCase(),
+          organizationId: req.input.organizationId,
+          signalType,
+          entityId: `fake-${ulid().toLowerCase()}`,
+          appliedAt,
+          undoneAt: null,
+          metadataStr: metadata ? JSON.stringify(metadata) : null,
+        });
+        rows.push(row);
+      }
+      return { inserted: rows.length };
+    }),
+    clearFake: mutation(
+      z.object({ organizationId: z.string() }),
+    ).handler(async ({ req, db }) => {
+      if (process.env.NODE_ENV === "production") {
+        throw new Error("DEV_ONLY");
+      }
+      authorize(req, { organizationId: req.input.organizationId });
+
+      const now = new Date();
+      const rows = await db.autonomousAction
+        .where({ organizationId: req.input.organizationId, undoneAt: null })
+        .get();
+      for (const row of rows) {
+        await db.autonomousAction.update(row.id, { undoneAt: now });
+      }
+      return { cleared: rows.length };
     }),
   }));

--- a/apps/web/src/components/devtools/devtools-menu/signals-submenu.tsx
+++ b/apps/web/src/components/devtools/devtools-menu/signals-submenu.tsx
@@ -160,11 +160,74 @@ const ForceDigestMenuItem = () => {
   );
 };
 
+const SeedLeverageActionsMenuItem = () => {
+  const currentOrg = useAtomValue(activeOrganizationAtom);
+
+  const handleSeed = async () => {
+    if (!currentOrg?.id) {
+      toast.error("No organization selected");
+      return;
+    }
+
+    try {
+      const res = await fetchClient.mutate.autonomousAction.seedFake({
+        organizationId: currentOrg.id,
+        count: 8,
+      });
+      toast.success(`Seeded ${res.inserted} autonomous actions`);
+    } catch (err) {
+      console.error("Failed to seed autonomous actions:", err);
+      toast.error("Failed to seed autonomous actions");
+    }
+  };
+
+  return (
+    <MenuItem
+      onClick={handleSeed}
+      aria-label="Seed fake autonomous actions for the leverage report"
+    >
+      Seed leverage actions
+    </MenuItem>
+  );
+};
+
+const ClearLeverageActionsMenuItem = () => {
+  const currentOrg = useAtomValue(activeOrganizationAtom);
+
+  const handleClear = async () => {
+    if (!currentOrg?.id) {
+      toast.error("No organization selected");
+      return;
+    }
+
+    try {
+      const res = await fetchClient.mutate.autonomousAction.clearFake({
+        organizationId: currentOrg.id,
+      });
+      toast.success(`Cleared ${res.cleared} autonomous actions`);
+    } catch (err) {
+      console.error("Failed to clear autonomous actions:", err);
+      toast.error("Failed to clear autonomous actions");
+    }
+  };
+
+  return (
+    <MenuItem
+      onClick={handleClear}
+      aria-label="Clear all autonomous actions for the current organization"
+    >
+      Clear leverage actions
+    </MenuItem>
+  );
+};
+
 export const SignalsSubmenu = () => {
   return (
     <>
       <AddPendingReplyMenuItem />
       <AddLoopToCloseMenuItem />
+      <SeedLeverageActionsMenuItem />
+      <ClearLeverageActionsMenuItem />
       <ForceDigestMenuItem />
     </>
   );

--- a/apps/web/src/components/signals/leverage-report.tsx
+++ b/apps/web/src/components/signals/leverage-report.tsx
@@ -63,11 +63,37 @@ export function LeverageReport({
     return (Date.now() - organizationCreatedAt.getTime()) / (1000 * 60 * 60 * 24);
   }, [organizationCreatedAt]);
 
-  const inWindow = allActions
-    ? allActions.filter(
-        (a) => new Date(a.appliedAt).getTime() >= windowStart.getTime(),
-      )
-    : [];
+  // "Since visit" uses previousVisitAt; if the user comes back soon, that window
+  // can be seconds wide and show nothing even when recent history exists. Fall
+  // back to last 24h in that case only.
+  const { inWindow, reportWindowStart, effectiveHeadingMode } = useMemo(() => {
+      const now = Date.now();
+      const last24hStart = new Date(now - 24 * 60 * 60 * 1000);
+      const filterFromStart = (start: Date) =>
+        allActions
+          ? allActions.filter(
+              (a) => new Date(a.appliedAt).getTime() >= start.getTime(),
+            )
+          : [];
+
+      const primary = filterFromStart(windowStart);
+      if (
+        primary.length === 0 &&
+        (allActions?.length ?? 0) > 0 &&
+        mode === "since-visit"
+      ) {
+        return {
+          inWindow: filterFromStart(last24hStart),
+          reportWindowStart: last24hStart,
+          effectiveHeadingMode: "last-24h" as const,
+        };
+      }
+      return {
+        inWindow: primary,
+        reportWindowStart: windowStart,
+        effectiveHeadingMode: mode,
+      };
+    }, [allActions, windowStart, mode]);
 
   const isNewOrg =
     (orgDaysOld == null || orgDaysOld < NEW_ORG_DAY_THRESHOLD) &&
@@ -102,7 +128,7 @@ export function LeverageReport({
 
   const total = inWindow.length;
   const heading =
-    mode === "since-visit" && visit.previousVisitAt
+    effectiveHeadingMode === "since-visit" && visit.previousVisitAt
       ? `Since your last visit · ${formatRelativeTime(visit.previousVisitAt)}`
       : "Last 24 hours";
 
@@ -142,7 +168,7 @@ export function LeverageReport({
                 to="/app/threads"
                 search={{
                   signalType: type,
-                  since: windowStart.toISOString(),
+                  since: reportWindowStart.toISOString(),
                 }}
                 onClick={() =>
                   posthog?.capture("signal:report_link_clicked", {

--- a/apps/web/src/routes/app/route.tsx
+++ b/apps/web/src/routes/app/route.tsx
@@ -106,6 +106,7 @@ function App() {
             agentChats: {
               include: { messages: true },
             },
+            autonomousActions: true,
           },
         },
       }),


### PR DESCRIPTION
## Summary

Adds **non-production** `autonomousAction.seedFake` / `autonomousAction.clearFake` mutations so local/dev can populate the leverage report, plus devtools menu entries. Fixes **"since visit"** showing nothing when the window is tiny but recent actions exist by falling back to the **last 24h** and aligning thread deep links with the effective window. Preloads `autonomousActions` on the app route so the report has data.

## Changes

- **API**: `seedFake` / `clearFake` (guarded with `NODE_ENV === "production"` → `DEV_ONLY`)
- **Web devtools**: "Seed leverage actions" / "Clear leverage actions" under Signals
- **Leverage report**: fallback window + `reportWindowStart` for thread filters
- **App route**: include `autonomousActions` in live-state preload

## Test plan

- [ ] Non-prod: seed from devtools, confirm leverage report shows actions
- [ ] Clear from devtools, confirm report empties appropriately
- [ ] Return after short gap with "since visit" mode: confirm fallback to last 24h when appropriate
- [ ] Confirm production rejects seed/clear (or is unreachable)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add dev-only tools to seed and clear autonomous actions for the leverage report, plus a safe fallback when "Since visit" is empty. Also preload `autonomousActions` so the report is populated on first load.

- **New Features**
  - API mutations: `seedFake` and `clearFake` (DEV_ONLY; blocked in production).
  - Web devtools: “Seed leverage actions” and “Clear leverage actions” under Signals.
  - App route now preloads `autonomousActions` in live state.

- **Bug Fixes**
  - Leverage report falls back to last 24h when a tiny “Since visit” window would show nothing; heading reflects the effective window.
  - Thread deep links use the effective start time (`reportWindowStart`) so the `since` filter matches the report.

<sup>Written for commit 903902f040709bed15fe71e2e218d766afef47b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added developer tools to seed and clear test autonomous action data for testing purposes.

* **Bug Fixes**
  * Improved signals report window logic to automatically fall back to the last 24 hours when the current reporting period contains no data, ensuring users always see available information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->