### PR TITLE
feat(worker): instrument pipeline with evlog AI cost tracking

### DIFF
--- a/apps/worker/src/handlers/crawl-documentation.ts
+++ b/apps/worker/src/handlers/crawl-documentation.ts
@@ -3,6 +3,7 @@ import { embed } from "ai";
 import { createHash } from "node:crypto";
 import type { Job } from "bullmq";
 import { createAILogger, createLogger, log } from "@workspace/utils/logging";
+import { AI_PRICING } from "../lib/ai-pricing";
 import { fetchClient } from "../lib/database/client";
 import {
   type DocumentationChunkPayload,
@@ -257,7 +258,7 @@ export const handleCrawlDocumentation = async (
     organizationId,
     baseUrl,
   });
-  const ai = createAILogger(requestLog);
+  const ai = createAILogger(requestLog, { cost: AI_PRICING });
   let status = 200;
 
   log.info(

--- a/apps/worker/src/handlers/embed-pr.ts
+++ b/apps/worker/src/handlers/embed-pr.ts
@@ -9,6 +9,7 @@ import {
   log,
 } from "@workspace/utils/logging";
 import z from "zod";
+import { AI_PRICING } from "../lib/ai-pricing";
 import { type PrPayload, upsertPrVector } from "../lib/qdrant/pull-requests";
 import { matchPrToThreads } from "./match-pr-threads";
 
@@ -139,14 +140,7 @@ export const summarizePr = async (
   requestLog?: ReturnType<typeof createLogger>,
 ): Promise<z.infer<typeof prSummarySchema>> => {
   const localRequestLog = requestLog ?? createLogger({ action: "summarize-pr" });
-  const localAi =
-    ai ??
-    createAILogger(localRequestLog, {
-      cost: {
-        "claude-sonnet-4.6": { input: 3, output: 15 },
-        "anthropic/claude-sonnet-4.6": { input: 3, output: 15 },
-      },
-    });
+  const localAi = ai ?? createAILogger(localRequestLog, { cost: AI_PRICING });
 
   const prompt = `
 You are analyzing a merged pull request to determine what user-facing issue it fixes or what change it introduces. Your output will be used to match this PR against open support threads.
@@ -288,12 +282,7 @@ export const handleEmbedPr = async (job: Job<EmbedPrJobData>) => {
     prRef,
     organizationId: data.organizationId,
   });
-  const ai = createAILogger(requestLog, {
-    cost: {
-      "claude-sonnet-4.6": { input: 3, output: 15 },
-      "anthropic/claude-sonnet-4.6": { input: 3, output: 15 },
-    },
-  });
+  const ai = createAILogger(requestLog, { cost: AI_PRICING });
   let status = 200;
 
   try {

--- a/apps/worker/src/lib/ai-pricing.ts
+++ b/apps/worker/src/lib/ai-pricing.ts
@@ -1,0 +1,11 @@
+// USD per 1M tokens. Keep in sync with provider pricing pages.
+// Embedding models are billed as input-only; we set output=0 so
+// estimatedCost still computes correctly through the same code path.
+export const AI_PRICING = {
+  "anthropic/claude-sonnet-4.6": { input: 3, output: 15 },
+  "claude-sonnet-4.6": { input: 3, output: 15 },
+  "gemini-3-flash-preview": { input: 0.3, output: 2.5 },
+  "gemini-2.5-flash": { input: 0.3, output: 2.5 },
+  "gemini-embedding-001": { input: 0.15, output: 0 },
+  "google/gemini-embedding-001": { input: 0.15, output: 0 },
+} as const satisfies Record<string, { input: number; output: number }>;

--- a/apps/worker/src/pipeline/processors/embed-messages.ts
+++ b/apps/worker/src/pipeline/processors/embed-messages.ts
@@ -1,8 +1,10 @@
 import { google } from "@ai-sdk/google";
+import { createAILogger, createLogger } from "@workspace/utils/logging";
 import { jsonContentToPlainText, safeParseJSON } from "@workspace/utils/tiptap";
 import { embed } from "ai";
 import { createHash } from "node:crypto";
 import { ULIDtoUUID } from "ulid-uuid-converter";
+import { AI_PRICING } from "../../lib/ai-pricing";
 import {
   deleteStaleMessageVectors,
   type MessagePayload,
@@ -35,13 +37,14 @@ const computeSha256 = (data: string): string => {
  */
 const generateMessageEmbedding = async (
   text: string,
+  ai?: ReturnType<typeof createAILogger>,
 ): Promise<number[] | null> => {
   if (!text || text.trim().length === 0) {
     return null;
   }
 
   try {
-    const { embedding } = await embed({
+    const { embedding, usage } = await embed({
       model: embeddingModel,
       value: text,
       providerOptions: {
@@ -49,6 +52,12 @@ const generateMessageEmbedding = async (
           taskType: "RETRIEVAL_DOCUMENT",
         },
       },
+    });
+    ai?.captureEmbed({
+      usage,
+      model: EMBEDDING_MODEL,
+      dimensions: embedding.length,
+      count: 1,
     });
 
     const norm = Math.hypot(...embedding);
@@ -93,8 +102,19 @@ export const embedMessagesProcessor: ProcessorDefinition<EmbedMessagesOutput> =
     ): Promise<ProcessorResult<EmbedMessagesOutput>> {
       const { thread, threadId } = context;
       const messages = thread.messages ?? [];
+      const requestLog = createLogger({
+        action: "pipeline.embed-messages",
+        processor: "embed-messages",
+        threadId,
+        organizationId: thread.organizationId,
+        jobId: context.context.jobId,
+        messageCount: messages.length,
+      });
+      const ai = createAILogger(requestLog, { cost: AI_PRICING });
+      let status = 200;
 
       if (messages.length === 0) {
+        requestLog.emit({ status });
         return {
           threadId,
           success: true,
@@ -155,7 +175,7 @@ export const embedMessagesProcessor: ProcessorDefinition<EmbedMessagesOutput> =
 
           const batchResults = await Promise.all(
             batch.map(async ({ message, plainText, index }) => {
-              const embedding = await generateMessageEmbedding(plainText);
+              const embedding = await generateMessageEmbedding(plainText, ai);
               if (!embedding) return null;
               const qdrantPointId = ULIDtoUUID(message.id.toUpperCase(), {
                 nullOnInvalidInput: true,
@@ -227,15 +247,21 @@ export const embedMessagesProcessor: ProcessorDefinition<EmbedMessagesOutput> =
           },
         };
       } catch (error) {
+        status = 500;
         console.error(
           `Embed-messages processor failed for thread ${threadId}:`,
           error,
+        );
+        requestLog.error(
+          `Embed-messages failed for thread ${threadId}: ${error instanceof Error ? error.message : String(error)}`,
         );
         return {
           threadId,
           success: false,
           error: error instanceof Error ? error.message : String(error),
         };
+      } finally {
+        requestLog.emit({ status });
       }
     },
   };

--- a/apps/worker/src/pipeline/processors/embed.ts
+++ b/apps/worker/src/pipeline/processors/embed.ts
@@ -1,6 +1,8 @@
 import { google } from "@ai-sdk/google";
+import { createAILogger, createLogger } from "@workspace/utils/logging";
 import { embed } from "ai";
 import { createHash } from "node:crypto";
+import { AI_PRICING } from "../../lib/ai-pricing";
 import {
   type ThreadPayload,
   upsertThreadVector,
@@ -36,13 +38,16 @@ const createSummaryText = (summary: ParsedSummary): string => {
 /**
  * Generate embedding vector from text
  */
-const generateEmbedding = async (text: string): Promise<number[] | null> => {
+const generateEmbedding = async (
+  text: string,
+  ai?: ReturnType<typeof createAILogger>,
+): Promise<number[] | null> => {
   if (!text || text.trim().length === 0) {
     return null;
   }
 
   try {
-    const { embedding } = await embed({
+    const { embedding, usage } = await embed({
       model: embeddingModel,
       value: text,
       providerOptions: {
@@ -50,6 +55,12 @@ const generateEmbedding = async (text: string): Promise<number[] | null> => {
           taskType: "SEMANTIC_SIMILARITY",
         },
       },
+    });
+    ai?.captureEmbed({
+      usage,
+      model: EMBEDDING_MODEL,
+      dimensions: embedding.length,
+      count: 1,
     });
 
     // Normalize the embedding vector
@@ -141,6 +152,15 @@ export const embedProcessor: ProcessorDefinition<EmbedOutput> = {
     context: ProcessorExecuteContext,
   ): Promise<ProcessorResult<EmbedOutput>> {
     const { context: jobContext, thread, threadId } = context;
+    const requestLog = createLogger({
+      action: "pipeline.embed",
+      processor: "embed",
+      threadId,
+      organizationId: thread.organizationId,
+      jobId: jobContext.jobId,
+    });
+    const ai = createAILogger(requestLog, { cost: AI_PRICING });
+    let status = 200;
 
     const summarizeOutput = jobContext.getProcessorOutput<SummarizeOutput>(
       "summarize",
@@ -148,6 +168,8 @@ export const embedProcessor: ProcessorDefinition<EmbedOutput> = {
     );
 
     if (!summarizeOutput) {
+      status = 500;
+      requestLog.emit({ status });
       return {
         threadId,
         success: false,
@@ -162,7 +184,7 @@ export const embedProcessor: ProcessorDefinition<EmbedOutput> = {
 
       const summaryText = createSummaryText(summary);
 
-      const embedding = await generateEmbedding(summaryText);
+      const embedding = await generateEmbedding(summaryText, ai);
 
       if (!embedding) {
         return {
@@ -207,12 +229,18 @@ export const embedProcessor: ProcessorDefinition<EmbedOutput> = {
         },
       };
     } catch (error) {
+      status = 500;
       console.error(`Embed processor failed for thread ${threadId}:`, error);
+      requestLog.error(
+        `Embed failed for thread ${threadId}: ${error instanceof Error ? error.message : String(error)}`,
+      );
       return {
         threadId,
         success: false,
         error: error instanceof Error ? error.message : String(error),
       };
+    } finally {
+      requestLog.emit({ status });
     }
   },
 };

--- a/apps/worker/src/pipeline/processors/suggest-duplicates.ts
+++ b/apps/worker/src/pipeline/processors/suggest-duplicates.ts
@@ -1,10 +1,12 @@
 import { google } from "@ai-sdk/google";
 import { computeUrgency } from "@workspace/schemas/signals";
+import { createAILogger, createLogger } from "@workspace/utils/logging";
 import { jsonContentToPlainText, safeParseJSON } from "@workspace/utils/tiptap";
 import { generateText, Output } from "ai";
 import { createHash } from "node:crypto";
 import { ulid } from "ulid";
 import z from "zod";
+import { AI_PRICING } from "../../lib/ai-pricing";
 import { fetchClient } from "../../lib/database/client";
 import type {
   ProcessorDefinition,
@@ -98,7 +100,8 @@ const evaluateDuplicates = async (
     title: string;
     shortDescription: string;
     score: number;
-  }>
+  }>,
+  ai?: ReturnType<typeof createAILogger>,
 ): Promise<DuplicateEvaluation[]> => {
   if (candidates.length === 0) {
     return [];
@@ -111,8 +114,9 @@ const evaluateDuplicates = async (
     )
     .join("\n\n");
 
+  const baseModel = google("gemini-3-flash-preview");
   const { output: aiResult } = await generateText({
-    model: google("gemini-3-flash-preview"),
+    model: ai ? ai.wrap(baseModel) : baseModel,
     output: Output.object({
       schema: evaluationSchema,
     }),
@@ -179,6 +183,15 @@ export const suggestDuplicatesProcessor: ProcessorDefinition<SuggestDuplicatesOu
     ): Promise<ProcessorResult<SuggestDuplicatesOutput>> {
       const { context: jobContext, thread, threadId } = context;
       const organizationId = thread.organizationId;
+      const requestLog = createLogger({
+        action: "pipeline.suggest-duplicates",
+        processor: "suggest-duplicates",
+        threadId,
+        organizationId,
+        jobId: jobContext.jobId,
+      });
+      const ai = createAILogger(requestLog, { cost: AI_PRICING });
+      let status = 200;
 
       try {
         console.log(`Suggesting duplicates for thread ${threadId}`);
@@ -256,7 +269,8 @@ export const suggestDuplicatesProcessor: ProcessorDefinition<SuggestDuplicatesOu
         // Evaluate duplicates using LLM
         const evaluations = await evaluateDuplicates(
           currentThreadData,
-          candidateData
+          candidateData,
+          ai
         );
 
         // Find the best duplicate: high confidence only, then by similarity score
@@ -375,15 +389,21 @@ export const suggestDuplicatesProcessor: ProcessorDefinition<SuggestDuplicatesOu
           },
         };
       } catch (error) {
+        status = 500;
         console.error(
           `Suggest-duplicates processor failed for thread ${threadId}:`,
           error
+        );
+        requestLog.error(
+          `Suggest-duplicates failed for thread ${threadId}: ${error instanceof Error ? error.message : String(error)}`,
         );
         return {
           threadId,
           success: false,
           error: error instanceof Error ? error.message : String(error),
         };
+      } finally {
+        requestLog.emit({ status });
       }
     },
   };

--- a/apps/worker/src/pipeline/processors/suggest-labels.ts
+++ b/apps/worker/src/pipeline/processors/suggest-labels.ts
@@ -1,10 +1,12 @@
 import { google } from "@ai-sdk/google";
-import { jsonContentToPlainText, safeParseJSON } from "@workspace/utils/tiptap";
 import { canDoAutonomously, computeUrgency } from "@workspace/schemas/signals";
+import { createAILogger, createLogger } from "@workspace/utils/logging";
+import { jsonContentToPlainText, safeParseJSON } from "@workspace/utils/tiptap";
 import { generateText, Output } from "ai";
 import { createHash } from "node:crypto";
 import { ulid } from "ulid";
 import z from "zod";
+import { AI_PRICING } from "../../lib/ai-pricing";
 import { getOrgAutonomy } from "../../lib/autonomy";
 import { fetchClient } from "../../lib/database/client";
 import type {
@@ -48,6 +50,7 @@ const computeSha256 = (data: string): string => {
 const generateLabelSuggestions = async (
   thread: ProcessorExecuteContext["thread"],
   labels: Label[],
+  ai?: ReturnType<typeof createAILogger>,
 ): Promise<string[]> => {
   const enabledLabels = labels.filter((l) => l.enabled);
 
@@ -73,8 +76,9 @@ const generateLabelSuggestions = async (
     name: l.name,
   }));
 
+  const baseModel = google("gemini-3-flash-preview");
   const { output: aiResult } = await generateText({
-    model: google("gemini-3-flash-preview"),
+    model: ai ? ai.wrap(baseModel) : baseModel,
     output: Output.object({
       schema: z.object({
         labelIds: z
@@ -134,6 +138,15 @@ export const suggestLabelsProcessor: ProcessorDefinition<SuggestLabelsOutput> =
     ): Promise<ProcessorResult<SuggestLabelsOutput>> {
       const { thread, threadId } = context;
       const organizationId = thread.organizationId;
+      const requestLog = createLogger({
+        action: "pipeline.suggest-labels",
+        processor: "suggest-labels",
+        threadId,
+        organizationId,
+        jobId: context.context.jobId,
+      });
+      const ai = createAILogger(requestLog, { cost: AI_PRICING });
+      let status = 200;
 
       try {
         console.log(`Suggesting labels for thread ${threadId}`);
@@ -173,6 +186,7 @@ export const suggestLabelsProcessor: ProcessorDefinition<SuggestLabelsOutput> =
         const suggestedLabelIds = await generateLabelSuggestions(
           thread,
           allLabels,
+          ai,
         );
 
         const autonomyMap = await getOrgAutonomy(organizationId);
@@ -301,15 +315,21 @@ export const suggestLabelsProcessor: ProcessorDefinition<SuggestLabelsOutput> =
           data: { labelIds: filteredSuggestedLabelIds, cached: false },
         };
       } catch (error) {
+        status = 500;
         console.error(
           `Suggest-labels processor failed for thread ${threadId}:`,
           error,
+        );
+        requestLog.error(
+          `Suggest-labels failed for thread ${threadId}: ${error instanceof Error ? error.message : String(error)}`,
         );
         return {
           threadId,
           success: false,
           error: error instanceof Error ? error.message : String(error),
         };
+      } finally {
+        requestLog.emit({ status });
       }
     },
   };

--- a/apps/worker/src/pipeline/processors/suggest-status.ts
+++ b/apps/worker/src/pipeline/processors/suggest-status.ts
@@ -1,10 +1,12 @@
 import { google } from "@ai-sdk/google";
 import { computeUrgency } from "@workspace/schemas/signals";
+import { createAILogger, createLogger } from "@workspace/utils/logging";
 import { jsonContentToPlainText, safeParseJSON } from "@workspace/utils/tiptap";
 import { generateText, Output } from "ai";
 import { createHash } from "node:crypto";
 import { ulid } from "ulid";
 import z from "zod";
+import { AI_PRICING } from "../../lib/ai-pricing";
 import { fetchClient } from "../../lib/database/client";
 import type {
   ProcessorDefinition,
@@ -98,6 +100,7 @@ REASONING FORMAT:
 const generateStatusSuggestion = async (
   thread: ProcessorExecuteContext["thread"],
   currentStatus: number,
+  ai?: ReturnType<typeof createAILogger>,
 ): Promise<{
   suggestedStatus: number | null;
   confidence: number;
@@ -139,8 +142,9 @@ const generateStatusSuggestion = async (
     .map(([status, label]) => `- ${label} (${status})`)
     .join("\n");
 
+  const baseModel = google("gemini-3-flash-preview");
   const { output: aiResult } = await generateText({
-    model: google("gemini-3-flash-preview"),
+    model: ai ? ai.wrap(baseModel) : baseModel,
     output: Output.object({
       schema: z.object({
         suggestedStatus: z
@@ -249,6 +253,15 @@ export const suggestStatusProcessor: ProcessorDefinition<SuggestStatusOutput> =
       const { thread, threadId } = context;
       const organizationId = thread.organizationId;
       const currentStatus = thread.status ?? 0;
+      const requestLog = createLogger({
+        action: "pipeline.suggest-status",
+        processor: "suggest-status",
+        threadId,
+        organizationId,
+        jobId: context.context.jobId,
+      });
+      const ai = createAILogger(requestLog, { cost: AI_PRICING });
+      let status = 200;
 
       try {
         console.log(
@@ -256,7 +269,7 @@ export const suggestStatusProcessor: ProcessorDefinition<SuggestStatusOutput> =
         );
 
         const { suggestedStatus, confidence, reasoning } =
-          await generateStatusSuggestion(thread, currentStatus);
+          await generateStatusSuggestion(thread, currentStatus, ai);
 
         // Get existing status suggestion for this thread
         const existingSuggestions = (await fetchClient.query.suggestion
@@ -345,15 +358,21 @@ export const suggestStatusProcessor: ProcessorDefinition<SuggestStatusOutput> =
           },
         };
       } catch (error) {
+        status = 500;
         console.error(
           `Suggest-status processor failed for thread ${threadId}:`,
           error,
+        );
+        requestLog.error(
+          `Suggest-status failed for thread ${threadId}: ${error instanceof Error ? error.message : String(error)}`,
         );
         return {
           threadId,
           success: false,
           error: error instanceof Error ? error.message : String(error),
         };
+      } finally {
+        requestLog.emit({ status });
       }
     },
   };

--- a/apps/worker/src/pipeline/processors/summarize.ts
+++ b/apps/worker/src/pipeline/processors/summarize.ts
@@ -1,9 +1,11 @@
 import { google } from "@ai-sdk/google";
 import type { InferLiveObject } from "@live-state/sync";
+import { createAILogger, createLogger } from "@workspace/utils/logging";
 import { generateText, Output } from "ai";
 import type { schema } from "api/schema";
 import { createHash } from "node:crypto";
 import z from "zod";
+import { AI_PRICING } from "../../lib/ai-pricing";
 import type { ParsedSummary } from "../../types";
 import type {
   ProcessorDefinition,
@@ -96,6 +98,7 @@ export const summarizeThread = async (
     typeof schema.thread,
     { messages: true; labels: { label: true } }
   >,
+  ai?: ReturnType<typeof createAILogger>,
 ): Promise<ParsedSummary> => {
   console.log(`Summarizing thread ${thread.id}`);
   const firstMessage = thread.messages?.sort((a, b) =>
@@ -162,8 +165,9 @@ Think: "If another user has the exact same underlying problem with different wor
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
+      const baseModel = google("gemini-3-flash-preview");
       const { output } = await generateText({
-        model: google("gemini-3-flash-preview"),
+        model: ai ? ai.wrap(baseModel) : baseModel,
         output: Output.object({ schema: summarySchema }),
         prompt,
       });
@@ -253,11 +257,21 @@ export const summarizeProcessor: ProcessorDefinition<SummarizeOutput> = {
     context: ProcessorExecuteContext,
   ): Promise<ProcessorResult<SummarizeOutput>> {
     const { thread, threadId } = context;
+    const requestLog = createLogger({
+      action: "pipeline.summarize",
+      processor: "summarize",
+      threadId,
+      organizationId: thread.organizationId,
+      jobId: context.context.jobId,
+    });
+    const ai = createAILogger(requestLog, { cost: AI_PRICING });
+    let status = 200;
 
     try {
-      const summary = await summarizeThread(thread);
+      const summary = await summarizeThread(thread, ai);
 
       if (!summary || !summary.title || summary.title.trim().length === 0) {
+        status = 500;
         return {
           threadId,
           success: false,
@@ -271,15 +285,21 @@ export const summarizeProcessor: ProcessorDefinition<SummarizeOutput> = {
         data: { summary },
       };
     } catch (error) {
+      status = 500;
       console.error(
         `Summarize processor failed for thread ${threadId}:`,
         error,
+      );
+      requestLog.error(
+        `Summarize failed for thread ${threadId}: ${error instanceof Error ? error.message : String(error)}`,
       );
       return {
         threadId,
         success: false,
         error: error instanceof Error ? error.message : String(error),
       };
+    } finally {
+      requestLog.emit({ status });
     }
   },
 };


### PR DESCRIPTION
## Summary

- Wires `createAILogger` into every Gemini call in the ingestion pipeline so token usage, model, and estimated cost reach Axiom. Previously only `embed-pr` and `crawl-documentation` were instrumented — the hot path (thread ingestion) was invisible in cost queries.
- Adds a shared `AI_PRICING` map (`apps/worker/src/lib/ai-pricing.ts`) covering Anthropic Sonnet 4.6, Gemini 3 Flash Preview, and Gemini embedding-001. Verify the values against current provider pricing pages.
- Each processor (`summarize`, `embed`, `embed-messages`, `suggest-status`, `suggest-labels`, `suggest-duplicates`) emits one wide event per `(processor, thread)` with `action = pipeline.<name>` and fields `ai.model`, `ai.inputTokens`, `ai.outputTokens`, `ai.totalTokens`, `ai.estimatedCost`, `ai.embedding.tokens`, etc.
- `embed-pr` and `crawl-documentation` now use the shared pricing map instead of inlined Anthropic-only values.

## Why

Hard to answer "which step is driving our AI bill?" today — `summarize by tag` in Axiom shows zero `worker.embed-pr` / `worker.crawl-documentation` events for the past week, and the pipeline (which runs ~per-thread × 6 LLM/embed calls) was never instrumented at all. With this change the next batch of pipeline jobs produces token + cost data per processor.

## Test plan

- [ ] Typecheck: `cd apps/worker && bunx tsc --noEmit` — only pre-existing errors remain (live-state `Property 'messages'` issues, qdrant vector type mismatches); no new errors introduced by these changes.
- [ ] Deploy worker. Confirm `AXIOM_DATASET` + `AXIOM_TOKEN` are set on Railway worker service.
- [ ] After one batch of pipeline jobs, run in Axiom:
  ```kusto
  ['<dataset>']
  | where _time > ago(1h) and service == "worker"
  | where action startswith "pipeline."
  | summarize calls=count(), inputTokens=sum(['ai.inputTokens']),
              outputTokens=sum(['ai.outputTokens']),
              embedTokens=sum(['ai.embedding.tokens']),
              estCostUSD=sum(['ai.estimatedCost'])
    by action
  ```
- [ ] Validate `AI_PRICING` values against current Google AI / Anthropic pricing pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Instrumented the worker ingestion pipeline to log token usage and estimated cost for all Gemini/Anthropic calls. A shared `AI_PRICING` map now powers consistent cost estimates sent to Axiom.

- **New Features**
  - Added `apps/worker/src/lib/ai-pricing.ts` with pricing for `anthropic/claude-sonnet-4.6`, `gemini-3-flash-preview`, `gemini-2.5-flash`, and `gemini-embedding-001`.
  - Wrapped all model calls in `summarize`, `embed`, `embed-messages`, `suggest-status`, `suggest-labels`, `suggest-duplicates`, plus `embed-pr` and `crawl-documentation`, with `createAILogger`; each emits one event per `(processor, thread)` with `ai.*` fields and `pipeline.*` actions.
  - Replaced inlined pricing in handlers with the shared map; embedding paths now capture `usage`, dimensions, and compute `ai.estimatedCost`.

- **Migration**
  - Ensure `AXIOM_DATASET` and `AXIOM_TOKEN` are set on the worker.
  - Verify `AI_PRICING` values against current provider pricing pages.

<sup>Written for commit 8abc03721cd77f40af7e23446ede2c22caca5f8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Improvements**
- Implemented AI model pricing and cost configuration for worker operations
- Enhanced structured logging and observability across worker pipelines
- Improved error handling with better status reporting and diagnostics
- Upgraded request-scoped logging for embedding and suggestion processors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->