### PR TITLE
feat(web): render GitHub PR links as chips in RichMarkdown

### DIFF
--- a/apps/web/src/components/chips.tsx
+++ b/apps/web/src/components/chips.tsx
@@ -16,7 +16,7 @@ import { Separator } from "@workspace/ui/components/separator";
 import { cn, formatRelativeTime } from "@workspace/ui/lib/utils";
 import type { schema } from "api/schema";
 import { cva, type VariantProps } from "class-variance-authority";
-import { CircleUser } from "lucide-react";
+import { CircleUser, GitPullRequest } from "lucide-react";
 
 const threadChipVariants = cva(
   "flex items-center w-fit gap-1.5 cursor-default text-xs border h-6 rounded-sm px-2 has-[>svg:first-child]:pl-1.5 has-[>svg:last-child]:pr-1.5 bg-foreground-tertiary/15 hover:bg-foreground-tertiary/25 transition-colors",
@@ -78,11 +78,7 @@ export function ThreadChip({
   );
 }
 
-export function ThreadSummaryCard({
-  thread,
-}: {
-  thread: ThreadSummaryThread;
-}) {
+export function ThreadSummaryCard({ thread }: { thread: ThreadSummaryThread }) {
   return (
     <>
       <div className="flex flex-col gap-1">
@@ -172,6 +168,49 @@ export function ThreadSummaryHoverCard({
         <ThreadSummaryCard thread={thread} />
       </HoverCardContent>
     </HoverCard>
+  );
+}
+
+// TODO: fetch live PR data (title + state) via
+// fetchClient.mutate.thread.fetchGithubPullRequests and surface it in a hover
+// card, mirroring ThreadChipWithSummary.
+export function PrChip({
+  owner,
+  repo,
+  number,
+  url,
+  disabled = false,
+  className,
+  ...props
+}: Omit<React.ComponentProps<typeof BaseButton>, "children" | "render"> &
+  VariantProps<typeof threadChipVariants> & {
+    owner: string;
+    repo: string;
+    number: number;
+    url: string;
+  }) {
+  return (
+    <BaseButton
+      type="button"
+      className={cn(threadChipVariants({ disabled }), className)}
+      disabled={disabled ?? false}
+      render={
+        // biome-ignore lint/a11y/useAnchorContent: Content is provided via children
+        <a
+          href={url}
+          target="_blank"
+          rel="noreferrer"
+          aria-label={`Pull request ${owner}/${repo}#${number} (opens in new tab)`}
+        />
+      }
+      {...props}
+    >
+      <GitPullRequest className="size-3.5 text-foreground-secondary shrink-0" />
+      <span className="text-foreground-primary">
+        {owner}/{repo}
+      </span>
+      <span className="text-foreground-secondary tabular-nums">#{number}</span>
+    </BaseButton>
   );
 }
 

--- a/apps/web/src/components/markdown/rich-markdown.tsx
+++ b/apps/web/src/components/markdown/rich-markdown.tsx
@@ -1,14 +1,29 @@
 import { useLiveQuery } from "@live-state/sync/client";
 import { Link } from "@tanstack/react-router";
 import { cn } from "@workspace/ui/lib/utils";
-import { useMemo } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { type Components, Streamdown } from "streamdown";
 import "streamdown/styles.css";
-import { ThreadChipWithSummary } from "~/components/chips";
+import { PrChip, ThreadChipWithSummary } from "~/components/chips";
 import { query } from "~/lib/live-state";
 import { buildThreadParam } from "~/utils/thread";
 
 const THREAD_LINK_PROXY_PREFIX = "https://frontdesk-thread.local/";
+
+const GITHUB_PR_URL_REGEX =
+  /^https?:\/\/(?:www\.)?github\.com\/([\w.-]+)\/([\w.-]+)\/pulls?\/(\d+)(?:\/[^?#]*)?(?:[?#].*)?$/;
+
+function parseGithubPrUrl(href: string | undefined) {
+  if (!href) return null;
+  const match = href.match(GITHUB_PR_URL_REGEX);
+  if (!match) return null;
+  return {
+    owner: match[1],
+    repo: match[2],
+    number: Number(match[3]),
+    url: href,
+  };
+}
 
 export type RichMarkdownPreset = "default" | "minimal" | "full" | "inline";
 
@@ -117,6 +132,41 @@ type RichMarkdownProps = {
   components?: Components;
 };
 
+function PrChipInline(props: {
+  owner: string;
+  repo: string;
+  number: number;
+  url: string;
+}) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [hasLeadingSpace, setHasLeadingSpace] = useState(false);
+  const [hasTrailingSpace, setHasTrailingSpace] = useState(false);
+
+  useLayoutEffect(() => {
+    const prev = ref.current?.previousSibling;
+    setHasLeadingSpace(
+      prev?.nodeType === Node.TEXT_NODE && /\s$/.test(prev.textContent ?? ""),
+    );
+    const next = ref.current?.nextSibling;
+    setHasTrailingSpace(
+      next?.nodeType === Node.TEXT_NODE && /^\s/.test(next.textContent ?? ""),
+    );
+  });
+
+  return (
+    <span ref={ref} className="contents">
+      <PrChip
+        {...props}
+        className={cn(
+          "inline-flex mb-0 translate-y-0.5",
+          hasLeadingSpace && "ml-px",
+          hasTrailingSpace && "mr-px",
+        )}
+      />
+    </span>
+  );
+}
+
 function ThreadMention({ threadId }: { threadId: string }) {
   const thread = useLiveQuery(
     query.thread.first({ id: threadId }).include({
@@ -129,18 +179,42 @@ function ThreadMention({ threadId }: { threadId: string }) {
     }),
   );
 
+  const ref = useRef<HTMLSpanElement>(null);
+  const [hasLeadingSpace, setHasLeadingSpace] = useState(false);
+  const [hasTrailingSpace, setHasTrailingSpace] = useState(false);
+
+  useLayoutEffect(() => {
+    const prev = ref.current?.previousSibling;
+    setHasLeadingSpace(
+      prev?.nodeType === Node.TEXT_NODE && /\s$/.test(prev.textContent ?? ""),
+    );
+    const next = ref.current?.nextSibling;
+    setHasTrailingSpace(
+      next?.nodeType === Node.TEXT_NODE && /^\s/.test(next.textContent ?? ""),
+    );
+  });
+
   if (!thread || !!thread.deletedAt) {
     return null;
   }
 
   return (
-    <ThreadChipWithSummary
-      thread={thread}
-      className="inline-flex mb-0 -translate-y-0.5"
-      render={
-        <Link to="/app/threads/$id" params={{ id: buildThreadParam(thread) }} />
-      }
-    />
+    <span ref={ref} className="contents">
+      <ThreadChipWithSummary
+        thread={thread}
+        className={cn(
+          "inline-flex mb-0 -translate-y-0.5",
+          hasLeadingSpace && "ml-px",
+          hasTrailingSpace && "mr-px",
+        )}
+        render={
+          <Link
+            to="/app/threads/$id"
+            params={{ id: buildThreadParam(thread) }}
+          />
+        }
+      />
+    </span>
   );
 }
 
@@ -202,6 +276,10 @@ export const RichMarkdown = ({
         ) {
           const threadId = href.slice(THREAD_LINK_PROXY_PREFIX.length);
           return <ThreadMention threadId={threadId} />;
+        }
+        const pr = parseGithubPrUrl(href);
+        if (pr) {
+          return <PrChipInline {...pr} />;
         }
         return (
           <a href={href} target="_blank" rel="noreferrer" {...props}>

--- a/apps/web/src/components/markdown/rich-markdown.tsx
+++ b/apps/web/src/components/markdown/rich-markdown.tsx
@@ -4,6 +4,7 @@ import { cn } from "@workspace/ui/lib/utils";
 import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { type Components, Streamdown } from "streamdown";
 import "streamdown/styles.css";
+import { z } from "zod";
 import { PrChip, ThreadChipWithSummary } from "~/components/chips";
 import { query } from "~/lib/live-state";
 import { buildThreadParam } from "~/utils/thread";
@@ -13,16 +14,25 @@ const THREAD_LINK_PROXY_PREFIX = "https://frontdesk-thread.local/";
 const GITHUB_PR_URL_REGEX =
   /^https?:\/\/(?:www\.)?github\.com\/([\w.-]+)\/([\w.-]+)\/pulls?\/(\d+)(?:\/[^?#]*)?(?:[?#].*)?$/;
 
+const GithubPrSchema = z.object({
+  owner: z.string().min(1),
+  repo: z.string().min(1),
+  number: z.number().int().positive(),
+  url: z.string().url(),
+});
+
 function parseGithubPrUrl(href: string | undefined) {
   if (!href) return null;
   const match = href.match(GITHUB_PR_URL_REGEX);
   if (!match) return null;
-  return {
+  const parseResult = GithubPrSchema.safeParse({
     owner: match[1],
     repo: match[2],
     number: Number(match[3]),
     url: href,
-  };
+  });
+  if (!parseResult.success) return null;
+  return parseResult.data;
 }
 
 export type RichMarkdownPreset = "default" | "minimal" | "full" | "inline";

--- a/apps/web/src/routes/app/_workspace/_main/playground/rich-markdown.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/playground/rich-markdown.tsx
@@ -63,6 +63,19 @@ This references a real thread using markdown protocol:
 The mention should render as the thread chip component.`;
 };
 
+const PR_MENTION_CONTENT = `## Pull request link example
+
+A fix for the reported SSO 401 errors has shipped in [vercel/next.js#12345](https://github.com/vercel/next.js/pull/12345).
+
+Other shapes that should also render as chips:
+
+- Trailing path: [files view](https://github.com/vercel/next.js/pull/12345/files)
+- Anchor: [discussion](https://github.com/vercel/next.js/pull/12345#discussion_r123)
+- \`/pulls/\` variant: [pulls form](https://github.com/vercel/next.js/pulls/67890)
+- \`www.\` host: [www host](https://www.github.com/vercel/next.js/pull/999)
+
+Non-PR GitHub links should stay as plain links: [repo home](https://github.com/vercel/next.js) and [an issue](https://github.com/vercel/next.js/issues/1).`;
+
 const buildInlineContent = (threadId: string | null) => {
   if (!threadId) {
     return "Inline preset sample with no thread mention available yet, **bold**, _italic_, and `code`.";
@@ -128,6 +141,14 @@ const VARIANTS: PlaygroundVariant[] = [
     mode: "static",
   },
   {
+    id: "pr-mention",
+    title: "PR link example",
+    description:
+      "Renders GitHub PR URLs as inline chips across canonical, /pulls/, www, anchor and trailing-path shapes.",
+    preset: "default",
+    mode: "static",
+  },
+  {
     id: "streaming-remend",
     title: "Streaming (parse incomplete on)",
     description:
@@ -189,6 +210,7 @@ function VariantCard({
 }) {
   const baseContent = (() => {
     if (variant.id === "thread-mention") return threadMentionContent;
+    if (variant.id === "pr-mention") return PR_MENTION_CONTENT;
     if (variant.id === "inline-static") return inlineContent;
     return SAMPLE_CONTENT;
   })();


### PR DESCRIPTION
## Summary

- Detect canonical GitHub pull request URLs in `RichMarkdown` link rendering and show them as inline `PrChip` controls (owner/repo, PR icon, number) instead of plain anchors.
- Add `PrChip` in `chips.tsx` and a playground variant that exercises `/pull/`, `/pulls/`, `www`, anchors, and trailing paths so non-PR GitHub links stay normal links.
- Wrap thread mention chips in a `contents` span and adjust adjacent text spacing so inline chips align cleanly next to markdown text.

## Test plan

- [ ] Open the app playground **Rich Markdown** route and select **PR link example**; confirm PR URLs render as chips and repo/issue links stay as links.
- [ ] Confirm **Thread mention** variant still shows the thread chip and spacing looks acceptable beside surrounding text.
- [ ] Smoke-test a real message or surface that uses `RichMarkdown` with a GitHub PR link and a thread mention.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render GitHub PR links as inline chips in `RichMarkdown` with schema validation and cleaner inline spacing; non-PR GitHub links remain unchanged.

- **New Features**
  - Added `PrChip` and detection + Zod validation for GitHub PR URLs in `RichMarkdown`; supports `/pull/`, `/pulls/`, `www`, anchors, and trailing paths.
  - Wrapped PR and thread chips in `contents` spans with whitespace-aware margins for clean inline alignment.
  - Added a playground variant to demo PR link rendering and edge cases.

<sup>Written for commit 385b51633b9bce3f35f84da3616d3cac2653601a. Summary will update on new commits. <a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/274?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub pull request links now render as interactive PR chips showing owner, repo and PR number.
  * Markdown-rendered GitHub PR links automatically display inline as styled PR chips instead of regular links.

* **Style**
  * Improved inline spacing and alignment for chips adjacent to surrounding text for better typography.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FrontDeskHQ/front-desk/pull/274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->