### PR TITLE
refactor(web): split ThreadChip into composable primitives

### DIFF
--- a/apps/web/src/components/chips.tsx
+++ b/apps/web/src/components/chips.tsx
@@ -19,48 +19,52 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { CircleUser } from "lucide-react";
 
 const threadChipVariants = cva(
-  "flex items-center w-fit gap-1.5 cursor-default",
+  "flex items-center w-fit gap-1.5 cursor-default text-xs border h-6 rounded-sm px-2 has-[>svg:first-child]:pl-1.5 has-[>svg:last-child]:pr-1.5 bg-foreground-tertiary/15 hover:bg-foreground-tertiary/25 transition-colors",
   {
     variants: {
-      variant: {
-        chip: "text-xs border h-6 rounded-sm px-2 has-[>svg:first-child]:pl-1.5 has-[>svg:last-child]:pr-1.5 bg-foreground-tertiary/15 hover:bg-foreground-tertiary/25 transition-colors",
-        unstyled: "text-sm",
-      },
       disabled: {
         true: "opacity-50 pointer-events-none",
         false: "",
       },
     },
     defaultVariants: {
-      variant: "chip",
       disabled: false,
     },
   },
 );
 
-export function BaseThreadChip({
+type ThreadChipThread = InferLiveObject<
+  typeof schema.thread,
+  { author: { include: { user: true } } }
+>;
+
+type ThreadSummaryThread = InferLiveObject<
+  typeof schema.thread,
+  {
+    author: { include: { user: true } };
+    assignedUser: { include: { user: true } };
+  }
+>;
+
+export function ThreadChip({
   thread,
   disabled = false,
   className,
-  variant,
   ...props
 }: Omit<React.ComponentProps<typeof BaseButton>, "children"> &
   VariantProps<typeof threadChipVariants> & {
-    thread: InferLiveObject<
-      typeof schema.thread,
-      { author: { include: { user: true } }; assignedUser?: true }
-    >;
+    thread: ThreadChipThread;
   }) {
   return (
     <BaseButton
       type="button"
-      className={cn(threadChipVariants({ variant, disabled }), className)}
+      className={cn(threadChipVariants({ disabled }), className)}
       disabled={disabled ?? false}
       {...props}
     >
       <Avatar
         variant="user"
-        size={variant === "unstyled" ? "md" : "sm"}
+        size="sm"
         fallback={thread.author?.name}
         src={thread.author?.user?.image ?? undefined}
       />
@@ -74,105 +78,112 @@ export function BaseThreadChip({
   );
 }
 
-export function ThreadChip({
+export function ThreadSummaryCard({
   thread,
-  disabled,
-  className,
-  variant,
-  ...props
-}: Omit<React.ComponentProps<typeof BaseButton>, "children"> &
-  VariantProps<typeof threadChipVariants> & {
-    thread: InferLiveObject<
-      typeof schema.thread,
-      {
-        author: { include: { user: true } };
-        assignedUser: { include: { user: true } };
-      }
-    >;
-  }) {
+}: {
+  thread: ThreadSummaryThread;
+}) {
   return (
-    <HoverCard>
-      <HoverCardTrigger
-        render={
-          <BaseThreadChip
-            thread={thread}
-            disabled={disabled}
-            className={className}
-            variant={variant}
-            {...props}
+    <>
+      <div className="flex flex-col gap-1">
+        <div className="font-medium text-sm flex items-center gap-1.5">
+          <span className="text-foreground-primary">{thread.name}</span>
+          {thread.shortId != null && (
+            <span className="text-foreground-secondary tabular-nums font-normal">
+              #{thread.shortId}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <Avatar
+            variant="user"
+            size="sm"
+            fallback={thread.author?.name}
+            src={thread.author?.user?.image ?? undefined}
           />
-        }
-      />
-      <HoverCardContent className="max-w-96 w-full flex flex-col gap-3">
+          <span className="text-sm">{thread.author?.name}</span>
+          <div className="ml-2 text-xs text-muted-foreground">
+            {thread.createdAt
+              ? formatRelativeTime(thread.createdAt as Date)
+              : "Unknown date"}
+          </div>
+        </div>
+      </div>
+      <Separator />
+      <div className="grid grid-cols-3 gap-3">
         <div className="flex flex-col gap-1">
-          <div className="font-medium text-sm flex items-center gap-1.5">
-            <span className="text-foreground-primary">{thread.name}</span>
-            {thread.shortId != null && (
-              <span className="text-foreground-secondary tabular-nums font-normal">
-                #{thread.shortId}
-              </span>
+          <div className="text-xs text-muted-foreground">Status</div>
+          <div className="flex items-center gap-2">
+            <StatusIndicator status={thread.status ?? 0} />
+            <span className="text-sm">
+              <StatusText status={thread.status ?? 0} />
+            </span>
+          </div>
+        </div>
+        <div className="flex flex-col gap-1">
+          <div className="text-xs text-muted-foreground">Priority</div>
+          <div className="flex items-center gap-2">
+            <PriorityIndicator priority={thread.priority ?? 0} />
+            <span className="text-sm">
+              <PriorityText priority={thread.priority ?? 0} />
+            </span>
+          </div>
+        </div>
+        <div className="flex flex-col gap-1">
+          <div className="text-xs text-muted-foreground">Assignee</div>
+          <div className="flex items-center gap-2">
+            {thread.assignedUserId && thread.assignedUser?.name ? (
+              <>
+                <Avatar
+                  variant="user"
+                  size="md"
+                  fallback={thread.assignedUser?.name}
+                  src={thread.assignedUser?.image ?? undefined}
+                />
+                <span className="text-sm">{thread.assignedUser?.name}</span>
+              </>
+            ) : (
+              <>
+                <CircleUser className="size-4 text-muted-foreground" />
+                <span className="text-sm text-muted-foreground">
+                  Unassigned
+                </span>
+              </>
             )}
           </div>
-          <div className="flex items-center gap-2">
-            <Avatar
-              variant="user"
-              size="sm"
-              fallback={thread.author?.name}
-              src={thread.author?.user?.image ?? undefined}
-            />
-            <span className="text-sm">{thread.author?.name}</span>
-            <div className="ml-2 text-xs text-muted-foreground">
-              {thread.createdAt
-                ? formatRelativeTime(thread.createdAt as Date)
-                : "Unknown date"}
-            </div>
-          </div>
         </div>
-        <Separator />
-        <div className="grid grid-cols-3 gap-3">
-          <div className="flex flex-col gap-1">
-            <div className="text-xs text-muted-foreground">Status</div>
-            <div className="flex items-center gap-2">
-              <StatusIndicator status={thread.status ?? 0} />
-              <span className="text-sm">
-                <StatusText status={thread.status ?? 0} />
-              </span>
-            </div>
-          </div>
-          <div className="flex flex-col gap-1">
-            <div className="text-xs text-muted-foreground">Priority</div>
-            <div className="flex items-center gap-2">
-              <PriorityIndicator priority={thread.priority ?? 0} />
-              <span className="text-sm">
-                <PriorityText priority={thread.priority ?? 0} />
-              </span>
-            </div>
-          </div>
-          <div className="flex flex-col gap-1">
-            <div className="text-xs text-muted-foreground">Assignee</div>
-            <div className="flex items-center gap-2">
-              {thread.assignedUserId && thread.assignedUser?.name ? (
-                <>
-                  <Avatar
-                    variant="user"
-                    size="md"
-                    fallback={thread.assignedUser?.name}
-                    src={thread.assignedUser?.image ?? undefined}
-                  />
-                  <span className="text-sm">{thread.assignedUser?.name}</span>
-                </>
-              ) : (
-                <>
-                  <CircleUser className="size-4 text-muted-foreground" />
-                  <span className="text-sm text-muted-foreground">
-                    Unassigned
-                  </span>
-                </>
-              )}
-            </div>
-          </div>
-        </div>
+      </div>
+    </>
+  );
+}
+
+export function ThreadSummaryHoverCard({
+  thread,
+  children,
+  ...props
+}: Omit<React.ComponentProps<typeof HoverCard>, "children"> & {
+  thread: ThreadSummaryThread;
+  children: React.ReactElement;
+}) {
+  return (
+    <HoverCard {...props}>
+      <HoverCardTrigger render={children} />
+      <HoverCardContent className="max-w-96 w-full flex flex-col gap-3">
+        <ThreadSummaryCard thread={thread} />
       </HoverCardContent>
     </HoverCard>
+  );
+}
+
+export function ThreadChipWithSummary({
+  thread,
+  ...props
+}: Omit<React.ComponentProps<typeof ThreadChip>, "thread"> & {
+  thread: ThreadSummaryThread;
+}) {
+  return (
+    <ThreadSummaryHoverCard thread={thread}>
+      <ThreadChip thread={thread} {...props} />
+    </ThreadSummaryHoverCard>
   );
 }

--- a/apps/web/src/components/chips.tsx
+++ b/apps/web/src/components/chips.tsx
@@ -137,8 +137,8 @@ export function ThreadSummaryCard({
                 <Avatar
                   variant="user"
                   size="md"
-                  fallback={thread.assignedUser?.name}
-                  src={thread.assignedUser?.image ?? undefined}
+                  fallback={thread.author?.name}
+                  src={thread.author?.user?.image ?? undefined}
                 />
                 <span className="text-sm">{thread.assignedUser?.name}</span>
               </>

--- a/apps/web/src/components/markdown/rich-markdown.tsx
+++ b/apps/web/src/components/markdown/rich-markdown.tsx
@@ -4,7 +4,7 @@ import { cn } from "@workspace/ui/lib/utils";
 import { useMemo } from "react";
 import { type Components, Streamdown } from "streamdown";
 import "streamdown/styles.css";
-import { ThreadChip } from "~/components/chips";
+import { ThreadChipWithSummary } from "~/components/chips";
 import { query } from "~/lib/live-state";
 import { buildThreadParam } from "~/utils/thread";
 
@@ -134,7 +134,7 @@ function ThreadMention({ threadId }: { threadId: string }) {
   }
 
   return (
-    <ThreadChip
+    <ThreadChipWithSummary
       thread={thread}
       className="inline-flex mb-0 -translate-y-0.5"
       render={

--- a/apps/web/src/components/signals/action-row/rows.tsx
+++ b/apps/web/src/components/signals/action-row/rows.tsx
@@ -5,12 +5,13 @@ import {
   type SignalType,
   urgencyTierFromScore,
 } from "@workspace/schemas/signals";
+import { Avatar } from "@workspace/ui/components/avatar";
 import { ActionButton } from "@workspace/ui/components/button";
 import { statusValues } from "@workspace/ui/components/indicator";
 import type { schema } from "api/schema";
 import { Check, ExternalLink } from "lucide-react";
 import { z } from "zod";
-import { ThreadChip } from "~/components/chips";
+import { ThreadSummaryHoverCard } from "~/components/chips";
 import { buildThreadParam } from "~/utils/thread";
 import { ActionRow } from "./action-row";
 import {
@@ -47,18 +48,29 @@ function TitleLabel({ type }: { type: SignalType }) {
   return <span>{SIGNAL_LABEL[type]}</span>;
 }
 
-function ThreadRef({
-  thread,
-  variant,
-}: {
-  thread: ThreadWithRels | undefined;
-  variant?: "chip" | "unstyled";
-}) {
+function ThreadRef({ thread }: { thread: ThreadWithRels | undefined }) {
   if (!thread) return null;
   return (
-    <Link to="/app/threads/$id" params={{ id: buildThreadParam(thread) }}>
-      <ThreadChip thread={thread} variant={variant} />
-    </Link>
+    <ThreadSummaryHoverCard thread={thread}>
+      <Link
+        to="/app/threads/$id"
+        params={{ id: buildThreadParam(thread) }}
+        className="inline-flex items-center w-fit gap-1.5 text-sm"
+      >
+        <Avatar
+          variant="user"
+          size="md"
+          fallback={thread.author?.name}
+          src={thread.author?.user?.image ?? undefined}
+        />
+        <span className="text-foreground-primary">{thread.name}</span>
+        {thread.shortId != null && (
+          <span className="text-foreground-secondary tabular-nums">
+            #{thread.shortId}
+          </span>
+        )}
+      </Link>
+    </ThreadSummaryHoverCard>
   );
 }
 
@@ -94,7 +106,7 @@ export function StatusActionRow({
     <ActionRow.Root tier={tierFor(suggestion.urgencyScore)}>
       <ActionRow.Header>
         <ActionRow.Title>
-          <ThreadRef thread={thread} variant="unstyled" />
+          <ThreadRef thread={thread} />
         </ActionRow.Title>
         <ActionRow.Reason>
           <TitleLabel type="status" />
@@ -131,7 +143,7 @@ export function DuplicateActionRow({
     <ActionRow.Root tier={tierFor(suggestion.urgencyScore)}>
       <ActionRow.Header>
         <ActionRow.Title>
-          <ThreadRef thread={thread} variant="unstyled" />
+          <ThreadRef thread={thread} />
         </ActionRow.Title>
         <ActionRow.Reason>
           {thread && target ? (
@@ -174,7 +186,7 @@ export function LinkedPrActionRow({
     <ActionRow.Root tier={tierFor(suggestion.urgencyScore)}>
       <ActionRow.Header>
         <ActionRow.Title>
-          <ThreadRef thread={thread} variant="unstyled" />
+          <ThreadRef thread={thread} />
         </ActionRow.Title>
         <ActionRow.Reason>
           <span className="inline-flex items-center gap-1.5">
@@ -220,7 +232,7 @@ export function PendingReplyActionRow({
     <ActionRow.Root tier={tierFor(suggestion.urgencyScore)}>
       <ActionRow.Header>
         <ActionRow.Title>
-          <ThreadRef thread={thread} variant="unstyled" />
+          <ThreadRef thread={thread} />
         </ActionRow.Title>
         <ActionRow.Reason>
           <TitleLabel type="pending_reply" />
@@ -250,7 +262,7 @@ export function LoopToCloseActionRow({
     <ActionRow.Root tier={tierFor(suggestion.urgencyScore)}>
       <ActionRow.Header>
         <ActionRow.Title>
-          <ThreadRef thread={thread} variant="unstyled" />
+          <ThreadRef thread={thread} />
         </ActionRow.Title>
         <ActionRow.Reason>
           <TitleLabel type="loop_to_close" />

--- a/apps/web/src/components/threads/thread-toolbar/quick-actions.tsx
+++ b/apps/web/src/components/threads/thread-toolbar/quick-actions.tsx
@@ -20,7 +20,7 @@ import { Check, ChevronDown, CircleUser, X, Zap } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ulid } from "ulid";
-import { BaseThreadChip } from "~/components/chips";
+import { ThreadChip } from "~/components/chips";
 import {
   usePendingDuplicateSuggestions,
   usePendingLabelSuggestions,
@@ -527,7 +527,7 @@ export const QuickActionsPanel = ({
                   <div className="flex gap-2 items-center flex-wrap group">
                     <HoverCardTrigger
                       render={
-                        <BaseThreadChip
+                        <ThreadChip
                           thread={duplicateSuggestion.thread}
                           className="border-dashed bg-transparent border-input dark:hover:bg-foreground-tertiary/15"
                           onClick={handleAcceptDuplicate}

--- a/apps/web/src/components/threads/thread-toolbar/support-intelligence.tsx
+++ b/apps/web/src/components/threads/thread-toolbar/support-intelligence.tsx
@@ -22,7 +22,7 @@ import type { schema } from "api/schema";
 import { Check, ChevronDown, CircleUser, X, Zap } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ulid } from "ulid";
-import { BaseThreadChip } from "~/components/chips";
+import { ThreadChip } from "~/components/chips";
 import { mutate, query } from "~/lib/live-state";
 import { buildThreadParam } from "~/utils/thread";
 
@@ -657,7 +657,7 @@ export const Suggestions = ({
               <div className="flex gap-2 items-center flex-wrap group">
                 <HoverCardTrigger
                   render={
-                    <BaseThreadChip
+                    <ThreadChip
                       thread={duplicateSuggestion.thread}
                       className="border-dashed bg-transparent border-input dark:hover:bg-foreground-tertiary/15"
                       onClick={handleAcceptDuplicate}

--- a/apps/web/src/components/threads/updates.tsx
+++ b/apps/web/src/components/threads/updates.tsx
@@ -9,7 +9,7 @@ import {
 import { formatRelativeTime } from "@workspace/ui/lib/utils";
 import type { schema } from "api/schema";
 import { Bot, CircleUserIcon, CopySlash, Github, Tag } from "lucide-react";
-import { ThreadChip } from "~/components/chips";
+import { ThreadChipWithSummary } from "~/components/chips";
 import { query } from "~/lib/live-state";
 import { buildThreadParam } from "~/utils/thread";
 
@@ -38,7 +38,10 @@ export function Update({
   const duplicateThread = useLiveQuery(
     query.thread
       .first({ id: metadata?.duplicateOfThreadId })
-      .include({ author: { include: { user: true } }, assignedUser: true }),
+      .include({
+        author: { include: { user: true } },
+        assignedUser: { include: { user: true } },
+      }),
   );
 
   const isAutonomous = metadata?.source === "autonomous";
@@ -178,7 +181,7 @@ export function Update({
         <span className="inline-flex items-center gap-1">
           {verbPrefix}marked as duplicate of{" "}
           {duplicateThread ? (
-            <ThreadChip
+            <ThreadChipWithSummary
               thread={duplicateThread}
               className="mx-0.5"
               render={


### PR DESCRIPTION
## Summary
- Replace `BaseThreadChip` / `ThreadChip` pair with three primitives: `ThreadChip` (chip-only), `ThreadSummaryCard` (panel content), `ThreadSummaryHoverCard` (hover-card wrapper around any trigger element)
- Add `ThreadChipWithSummary` as a thin convenience composing the above
- Drop the `unstyled` chip variant; the signals action rows now render their inline thread reference directly (avatar + name + `#shortId` in a `Link`) and wrap it with `ThreadSummaryHoverCard` for the summary preview
- Widen the `duplicateThread` include in `threads/updates.tsx` so the new summary card can render the assignee avatar

## Test plan
- [ ] `bun run --filter web typecheck`
- [ ] Hover the thread mention chip inside a markdown message — summary card appears with status / priority / assignee
- [ ] Signals action rows — inline thread refs hover-preview correctly and the link still navigates
- [ ] "Marked as duplicate" thread update entry — hover preview works
- [ ] Thread toolbar duplicate-suggestion chips (quick-actions + support-intelligence) — shared hover card with action buttons still opens; chip styling unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the thread mention UI into three composable primitives—`ThreadChip`, `ThreadSummaryCard`, and `ThreadSummaryHoverCard`—to make hover previews reusable across the app. Also fixed the assignee avatar in the summary card to use the author image.

- **Refactors**
  - Added `ThreadChip` (chip-only), `ThreadSummaryCard` (panel content), `ThreadSummaryHoverCard` (wrap any trigger), and `ThreadChipWithSummary` (convenience).
  - Replaced markdown mentions with `ThreadChipWithSummary`; signals action rows now inline render (avatar + name + `#shortId`) wrapped in `ThreadSummaryHoverCard`.
  - Quick actions and support intelligence now use `ThreadChip` for chip-only use.
  - Broadened duplicate thread query to include `assignedUser.user` so the summary can show the assignee details.

- **Migration**
  - Use `ThreadChip` for chip-only rendering.
  - Wrap any element with `ThreadSummaryHoverCard` to add a summary preview.
  - Use `ThreadChipWithSummary` when you want a chip with a preview.
  - Remove any `variant="unstyled"` usage and inline the content where needed.

<sup>Written for commit d2e2b965e9ecf390bad43fcedc6501ff42ab10a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hover cards now show full thread summaries (status, priority, assignee/unassigned, creation time) when hovering thread references.

* **Refactor**
  * Thread references simplified to compact chips showing thread name and author avatar.
  * Thread mention, signal action rows, duplicate suggestions, and thread updates now use the new summary hover behavior for consistent presentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FrontDeskHQ/front-desk/pull/271)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->