### PR TITLE
feat(devtools): update PR suggestion devtool to match how the AI outputs reasoning

### DIFF
--- a/apps/web/src/components/devtools/devtools-menu/add-pr-suggestion-command.tsx
+++ b/apps/web/src/components/devtools/devtools-menu/add-pr-suggestion-command.tsx
@@ -1,21 +1,22 @@
 "use client";
 
-import { useParams } from "@tanstack/react-router";
 import { MenuItem } from "@workspace/ui/components/menu";
 import { useAtomValue } from "jotai/react";
 import { toast } from "sonner";
 import { ulid } from "ulid";
 import { activeOrganizationAtom } from "~/lib/atoms";
 import { fetchClient } from "~/lib/live-state";
+import {
+  resolveThreadUlid,
+  useThreadRouteRawParam,
+} from "./thread-route-for-devtools";
 
 export const AddPrSuggestionMenuItem = () => {
   const currentOrg = useAtomValue(activeOrganizationAtom);
-  const params = useParams({ strict: false });
-  const threadId =
-    (params as { id?: string } | undefined)?.id ?? null;
+  const rawThreadParam = useThreadRouteRawParam();
 
   const handleAddPrSuggestion = async () => {
-    if (!threadId) {
+    if (!rawThreadParam) {
       toast.error("Open a thread first to add a PR suggestion");
       return;
     }
@@ -24,6 +25,20 @@ export const AddPrSuggestionMenuItem = () => {
       toast.error("No organization selected");
       return;
     }
+
+    const threadId = await resolveThreadUlid(rawThreadParam);
+    if (!threadId) {
+      toast.error("Could not resolve thread");
+      return;
+    }
+
+    const repo = "acme/app";
+    const prNumber = 142;
+    const prUrl = `https://github.com/${repo}/pull/${prNumber}`;
+    const prLink = `[${repo}#${prNumber}](${prUrl})`;
+    const reasoning =
+      "The merged PR adds the missing webhook retry behavior the user reported as broken.";
+    const summary = `Support for the missing webhook retry behavior has shipped in ${prLink}.`;
 
     try {
       const now = new Date();
@@ -46,6 +61,8 @@ export const AddPrSuggestionMenuItem = () => {
             "PR addresses session timeout issues mentioned in this thread",
         }),
         metadataStr: null,
+        summary,
+        reasoning,
         createdAt: now,
         updatedAt: now,
       });

--- a/apps/web/src/components/devtools/devtools-menu/signals-submenu.tsx
+++ b/apps/web/src/components/devtools/devtools-menu/signals-submenu.tsx
@@ -1,26 +1,35 @@
 "use client";
 
-import { useParams } from "@tanstack/react-router";
-import { MenuItem } from "@workspace/ui/components/menu";
+import { MenuItem, MenuSeparator } from "@workspace/ui/components/menu";
 import { useAtomValue } from "jotai/react";
 import { toast } from "sonner";
 import { ulid } from "ulid";
 import { activeOrganizationAtom } from "~/lib/atoms";
 import { fetchClient } from "~/lib/live-state";
+import { AddPrSuggestionMenuItem } from "./add-pr-suggestion-command";
+import {
+  resolveThreadUlid,
+  useThreadRouteRawParam,
+} from "./thread-route-for-devtools";
 
 const AddPendingReplyMenuItem = () => {
   const currentOrg = useAtomValue(activeOrganizationAtom);
-  const params = useParams({ strict: false });
-  const threadId = (params as { id?: string } | undefined)?.id ?? null;
+  const rawThreadParam = useThreadRouteRawParam();
 
   const handleAdd = async () => {
-    if (!threadId) {
+    if (!rawThreadParam) {
       toast.error("Open a thread first");
       return;
     }
 
     if (!currentOrg?.id) {
       toast.error("No organization selected");
+      return;
+    }
+
+    const threadId = await resolveThreadUlid(rawThreadParam);
+    if (!threadId) {
+      toast.error("Could not resolve thread");
       return;
     }
 
@@ -67,17 +76,22 @@ const AddPendingReplyMenuItem = () => {
 
 const AddLoopToCloseMenuItem = () => {
   const currentOrg = useAtomValue(activeOrganizationAtom);
-  const params = useParams({ strict: false });
-  const threadId = (params as { id?: string } | undefined)?.id ?? null;
+  const rawThreadParam = useThreadRouteRawParam();
 
   const handleAdd = async () => {
-    if (!threadId) {
+    if (!rawThreadParam) {
       toast.error("Open a thread first");
       return;
     }
 
     if (!currentOrg?.id) {
       toast.error("No organization selected");
+      return;
+    }
+
+    const threadId = await resolveThreadUlid(rawThreadParam);
+    if (!threadId) {
+      toast.error("Could not resolve thread");
       return;
     }
 
@@ -224,8 +238,10 @@ const ClearLeverageActionsMenuItem = () => {
 export const SignalsSubmenu = () => {
   return (
     <>
+      <AddPrSuggestionMenuItem />
       <AddPendingReplyMenuItem />
       <AddLoopToCloseMenuItem />
+      <MenuSeparator />
       <SeedLeverageActionsMenuItem />
       <ClearLeverageActionsMenuItem />
       <ForceDigestMenuItem />

--- a/apps/web/src/components/devtools/devtools-menu/thread-route-for-devtools.tsx
+++ b/apps/web/src/components/devtools/devtools-menu/thread-route-for-devtools.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { getRouteApi } from "@tanstack/react-router";
+import { getDefaultStore } from "jotai/vanilla";
+import { activeOrganizationAtom } from "~/lib/atoms";
+import { fetchClient } from "~/lib/live-state";
+import { parseThreadParam } from "~/utils/thread";
+
+export const useThreadRouteRawParam = (): string | null => {
+  try {
+    return getRouteApi("/app/_workspace/_main/threads/$id/").useParams().id;
+  } catch {
+    return null;
+  }
+};
+
+export const resolveThreadUlid = async (
+  rawParam: string,
+): Promise<string | null> => {
+  const parsed = parseThreadParam(rawParam);
+  if (!parsed) return null;
+  if (parsed.kind === "ulid") return parsed.id;
+  const orgId = getDefaultStore().get(activeOrganizationAtom)?.id;
+  if (!orgId) return null;
+  const thread = await fetchClient.query.thread
+    .first({ shortId: parsed.shortId, organizationId: orgId })
+    .get();
+  return thread?.id ?? null;
+};

--- a/apps/web/src/components/devtools/devtools-menu/threads-submenu.tsx
+++ b/apps/web/src/components/devtools/devtools-menu/threads-submenu.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { MenuItem } from "@workspace/ui/components/menu";
-import { AddPrSuggestionMenuItem } from "./add-pr-suggestion-command";
 import { DuplicateThreadMenuItem } from "./duplicate-thread-command";
 
 interface ThreadsSubmenuProps {
@@ -13,7 +12,6 @@ export const ThreadsSubmenu = ({ onOpenDialog }: ThreadsSubmenuProps) => {
     <>
       <MenuItem onClick={onOpenDialog}>Create Thread</MenuItem>
       <DuplicateThreadMenuItem />
-      <AddPrSuggestionMenuItem />
     </>
   );
 };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the DevTools PR suggestion command to include summary and reasoning fields to match how the assistant outputs reasoning. It now works with both ULID and short thread IDs, and the command lives under Signals.

- New Features
  - Inserts suggestions with `summary` and `reasoning`, including a sample PR link `[acme/app#142](https://github.com/acme/app/pull/142)`.
  - Added “Add PR suggestion” to the Signals submenu with a menu separator.

- Refactors
  - Introduced `useThreadRouteRawParam` and `resolveThreadUlid` to parse route params and resolve short IDs to ULIDs.
  - Updated pending-reply and loop-to-close commands to use the resolver and show errors if the thread/org cannot be resolved.
  - Removed direct `useParams` usage and moved the PR suggestion item from Threads to Signals.

<sup>Written for commit 2a28923a13cb5e4b8d558131827c3e3ad8b45a2a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

