### PR TITLE
feat(suggestions): summary, reasoning, and suggested actions

### DIFF
--- a/apps/api/src/live-state/schema.ts
+++ b/apps/api/src/live-state/schema.ts
@@ -11,6 +11,7 @@ import {
   timestamp,
 } from "@live-state/sync";
 import type { OrganizationSettings } from "@workspace/schemas/organization";
+import type { SuggestedActions } from "@workspace/schemas/signals";
 
 const organization = object("organization", {
   id: id(),
@@ -158,6 +159,9 @@ const suggestion = object("suggestion", {
   organizationId: reference("organization.id"),
   resultsStr: string().nullable(), // JSON array of results (e.g., label IDs)
   metadataStr: string().nullable(), // Flexible JSON metadata (hash, version, etc.)
+  summary: string().nullable(), // AI-generated one-line summary; null for deterministic signals (UI renders those)
+  reasoning: string().nullable(), // AI-generated reasoning (null for deterministic signals)
+  suggestedActions: json<SuggestedActions>().nullable(), // Actions the agent can take (REPLY_SUGGESTION, ...)
   urgencyScore: number().default(0),
   dismissedAt: timestamp().nullable(),
   actedAt: timestamp().nullable(),

--- a/apps/worker/src/handlers/digest-scan.ts
+++ b/apps/worker/src/handlers/digest-scan.ts
@@ -298,6 +298,9 @@ async function createDigestSignal(params: {
     accepted: false,
     resultsStr: params.resultsStr,
     metadataStr: JSON.stringify({ digestIncludedAt: [] }),
+    summary: null,
+    reasoning: null,
+    suggestedActions: null,
     urgencyScore: normalizedType
       ? computeUrgency({ signalType: normalizedType, ageHours: 0 })
       : 0,

--- a/apps/worker/src/handlers/match-pr-threads.ts
+++ b/apps/worker/src/handlers/match-pr-threads.ts
@@ -155,6 +155,9 @@ const storeLinkedPrSuggestion = async (params: {
         reasoning,
       }),
       metadataStr: null,
+      summary: null,
+      reasoning: null,
+      suggestedActions: null,
       urgencyScore: computeUrgency({
         signalType: "linked_pr",
         ageHours: 0,

--- a/apps/worker/src/pipeline/processors/suggest-duplicates.ts
+++ b/apps/worker/src/pipeline/processors/suggest-duplicates.ts
@@ -313,6 +313,8 @@ export const suggestDuplicatesProcessor: ProcessorDefinition<SuggestDuplicatesOu
             currentThreadId: threadId,
           });
 
+          const reasoning = selectedDuplicate.reason;
+
           // Check for existing suggestion
           const existingSuggestions = (await fetchClient.query.suggestion
             .where({
@@ -336,6 +338,7 @@ export const suggestDuplicatesProcessor: ProcessorDefinition<SuggestDuplicatesOu
                 reason: selectedDuplicate.reason,
                 score: selectedDuplicate.score,
               }),
+              reasoning,
               updatedAt: now,
             });
           } else {
@@ -364,6 +367,9 @@ export const suggestDuplicatesProcessor: ProcessorDefinition<SuggestDuplicatesOu
                 score: selectedDuplicate.score,
               }),
               metadataStr: null,
+              summary: null,
+              reasoning,
+              suggestedActions: null,
               urgencyScore: computeUrgency({
                 signalType: "duplicate",
                 ageHours: 0,

--- a/apps/worker/src/pipeline/processors/suggest-labels.ts
+++ b/apps/worker/src/pipeline/processors/suggest-labels.ts
@@ -262,6 +262,9 @@ export const suggestLabelsProcessor: ProcessorDefinition<SuggestLabelsOutput> =
                 accepted: true,
                 resultsStr: null,
                 metadataStr: null,
+                summary: null,
+                reasoning: null,
+                suggestedActions: null,
                 urgencyScore: computeUrgency({
                   signalType: "label",
                   ageHours: 0,
@@ -291,6 +294,9 @@ export const suggestLabelsProcessor: ProcessorDefinition<SuggestLabelsOutput> =
               accepted: false,
               resultsStr: null,
               metadataStr: null,
+              summary: null,
+              reasoning: null,
+              suggestedActions: null,
               urgencyScore: computeUrgency({
                 signalType: "label",
                 ageHours: 0,

--- a/apps/worker/src/pipeline/processors/suggest-status.ts
+++ b/apps/worker/src/pipeline/processors/suggest-status.ts
@@ -299,6 +299,7 @@ export const suggestStatusProcessor: ProcessorDefinition<SuggestStatusOutput> =
               accepted: existingSuggestion.accepted,
               resultsStr,
               metadataStr,
+              reasoning,
               updatedAt: now,
             });
           } else {
@@ -313,6 +314,9 @@ export const suggestStatusProcessor: ProcessorDefinition<SuggestStatusOutput> =
               accepted: false,
               resultsStr,
               metadataStr,
+              summary: null,
+              reasoning,
+              suggestedActions: null,
               urgencyScore: computeUrgency({
                 signalType: "status",
                 ageHours: 0,

--- a/packages/schemas/src/signals.ts
+++ b/packages/schemas/src/signals.ts
@@ -193,6 +193,30 @@ export function parseAutonomousActionMetadata(
   }
 }
 
+export const SUGGESTED_ACTION_KINDS = ["REPLY_SUGGESTION"] as const;
+export const suggestedActionKindSchema = z.enum(SUGGESTED_ACTION_KINDS);
+export type SuggestedActionKind = z.infer<typeof suggestedActionKindSchema>;
+
+export const replySuggestionActionSchema = z.object({
+  kind: z.literal("REPLY_SUGGESTION"),
+  draftContent: z.string(),
+});
+export type ReplySuggestionAction = z.infer<typeof replySuggestionActionSchema>;
+
+export const suggestedActionSchema = z.discriminatedUnion("kind", [
+  replySuggestionActionSchema,
+]);
+export type SuggestedAction = z.infer<typeof suggestedActionSchema>;
+
+export const suggestedActionsSchema = z.array(suggestedActionSchema);
+export type SuggestedActions = z.infer<typeof suggestedActionsSchema>;
+
+export function parseSuggestedActions(input: unknown): SuggestedActions {
+  if (input == null) return [];
+  const result = suggestedActionsSchema.safeParse(input);
+  return result.success ? result.data : [];
+}
+
 export const STATUS_LABELS: Record<number, string> = {
   0: "Open",
   1: "In progress",


### PR DESCRIPTION
## Summary
Adds first-class fields on `suggestion` for AI-driven UX: optional `summary`, `reasoning`, and `suggestedActions` (typed JSON), plus shared Zod types in `@workspace/schemas` (e.g. `REPLY_SUGGESTION`).

## Changes
- **Live-state schema**: `summary`, `reasoning`, `suggestedActions` on suggestions.
- **schemas/signals**: `suggestedActionSchema`, `suggestedActionsSchema`, `parseSuggestedActions`.
- **Worker**: Set new fields to `null` for deterministic signals (digest, linked PR, labels); pass duplicate/status `reasoning` where applicable.

## Notes
- Unstaged local change in `packages/ui/src/routes/__root.tsx` was **not** included (only previously staged files were committed).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `summary`, `reasoning`, and typed `suggestedActions` to `suggestion` to support clearer UX and agent-driven actions. Adds Zod types in `@workspace/schemas` and populates the new fields across worker processors.

- **New Features**
  - Live-state `suggestion` schema: `summary` (one-line), `reasoning`, `suggestedActions` as `json<SuggestedActions>`.
  - `@workspace/schemas/signals`: `suggestedActionSchema`, `suggestedActionsSchema`, `parseSuggestedActions`, and `SUGGESTED_ACTION_KINDS` with `REPLY_SUGGESTION`.
  - Workers: set `summary/reasoning/suggestedActions` to null for deterministic signals (digest, linked PR, labels); persist `reasoning` for duplicate and status suggestions.

<sup>Written for commit d33ebaf9a19176c05682b55f807488030d38cd7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

