### PR TITLE
feat(worker): LLM re-rank for linked_pr suggestions

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -7,7 +7,8 @@
     "dev": "bun run --watch src/worker.ts",
     "start": "bun run src/worker.ts",
     "eval:prepare": "bun run src/evals/thread-similarity.prepare.ts",
-    "eval:similarity": "bun run src/evals/thread-similarity.eval.ts"
+    "eval:similarity": "bun run src/evals/thread-similarity.eval.ts",
+    "eval:match-pr-llm": "bun run src/evals/match-pr-threads-llm.eval.ts"
   },
   "dependencies": {
     "@ai-sdk/google": "^3.0.13",

--- a/apps/worker/src/evals/match-pr-threads-llm.eval.ts
+++ b/apps/worker/src/evals/match-pr-threads-llm.eval.ts
@@ -1,0 +1,574 @@
+import { createAILogger, createLogger } from "@workspace/utils/logging";
+import {
+  evaluatePrThreadMatches,
+  type MatchEvaluation,
+  type ThreadCandidate,
+} from "../handlers/match-pr-threads";
+import { AI_PRICING } from "../lib/ai-pricing";
+
+/**
+ * PR ↔ Thread LLM matcher eval
+ *
+ * Isolates the `evaluatePrThreadMatches` step (LLM re-rank) from vector search.
+ * Each case feeds a PR plus a synthetic candidate list and asserts the model's
+ * verdict on each candidate, plus that the summary contains the PR markdown link.
+ *
+ * Run with: bun run src/evals/match-pr-threads-llm.eval.ts
+ */
+
+const TEST_REPO = "acme/app";
+const prUrl = (n: number) => `https://github.com/${TEST_REPO}/pull/${n}`;
+const prLink = (n: number) => `[${TEST_REPO}#${n}](${prUrl(n)})`;
+
+interface ExpectedCandidate {
+  threadId: string;
+  matches: boolean;
+  /** If matches=true and required=true, the eval requires confidence === "high". */
+  required?: boolean;
+}
+
+interface PrInput {
+  title: string;
+  shortDescription: string;
+  prNumber: number;
+}
+
+interface TestCase {
+  name: string;
+  pr: PrInput;
+  candidates: ThreadCandidate[];
+  expected: ExpectedCandidate[];
+}
+
+// ─── Test cases ────────────────────────────────────────────────────────────
+
+const CASES: TestCase[] = [
+  // 1. Clear-cut match: PR and thread describe the exact same SSO failure.
+  {
+    name: "Direct match: SSO 401 fix vs SSO 401 thread",
+    pr: {
+      prNumber: 101,
+      title: "Fix SSO authentication returning 401 for valid tokens",
+      shortDescription:
+        "SSO sign-in returned 401 for valid tokens after the IdP migration; fixed by accepting tokens from both old and new issuer URLs.",
+    },
+    candidates: [
+      {
+        threadId: "t-sso-401",
+        title: "Can't sign in via SSO — getting 401",
+        shortDescription:
+          "User reports SSO login fails with 401 since last week, valid corporate account.",
+        score: 0.86,
+      },
+    ],
+    expected: [{ threadId: "t-sso-401", matches: true, required: true }],
+  },
+
+  // 2. Same area, different problem: PR fixes Google SSO; thread is about
+  //    email/password reset. Should NOT match.
+  {
+    name: "False-positive trap: same area (auth), different problem",
+    pr: {
+      prNumber: 102,
+      title: "Fix Google SSO callback dropping the state param",
+      shortDescription:
+        "Google OAuth callback was discarding the `state` parameter, causing the SSO handshake to fail intermittently.",
+    },
+    candidates: [
+      {
+        threadId: "t-pwd-reset",
+        title: "Password reset email never arrives",
+        shortDescription:
+          "User can't sign in and the password reset email never lands in their inbox.",
+        score: 0.78,
+      },
+    ],
+    expected: [{ threadId: "t-pwd-reset", matches: false }],
+  },
+
+  // 3. Vague topical overlap: PR adds retry logic for one specific payment
+  //    flow; thread says "payments sometimes fail" with no specifics.
+  //    Should be cautious — not a high-confidence match.
+  {
+    name: "Vague overlap: payment retry vs generic 'payments fail'",
+    pr: {
+      prNumber: 103,
+      title: "Add retry on Stripe SCA challenge timeouts",
+      shortDescription:
+        "Cards requiring SCA were failing when the 3DS challenge timed out; we now retry once on SCA timeout.",
+    },
+    candidates: [
+      {
+        threadId: "t-payments-vague",
+        title: "Payments sometimes fail",
+        shortDescription:
+          "Customer says checkout fails 'sometimes', no card type, error code, or reproduction steps provided.",
+        score: 0.77,
+      },
+    ],
+    expected: [{ threadId: "t-payments-vague", matches: false }],
+  },
+
+  // 4. Mixed batch: one strong match, one unrelated, one same-area-distractor.
+  {
+    name: "Mixed batch: 1 match, 2 distractors",
+    pr: {
+      prNumber: 104,
+      title: "Fix CSV export missing the 'status' column",
+      shortDescription:
+        "CSV exports were missing the `status` column. Added it back to the serializer.",
+    },
+    candidates: [
+      {
+        threadId: "t-csv-status",
+        title: "CSV export missing status column",
+        shortDescription:
+          "Downloaded CSV no longer contains the status column for any thread row.",
+        score: 0.88,
+      },
+      {
+        threadId: "t-csv-timeout",
+        title: "CSV export times out for large orgs",
+        shortDescription:
+          "Exports for orgs with >50k threads time out before the file is generated.",
+        score: 0.74,
+      },
+      {
+        threadId: "t-unrelated-mobile",
+        title: "Mobile app crashes on iOS 17",
+        shortDescription:
+          "App crashes on launch on iPhones running iOS 17.4 or later.",
+        score: 0.71,
+      },
+    ],
+    expected: [
+      { threadId: "t-csv-status", matches: true, required: true },
+      { threadId: "t-csv-timeout", matches: false },
+      { threadId: "t-unrelated-mobile", matches: false },
+    ],
+  },
+
+  // 5. Internal-only PR (no user-facing impact): nothing should match,
+  //    even if the candidate looks vaguely related.
+  {
+    name: "Internal-only PR rejects vaguely-related thread",
+    pr: {
+      prNumber: 105,
+      title: "Refactor thread service into smaller modules",
+      shortDescription:
+        "Pure internal refactor: split `ThreadService` into 4 smaller modules. No behavior changes.",
+    },
+    candidates: [
+      {
+        threadId: "t-thread-load",
+        title: "Threads load slowly",
+        shortDescription:
+          "Thread list takes 10+ seconds to load in the dashboard.",
+        score: 0.76,
+      },
+    ],
+    expected: [{ threadId: "t-thread-load", matches: false }],
+  },
+
+  // 6. Empty candidates → empty evaluations, no LLM call.
+  {
+    name: "Empty candidate list returns []",
+    pr: {
+      prNumber: 106,
+      title: "Fix webhook retry backoff",
+      shortDescription: "Webhook retries now use exponential backoff.",
+    },
+    candidates: [],
+    expected: [],
+  },
+
+  // 7. Inverse direction: PR adds a feature, thread is a bug report for a
+  //    different existing feature. Same product area (notifications) but
+  //    add-vs-fix mismatch.
+  {
+    name: "Feature-add PR vs bug-report thread in same area",
+    pr: {
+      prNumber: 107,
+      title: "Add Slack DM notification channel",
+      shortDescription:
+        "Adds a new opt-in Slack DM channel for thread notifications. Does not change existing email or in-app notifications.",
+    },
+    candidates: [
+      {
+        threadId: "t-email-notif-bug",
+        title: "Not receiving email notifications for new replies",
+        shortDescription:
+          "User stopped getting email notifications when teammates reply on their threads.",
+        score: 0.79,
+      },
+    ],
+    expected: [{ threadId: "t-email-notif-bug", matches: false }],
+  },
+
+  // 8. Feature request directly addressed: thread asks for dark mode,
+  //    PR ships dark mode. Summary should be feature-add framing
+  //    ("has been addressed by"), not "a fix for".
+  {
+    name: "Feature request: dark mode ship matches dark-mode request",
+    pr: {
+      prNumber: 108,
+      title: "Add system-wide dark mode",
+      shortDescription:
+        "Adds a fully themed dark mode across the app, including settings toggle and OS preference auto-detection.",
+    },
+    candidates: [
+      {
+        threadId: "t-feature-dark-mode",
+        title: "Feature request: dark mode",
+        shortDescription:
+          "Customer asks for a dark mode option, says they work nights and the bright UI is hard on their eyes.",
+        score: 0.83,
+      },
+    ],
+    expected: [{ threadId: "t-feature-dark-mode", matches: true, required: true }],
+  },
+
+  // 9. Adjacent feature: thread asks for Slack integration, PR ships a
+  //    Discord integration. Same shape of request (chat integration) but
+  //    different platform — should NOT match.
+  {
+    name: "Adjacent feature: Discord PR does NOT satisfy Slack request",
+    pr: {
+      prNumber: 109,
+      title: "Add Discord integration for thread notifications",
+      shortDescription:
+        "Ships a new Discord integration that posts new threads to a configured channel.",
+    },
+    candidates: [
+      {
+        threadId: "t-feature-slack",
+        title: "Can we get Slack notifications for new threads?",
+        shortDescription:
+          "Team uses Slack and wants new-thread notifications posted to a Slack channel.",
+        score: 0.81,
+      },
+    ],
+    expected: [{ threadId: "t-feature-slack", matches: false }],
+  },
+
+  // 10. Partial feature request: thread asks for export to PDF + CSV +
+  //     XLSX. PR ships only CSV export. Should NOT be a high-confidence
+  //     match — most of the ask is still unaddressed.
+  {
+    name: "Partial feature: PR ships CSV only, request was CSV+PDF+XLSX",
+    pr: {
+      prNumber: 110,
+      title: "Add CSV export for threads",
+      shortDescription:
+        "Adds a one-click CSV export for the thread list. PDF and Excel exports are not included in this change.",
+    },
+    candidates: [
+      {
+        threadId: "t-feature-multi-export",
+        title: "Need export to CSV, PDF, and Excel",
+        shortDescription:
+          "Customer needs to export thread data in CSV, PDF, and Excel formats for compliance reporting.",
+        score: 0.82,
+      },
+    ],
+    expected: [{ threadId: "t-feature-multi-export", matches: false }],
+  },
+
+  // 11. Behavior-change PR (not a bug fix, not a new feature): tightens a
+  //     default; thread is a complaint about the old behavior.
+  {
+    name: "Behavior change: default lowered to address complaint",
+    pr: {
+      prNumber: 111,
+      title: "Lower default session timeout from 30 days to 7 days",
+      shortDescription:
+        "Changes the default session timeout to 7 days. Existing sessions are honored; the new default applies to new sessions.",
+    },
+    candidates: [
+      {
+        threadId: "t-session-too-long",
+        title: "Sessions stay logged in for way too long",
+        shortDescription:
+          "Customer concerned that the 30-day session window is a security risk for shared devices.",
+        score: 0.84,
+      },
+    ],
+    expected: [{ threadId: "t-session-too-long", matches: true, required: true }],
+  },
+
+  // 12. Question-style thread ("how do I…?"): even if the PR adds the
+  //     capability the user is asking about, an unresolved how-to is
+  //     documentation territory, not a shipped resolution. Be cautious:
+  //     low/medium confidence is fine, NOT a high-confidence match.
+  {
+    name: "How-to question is not resolved by a feature PR",
+    pr: {
+      prNumber: 112,
+      title: "Add bulk-tag action to thread list",
+      shortDescription:
+        "Adds a bulk-tag action accessible from the thread list multi-select toolbar.",
+    },
+    candidates: [
+      {
+        threadId: "t-howto-tag",
+        title: "How do I tag a bunch of threads at once?",
+        shortDescription:
+          "User is asking whether there's any way to apply a tag to many threads in one go.",
+        score: 0.86,
+      },
+    ],
+    expected: [{ threadId: "t-howto-tag", matches: false }],
+  },
+
+  // 13. API-shape feature request: thread wants webhook signatures; PR
+  //     ships HMAC signing on outbound webhooks. Direct match.
+  {
+    name: "API feature: HMAC signing ships, matches signature request",
+    pr: {
+      prNumber: 113,
+      title: "Sign outbound webhooks with HMAC-SHA256",
+      shortDescription:
+        "All outbound webhook deliveries are now signed with HMAC-SHA256 using the org's webhook secret. Adds X-Signature header.",
+    },
+    candidates: [
+      {
+        threadId: "t-feature-webhook-signing",
+        title: "Please add signatures to webhooks",
+        shortDescription:
+          "Security team asking for signed webhook payloads so they can verify authenticity before processing.",
+        score: 0.85,
+      },
+    ],
+    expected: [
+      { threadId: "t-feature-webhook-signing", matches: true, required: true },
+    ],
+  },
+
+  // 14. Deprecation/removal PR vs feature-use thread: PR removes a
+  //     feature the user is actively asking about. Same area, opposite
+  //     direction — must not match.
+  {
+    name: "Deprecation PR does NOT match a feature-use thread",
+    pr: {
+      prNumber: 114,
+      title: "Remove legacy v1 REST API",
+      shortDescription:
+        "Removes the deprecated v1 REST endpoints. v2 is the supported API going forward.",
+    },
+    candidates: [
+      {
+        threadId: "t-v1-usage",
+        title: "v1 API returning unexpected 404s on /threads",
+        shortDescription:
+          "Customer hitting /v1/threads is getting sporadic 404s and wants help debugging.",
+        score: 0.79,
+      },
+    ],
+    expected: [{ threadId: "t-v1-usage", matches: false }],
+  },
+];
+
+// ─── Runner ────────────────────────────────────────────────────────────────
+
+interface CaseResult {
+  name: string;
+  passed: boolean;
+  issues: string[];
+  evaluations: MatchEvaluation[];
+  duration: number;
+}
+
+const requestLog = createLogger({ action: "eval.match-pr-threads-llm" });
+const ai = createAILogger(requestLog, { cost: AI_PRICING });
+
+const expectedByThreadId = (tc: TestCase): Map<string, ExpectedCandidate> => {
+  const m = new Map<string, ExpectedCandidate>();
+  for (const e of tc.expected) m.set(e.threadId, e);
+  return m;
+};
+
+const runCase = async (tc: TestCase): Promise<CaseResult> => {
+  const start = performance.now();
+  const issues: string[] = [];
+
+  const evaluations = await evaluatePrThreadMatches(
+    {
+      title: tc.pr.title,
+      shortDescription: tc.pr.shortDescription,
+      repo: TEST_REPO,
+      prNumber: tc.pr.prNumber,
+      prUrl: prUrl(tc.pr.prNumber),
+    },
+    tc.candidates,
+    ai,
+  );
+
+  if (tc.candidates.length === 0) {
+    if (evaluations.length !== 0) {
+      issues.push(
+        `Empty candidates should return [], got ${evaluations.length} evaluations`,
+      );
+    }
+    return {
+      name: tc.name,
+      passed: issues.length === 0,
+      issues,
+      evaluations,
+      duration: performance.now() - start,
+    };
+  }
+
+  // 1. Every candidate must be evaluated exactly once.
+  const seen = new Set<string>();
+  for (const e of evaluations) {
+    if (seen.has(e.threadId)) {
+      issues.push(`Duplicate evaluation for ${e.threadId}`);
+    }
+    seen.add(e.threadId);
+  }
+
+  const expected = expectedByThreadId(tc);
+  for (const c of tc.candidates) {
+    if (!seen.has(c.threadId)) {
+      issues.push(`Missing evaluation for ${c.threadId}`);
+    }
+  }
+
+  // 2. Each evaluation must agree with the expected verdict, and (if a
+  //    required match) reach "high" confidence. Summaries on positive matches
+  //    must contain the PR markdown link.
+  const link = prLink(tc.pr.prNumber);
+  for (const e of evaluations) {
+    const exp = expected.get(e.threadId);
+    if (!exp) {
+      issues.push(`Unexpected evaluation for ${e.threadId}`);
+      continue;
+    }
+
+    if (exp.matches && !e.matches) {
+      issues.push(
+        `${e.threadId}: expected match=true, got false (reason: ${e.reason})`,
+      );
+    }
+    if (!exp.matches && e.matches && e.confidence === "high") {
+      issues.push(
+        `${e.threadId}: expected non-match, got high-confidence match (reason: ${e.reason})`,
+      );
+    }
+    if (exp.matches && exp.required && e.confidence !== "high") {
+      issues.push(
+        `${e.threadId}: required high confidence, got ${e.confidence}`,
+      );
+    }
+
+    // Summary checks — only enforced when the model claims a match (the
+    // summary on a non-match isn't shown to anyone).
+    if (e.matches) {
+      if (!e.summary || e.summary.trim().length === 0) {
+        issues.push(`${e.threadId}: empty summary on a positive match`);
+      } else if (!e.summary.includes(prUrl(tc.pr.prNumber))) {
+        issues.push(
+          `${e.threadId}: summary missing PR URL (expected ${link}): "${e.summary}"`,
+        );
+      } else if (!e.summary.includes("](")) {
+        issues.push(
+          `${e.threadId}: summary contains URL but not as a markdown link: "${e.summary}"`,
+        );
+      }
+      if (e.summary && e.summary.length > 300) {
+        issues.push(
+          `${e.threadId}: summary suspiciously long (${e.summary.length} chars)`,
+        );
+      }
+    }
+
+    if (!e.reason || e.reason.trim().length === 0) {
+      issues.push(`${e.threadId}: empty reason`);
+    }
+  }
+
+  return {
+    name: tc.name,
+    passed: issues.length === 0,
+    issues,
+    evaluations,
+    duration: performance.now() - start,
+  };
+};
+
+const main = async (): Promise<void> => {
+  const startTime = performance.now();
+
+  console.log("=".repeat(72));
+  console.log("PR ↔ Thread LLM matcher eval");
+  console.log(`${CASES.length} test cases`);
+  console.log("=".repeat(72));
+
+  const results: CaseResult[] = [];
+
+  for (let i = 0; i < CASES.length; i++) {
+    const tc = CASES[i]!;
+    console.log(`\n[${i + 1}/${CASES.length}] ${tc.name}`);
+
+    try {
+      const result = await runCase(tc);
+      results.push(result);
+
+      const icon = result.passed ? "✅" : "❌";
+      console.log(`  ${icon} ${(result.duration / 1000).toFixed(2)}s`);
+
+      for (const e of result.evaluations) {
+        console.log(
+          `    - ${e.threadId}: matches=${e.matches} conf=${e.confidence}`,
+        );
+        console.log(`      reason:  ${e.reason}`);
+        if (e.matches) console.log(`      summary: ${e.summary}`);
+      }
+
+      if (!result.passed) {
+        for (const issue of result.issues) {
+          console.log(`    ! ${issue}`);
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      results.push({
+        name: tc.name,
+        passed: false,
+        issues: [`EXCEPTION: ${message}`],
+        evaluations: [],
+        duration: 0,
+      });
+      console.log(`  💥 ${message}`);
+    }
+  }
+
+  const totalTime = performance.now() - startTime;
+  const passed = results.filter((r) => r.passed).length;
+  const failed = results.length - passed;
+
+  console.log(`\n${"=".repeat(72)}`);
+  console.log("Results");
+  console.log("-".repeat(72));
+  for (const r of results) {
+    const icon = r.passed ? "✅" : "❌";
+    console.log(`  ${icon} ${r.name}`);
+    if (!r.passed) {
+      for (const issue of r.issues) {
+        console.log(`     - ${issue}`);
+      }
+    }
+  }
+  console.log("=".repeat(72));
+  console.log(
+    `${passed} passed, ${failed} failed out of ${results.length} (${(totalTime / 1000).toFixed(1)}s)`,
+  );
+  console.log("=".repeat(72));
+
+  if (failed > 0) process.exit(1);
+};
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  process.exit(1);
+});

--- a/apps/worker/src/handlers/embed-pr.ts
+++ b/apps/worker/src/handlers/embed-pr.ts
@@ -391,13 +391,14 @@ export const handleEmbedPr = async (job: Job<EmbedPrJobData>) => {
 
     log.info(
       "worker.embed-pr",
-      `🔗 Thread matching for ${prRef}: ${matchResult.suggestionsCreated} suggestions, ${matchResult.skippedAlreadyLinked} skipped (already linked)`,
+      `🔗 Thread matching for ${prRef}: ${matchResult.suggestionsCreated} suggestions, ${matchResult.skippedAlreadyLinked} skipped (already linked), ${matchResult.skippedLowConfidence} skipped (low LLM confidence)`,
     );
     requestLog.set({
       pr: {
         pointId,
         suggestionsCreated: matchResult.suggestionsCreated,
         skippedAlreadyLinked: matchResult.skippedAlreadyLinked,
+        skippedLowConfidence: matchResult.skippedLowConfidence,
       },
     });
 

--- a/apps/worker/src/handlers/match-pr-threads.ts
+++ b/apps/worker/src/handlers/match-pr-threads.ts
@@ -1,13 +1,21 @@
+import { google } from "@ai-sdk/google";
 import { computeUrgency } from "@workspace/schemas/signals";
+import {
+  createAILogger,
+  createLogger,
+  log,
+} from "@workspace/utils/logging";
+import { generateText, Output } from "ai";
 import { ulid } from "ulid";
 import { z } from "zod";
-import { log } from "@workspace/utils/logging";
+import { AI_PRICING } from "../lib/ai-pricing";
 import { fetchClient } from "../lib/database/client";
 import { searchSimilarThreads } from "../lib/qdrant/threads";
 
 const SUGGESTION_TYPE_LINKED_PR = "linked_pr";
 const MATCH_SCORE_THRESHOLD = 0.75;
 const MAX_MATCHES = 3;
+const MAX_LLM_CANDIDATES = 5;
 const OPEN_STATUSES = [0, 1]; // Open, In Progress
 
 export interface MatchPrToThreadsInput {
@@ -27,7 +35,101 @@ export interface MatchPrToThreadsResult {
   matchedThreadIds: string[];
   suggestionsCreated: number;
   skippedAlreadyLinked: number;
+  skippedLowConfidence: number;
 }
+
+export interface ThreadCandidate {
+  threadId: string;
+  title: string;
+  shortDescription: string;
+  score: number;
+}
+
+export interface MatchEvaluation {
+  threadId: string;
+  matches: boolean;
+  confidence: "high" | "medium" | "low";
+  reason: string;
+  summary: string;
+}
+
+const matchEvaluationSchema = z.object({
+  evaluations: z.array(
+    z.object({
+      threadId: z.string(),
+      matches: z.boolean(),
+      confidence: z.enum(["high", "medium", "low"]),
+      reason: z
+        .string()
+        .describe(
+          "One sentence explaining why this PR matches (or doesn't match) the thread.",
+        ),
+      summary: z
+        .string()
+        .describe(
+          "One short markdown line, written as a statement to the support agent that resolution has shipped. MUST contain a markdown link to the PR in the form [<repo>#<prNumber>](<prUrl>). Frame it as 'a fix has shipped' / 'the requested feature has been addressed' — not as speculation. Examples: 'A fix for the reported login failure has shipped in [owner/repo#123](https://github.com/owner/repo/pull/123).' or 'The requested CSV export filter has been addressed by [owner/repo#456](https://github.com/owner/repo/pull/456).' Keep it under ~200 characters.",
+        ),
+    }),
+  ),
+});
+
+export const evaluatePrThreadMatches = async (
+  pr: {
+    title: string;
+    shortDescription: string;
+    repo: string;
+    prNumber: number;
+    prUrl: string;
+  },
+  candidates: ThreadCandidate[],
+  ai: ReturnType<typeof createAILogger>,
+): Promise<MatchEvaluation[]> => {
+  if (candidates.length === 0) return [];
+
+  const candidatesText = candidates
+    .map(
+      (c, i) =>
+        `Candidate ${i + 1} (ID: ${c.threadId}):\n  Title: ${c.title}\n  Description: ${c.shortDescription}`,
+    )
+    .join("\n\n");
+
+  const prLink = `[${pr.repo}#${pr.prNumber}](${pr.prUrl})`;
+
+  const { output } = await generateText({
+    model: ai.wrap(google("gemini-3-flash-preview")),
+    output: Output.object({ schema: matchEvaluationSchema }),
+    prompt: `You are deciding whether a merged pull request resolves the user issue described in a support thread.
+
+A MATCH means: shipping this PR would resolve, fix, or directly address what the user is asking about in the thread. Be VERY conservative - when in doubt, it's NOT a match.
+
+COMMON FALSE POSITIVES TO AVOID:
+- Same product area / feature but DIFFERENT problem
+- Similar terminology but DIFFERENT root cause
+- PR touches the same surface but does not fix the user's complaint
+- Vague topical overlap is not enough — the PR must plausibly resolve the thread
+
+PULL REQUEST:
+Title: ${pr.title}
+Summary: ${pr.shortDescription}
+Markdown link to use: ${prLink}
+Markdown link target URL (for reference, do not paste raw): ${pr.prUrl}
+
+CANDIDATE THREADS:
+${candidatesText}
+
+For each candidate, produce:
+1. matches / confidence — only "high" if you are CERTAIN this PR resolves that thread.
+2. reason — one sentence explaining why it matches (or doesn't).
+3. summary — ONE short markdown line aimed at a support agent, written as a statement that resolution has shipped (not speculation). It MUST embed the PR as a markdown link using exactly this form: ${prLink}. Do NOT paste the bare URL. Keep it under ~200 characters and reference what was fixed/added for THIS specific thread.
+   Voice: declarative, past tense, resolution-shipped framing — e.g. "A fix for …", "The requested … has been addressed by …", "Support for … has shipped in …".
+   Examples:
+   - "A fix for the reported SSO 401 errors has shipped in ${prLink}."
+   - "The requested CSV 'status' column has been added by ${prLink}."
+   - "Support for the missing webhook retry behavior has shipped in ${prLink}."`,
+  });
+
+  return output.evaluations;
+};
 
 type SuggestionRow = {
   id: string;
@@ -75,6 +177,21 @@ const parseResultsStr = (resultsStr: string | null): LinkedPrResults | null => {
 /**
  * Store a linked_pr suggestion for a thread, respecting existing suggestions and dismissals.
  */
+const ensurePrLinkInSummary = (
+  summary: string,
+  repo: string,
+  prNumber: number,
+  prUrl: string,
+  reasoning: string,
+): string => {
+  const trimmed = summary.trim();
+  if (trimmed && trimmed.includes(prUrl)) {
+    return trimmed;
+  }
+  // LLM omitted the link (or returned empty) — fall back to a deterministic line
+  return `[${repo}#${prNumber}](${prUrl}) — ${reasoning}`;
+};
+
 const storeLinkedPrSuggestion = async (params: {
   threadId: string;
   organizationId: string;
@@ -85,6 +202,7 @@ const storeLinkedPrSuggestion = async (params: {
   repo: string;
   confidence: number;
   reasoning: string;
+  summary: string;
 }): Promise<boolean> => {
   const {
     threadId,
@@ -96,7 +214,16 @@ const storeLinkedPrSuggestion = async (params: {
     repo,
     confidence,
     reasoning,
+    summary: rawSummary,
   } = params;
+
+  const summary = ensurePrLinkInSummary(
+    rawSummary,
+    repo,
+    prNumber,
+    prUrl,
+    reasoning,
+  );
 
   try {
     const existingSuggestions = (await fetchClient.query.suggestion
@@ -130,6 +257,8 @@ const storeLinkedPrSuggestion = async (params: {
           confidence,
           reasoning,
         }),
+        summary,
+        reasoning,
         updatedAt: new Date(),
       });
       return true;
@@ -155,8 +284,8 @@ const storeLinkedPrSuggestion = async (params: {
         reasoning,
       }),
       metadataStr: null,
-      summary: null,
-      reasoning: null,
+      summary,
+      reasoning,
       suggestedActions: null,
       urgencyScore: computeUrgency({
         signalType: "linked_pr",
@@ -187,13 +316,21 @@ export const matchPrToThreads = async (
     matchedThreadIds: [],
     suggestionsCreated: 0,
     skippedAlreadyLinked: 0,
+    skippedLowConfidence: 0,
   };
+
+  const requestLog = createLogger({
+    action: "worker.match-pr-threads",
+    organizationId: input.organizationId,
+    prRef: `${input.owner}/${input.repo}#${input.prNumber}`,
+  });
+  const ai = createAILogger(requestLog, { cost: AI_PRICING });
 
   try {
     // Search for similar open threads using the PR embedding
     const similarThreads = await searchSimilarThreads(input.embedding, {
       organizationId: input.organizationId,
-      limit: MAX_MATCHES + 5, // Fetch extra to account for filtering
+      limit: MAX_LLM_CANDIDATES + 5, // Fetch extra to account for filtering
       scoreThreshold: MATCH_SCORE_THRESHOLD,
       statusFilter: OPEN_STATUSES,
     });
@@ -203,55 +340,96 @@ export const matchPrToThreads = async (
     }
 
     const repo = `${input.owner}/${input.repo}`;
-    let matchCount = 0;
 
+    // Filter out threads that already have a linked PR (batch fetch)
+    const candidateIds = similarThreads.map((s) => s.threadId);
+    let linkedThreadIds = new Set<string>();
+    try {
+      const existingThreads = (await fetchClient.query.thread
+        .where({ id: { $in: candidateIds } })
+        .get()) as Array<{ id: string; externalPrId: string | null }>;
+      linkedThreadIds = new Set(
+        existingThreads.filter((t) => t.externalPrId).map((t) => t.id),
+      );
+    } catch (error) {
+      log.warn(
+        "worker.match-pr-threads",
+        `Failed to batch-fetch threads for PR link check, proceeding without filter: ${formatError(error)}`,
+      );
+    }
+
+    const candidates: ThreadCandidate[] = [];
     for (const match of similarThreads) {
-      if (matchCount >= MAX_MATCHES) break;
-
-      // Fetch the thread to check if it already has a linked PR
-      try {
-        const threads = await fetchClient.query.thread
-          .where({ id: match.threadId })
-          .get();
-
-        const thread = threads[0] as
-          | { id: string; externalPrId: string | null }
-          | undefined;
-
-        if (!thread) continue;
-
-        if (thread.externalPrId) {
-          result.skippedAlreadyLinked++;
-          continue;
-        }
-      } catch (error) {
-        log.warn(
-          "worker.match-pr-threads",
-          `Failed to fetch thread ${match.threadId} for PR link check, skipping: ${formatError(error)}`,
-        );
+      if (candidates.length >= MAX_LLM_CANDIDATES) break;
+      if (linkedThreadIds.has(match.threadId)) {
+        result.skippedAlreadyLinked++;
         continue;
       }
-
-      // Create the suggestion
-      const stored = await storeLinkedPrSuggestion({
+      candidates.push({
         threadId: match.threadId,
+        title: match.payload.title,
+        shortDescription: match.payload.shortDescription,
+        score: match.score,
+      });
+    }
+
+    if (candidates.length === 0) {
+      return result;
+    }
+
+    // LLM re-rank: verify each candidate actually describes an issue this PR fixes
+    let evaluations: MatchEvaluation[] = [];
+    try {
+      evaluations = await evaluatePrThreadMatches(
+        {
+          title: input.prTitle,
+          shortDescription: input.shortDescription,
+          repo,
+          prNumber: input.prNumber,
+          prUrl: input.prUrl,
+        },
+        candidates,
+        ai,
+      );
+    } catch (error) {
+      log.error(
+        "worker.match-pr-threads",
+        `LLM evaluation failed for PR ${repo}#${input.prNumber}: ${formatError(error)}`,
+      );
+      return result;
+    }
+
+    // Pick best matches by similarity score, restricted to high-confidence positive evaluations
+    const candidateByThreadId = new Map(candidates.map((c) => [c.threadId, c]));
+    const confirmed = evaluations
+      .filter((e) => e.matches && e.confidence === "high")
+      .map((e) => ({ evaluation: e, candidate: candidateByThreadId.get(e.threadId) }))
+      .filter((x): x is { evaluation: MatchEvaluation; candidate: ThreadCandidate } =>
+        Boolean(x.candidate),
+      )
+      .sort((a, b) => b.candidate.score - a.candidate.score)
+      .slice(0, MAX_MATCHES);
+
+    result.skippedLowConfidence = candidates.length - confirmed.length;
+
+    for (const { evaluation, candidate } of confirmed) {
+      const stored = await storeLinkedPrSuggestion({
+        threadId: candidate.threadId,
         organizationId: input.organizationId,
         prId: input.prId,
         prNumber: input.prNumber,
         prTitle: input.prTitle,
         prUrl: input.prUrl,
         repo,
-        confidence: match.score,
-        reasoning: input.shortDescription,
+        confidence: candidate.score,
+        reasoning: evaluation.reason,
+        summary: evaluation.summary,
       });
 
-      if (!stored) {
-        continue;
-      }
+      if (!stored) continue;
 
       result.suggestionsCreated++;
-      result.matchedThreadIds.push(match.threadId);
-      matchCount++;
+      result.matchedThreadIds.push(candidate.threadId);
     }
 
     return result;

--- a/apps/worker/src/handlers/match-pr-threads.ts
+++ b/apps/worker/src/handlers/match-pr-threads.ts
@@ -61,11 +61,13 @@ const matchEvaluationSchema = z.object({
       confidence: z.enum(["high", "medium", "low"]),
       reason: z
         .string()
+        .min(1)
         .describe(
           "One sentence explaining why this PR matches (or doesn't match) the thread.",
         ),
       summary: z
         .string()
+        .min(1)
         .describe(
           "One short markdown line, written as a statement to the support agent that resolution has shipped. MUST contain a markdown link to the PR in the form [<repo>#<prNumber>](<prUrl>). Frame it as 'a fix has shipped' / 'the requested feature has been addressed' — not as speculation. Examples: 'A fix for the reported login failure has shipped in [owner/repo#123](https://github.com/owner/repo/pull/123).' or 'The requested CSV export filter has been addressed by [owner/repo#456](https://github.com/owner/repo/pull/456).' Keep it under ~200 characters.",
         ),
@@ -185,11 +187,13 @@ const ensurePrLinkInSummary = (
   reasoning: string,
 ): string => {
   const trimmed = summary.trim();
-  if (trimmed && trimmed.includes(prUrl)) {
+  const prLink = `[${repo}#${prNumber}](${prUrl})`;
+  // Only accept the LLM summary if it embeds the PR as a proper markdown
+  // link — a bare URL counts as a miss and falls back to the deterministic line
+  if (trimmed.includes(prLink)) {
     return trimmed;
   }
-  // LLM omitted the link (or returned empty) — fall back to a deterministic line
-  return `[${repo}#${prNumber}](${prUrl}) — ${reasoning}`;
+  return `${prLink} — ${reasoning}`;
 };
 
 const storeLinkedPrSuggestion = async (params: {
@@ -399,9 +403,15 @@ export const matchPrToThreads = async (
       return result;
     }
 
-    // Pick best matches by similarity score, restricted to high-confidence positive evaluations
+    // Dedupe LLM evaluations by threadId so a model that emits the same
+    // candidate twice can't inflate confirmed/store/skip counters.
     const candidateByThreadId = new Map(candidates.map((c) => [c.threadId, c]));
-    const confirmed = evaluations
+    const uniqueEvaluations = Array.from(
+      new Map(evaluations.map((e) => [e.threadId, e])).values(),
+    );
+
+    // Pick best matches by similarity score, restricted to high-confidence positive evaluations
+    const confirmed = uniqueEvaluations
       .filter((e) => e.matches && e.confidence === "high")
       .map((e) => ({ evaluation: e, candidate: candidateByThreadId.get(e.threadId) }))
       .filter((x): x is { evaluation: MatchEvaluation; candidate: ThreadCandidate } =>
@@ -410,7 +420,7 @@ export const matchPrToThreads = async (
       .sort((a, b) => b.candidate.score - a.candidate.score)
       .slice(0, MAX_MATCHES);
 
-    result.skippedLowConfidence = candidates.length - confirmed.length;
+    result.skippedLowConfidence = uniqueEvaluations.length - confirmed.length;
 
     for (const { evaluation, candidate } of confirmed) {
       const stored = await storeLinkedPrSuggestion({


### PR DESCRIPTION
## Summary
- Adds an LLM verification step (Gemini 3 flash) on top of the vector-similarity search used to generate `linked_pr` suggestions. Vector match alone was producing too many same-area / wrong-problem suggestions; now the model judges each top-K candidate and only `matches:true` + `confidence:"high"` become suggestions.
- The model also generates the suggestion `summary` per candidate, written in resolution-shipped voice ("A fix for … has shipped in [repo#N](url).", "The requested … has been addressed by …"). A deterministic fallback (`ensurePrLinkInSummary`) guarantees the PR markdown link is always present.
- Adds a new eval (`bun run --filter worker eval:match-pr-llm`) that isolates `evaluatePrThreadMatches` from the vector half. Cases cover fixes, feature requests, behavior changes, partial ships, deprecations, how-to questions, and same-area-wrong-direction traps — across both expected-match (required: high) and expected-non-match assertions.
- Replaces the per-candidate `fetchClient.query.thread` loop in `matchPrToThreads` with a single `$in` batch query, and threads a `skippedLowConfidence` counter through `MatchPrToThreadsResult` + the `embed-pr` log line.

## Test plan
- [ ] `bun run --filter worker eval:match-pr-llm` passes (all 14 cases).
- [ ] Manually trigger a `linked_pr` suggestion via the existing flow and confirm: (a) `suggestion.summary` contains a markdown link to the PR, (b) `suggestion.reasoning` is the LLM's per-thread explanation (not the generic PR shortDescription), (c) suggestions are no longer created when the PR is only same-area but unrelated.
- [ ] Spot-check the embed-pr log line includes `skippedLowConfidence`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an LLM re-rank step for `linked_pr` suggestions to cut same-area/wrong-problem matches and generate concise, PR-linked summaries. Tightens validation with a markdown link requirement, de-dupes LLM outputs, and adds an eval harness and counters for low-confidence skips.

- **New Features**
  - LLM verification (Gemini 3 Flash) over up to 5 vector hits; only `matches:true` with `confidence:"high"` become suggestions.
  - New eval `bun run --filter worker eval:match-pr-llm` targeting fixes, feature requests, partial ships, deprecations, how-to traps, and non-matches.

- **Refactors**
  - Batched `$in` query to skip already-linked threads; cap LLM candidates to 5 and suggestions to 3; store similarity as confidence; logs include `skippedLowConfidence`.
  - Persist per-candidate LLM `summary` and `reasoning`; dedupe evaluations by `threadId` to keep counters accurate.
  - Hardened validation: reject empty `reason`/`summary` and require a markdown PR link; `ensurePrLinkInSummary` falls back if the model omits it.

<sup>Written for commit a18670a602b36030230a502a0850fd7f60775cfa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved PR-to-thread matching accuracy by adding LLM-based evaluation following semantic search.
  * Enhanced metrics tracking for thread matching results, including skipped suggestions.

* **Chores**
  * Added evaluation commands and diagnostic tooling for PR-thread matching validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FrontDeskHQ/front-desk/pull/270)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->