### PR TITLE
feat(signals): compound-action read cards with in-bundle selection

### DIFF
--- a/apps/api/src/lib/signals/agent-read.ts
+++ b/apps/api/src/lib/signals/agent-read.ts
@@ -11,6 +11,10 @@ export type ReadSelection =
   | "primary"
   | {
       alternativeIndex: number;
+    }
+  | {
+      /** Indices into `read.primary` the human kept selected in the bundle. */
+      primaryActionIndices: number[];
     };
 
 export const assertReadFingerprint = (
@@ -31,12 +35,23 @@ export const resolveBundleFromSelection = (
 
   if (selection === "primary") {
     bundle = [...read.primary];
-  } else {
+  } else if ("alternativeIndex" in selection) {
     const alternative = read.alternatives?.[selection.alternativeIndex];
     if (!alternative) {
       throw new Error("INVALID_SELECTION");
     }
     bundle = [alternative];
+  } else {
+    if (selection.primaryActionIndices.length === 0) {
+      throw new Error("INVALID_SELECTION");
+    }
+    bundle = selection.primaryActionIndices.map((index) => {
+      const action = read.primary[index];
+      if (!action) {
+        throw new Error("INVALID_SELECTION");
+      }
+      return action;
+    });
   }
 
   return bundle.map((action) => {

--- a/apps/api/src/lib/signals/agent-read.ts
+++ b/apps/api/src/lib/signals/agent-read.ts
@@ -45,7 +45,12 @@ export const resolveBundleFromSelection = (
     if (selection.primaryActionIndices.length === 0) {
       throw new Error("INVALID_SELECTION");
     }
-    bundle = selection.primaryActionIndices.map((index) => {
+    // Normalize so duplicate or reordered indices can't replay or reorder a
+    // primary action's side effects.
+    const normalizedIndices = [...new Set(selection.primaryActionIndices)].sort(
+      (a, b) => a - b,
+    );
+    bundle = normalizedIndices.map((index) => {
       const action = read.primary[index];
       if (!action) {
         throw new Error("INVALID_SELECTION");
@@ -61,4 +66,21 @@ export const resolveBundleFromSelection = (
       draftMarkdown: replyDraft ?? action.draftMarkdown,
     };
   });
+};
+
+/**
+ * Primary actions the human left unselected in a subset bundle. These must
+ * survive a fully-successful execution of the selected subset rather than being
+ * cleared along with the rest of the read. Empty for full-primary or
+ * alternative selections, where no primary action is intentionally retained.
+ */
+export const deselectedPrimaryActions = (
+  read: ThreadRead,
+  selection: ReadSelection,
+): Action[] => {
+  if (selection === "primary" || "alternativeIndex" in selection) {
+    return [];
+  }
+  const selected = new Set(selection.primaryActionIndices);
+  return read.primary.filter((_, index) => !selected.has(index));
 };

--- a/apps/api/src/lib/signals/thread-procedures.ts
+++ b/apps/api/src/lib/signals/thread-procedures.ts
@@ -29,6 +29,9 @@ import type {
 const readSelectionSchema = z.union([
   z.literal("primary"),
   z.object({ alternativeIndex: z.number().int().min(0) }),
+  z.object({
+    primaryActionIndices: z.array(z.number().int().min(0)).min(1),
+  }),
 ]);
 
 export const executeAutonomousBundleInputSchema = z.object({

--- a/apps/api/src/lib/signals/thread-procedures.ts
+++ b/apps/api/src/lib/signals/thread-procedures.ts
@@ -13,6 +13,7 @@ import type { AuthorizeReq } from "../authorize";
 import { authorize } from "../authorize";
 import {
   assertReadFingerprint,
+  deselectedPrimaryActions,
   nextAgentReadAfterExecution,
   type ReadSelection,
   resolveBundleFromSelection,
@@ -151,9 +152,10 @@ export const runAcceptRead = async (
 
   assertReadFingerprint(thread.agentRead, input.readFingerprint);
 
+  const selection = input.selection as ReadSelection;
   const bundle = resolveBundleFromSelection(
     thread.agentRead,
-    input.selection as ReadSelection,
+    selection,
     input.replyDraft,
   );
 
@@ -166,7 +168,18 @@ export const runAcceptRead = async (
   });
 
   const result = await executeBundle(bundle, registry, ctx);
-  const nextRead = nextAgentReadAfterExecution(thread.agentRead, result);
+  let nextRead = nextAgentReadAfterExecution(thread.agentRead, result);
+
+  // A successful subset selection only consumes the chosen primary actions;
+  // preserve the ones the human deselected instead of clearing the read with
+  // them. (Partial failures already retain the unconsumed primary entries.)
+  if (!result.failed) {
+    const deselected = deselectedPrimaryActions(thread.agentRead, selection);
+    if (deselected.length > 0) {
+      nextRead = { ...thread.agentRead, primary: deselected };
+    }
+  }
+
   await persistAgentRead(db, input.threadId, nextRead);
 
   if (result.failed) {

--- a/apps/web/src/components/signals/action-row/handlers.ts
+++ b/apps/web/src/components/signals/action-row/handlers.ts
@@ -1,7 +1,7 @@
 import {
   ACTION_KIND_LABEL,
-  fingerprintAgentRead,
   type Action,
+  fingerprintAgentRead,
   type InlineSuggestion,
   type ThreadRead,
 } from "@workspace/schemas/signals";
@@ -13,7 +13,33 @@ export type ActorContext = {
   posthog: { capture: (e: string, p?: Record<string, unknown>) => void } | null;
 };
 
-type ReadSelection = "primary" | { alternativeIndex: number };
+type ReadSelection =
+  | "primary"
+  | { alternativeIndex: number }
+  | { primaryActionIndices: number[] };
+
+const resolveSelectedActions = (
+  read: ThreadRead,
+  selection: ReadSelection,
+): Action[] => {
+  if (selection === "primary") return read.primary;
+  if ("alternativeIndex" in selection) {
+    const alternative = read.alternatives?.[selection.alternativeIndex];
+    return alternative ? [alternative] : [];
+  }
+  return selection.primaryActionIndices
+    .map((index) => read.primary[index])
+    .filter((action): action is Action => action != null);
+};
+
+const formatSelection = (selection?: ReadSelection): string | undefined => {
+  if (selection === undefined) return undefined;
+  if (selection === "primary") return "primary";
+  if ("alternativeIndex" in selection) {
+    return `alternative:${selection.alternativeIndex}`;
+  }
+  return `primary:${selection.primaryActionIndices.join(",")}`;
+};
 
 const summarizeActionKinds = (actions: Action[]): string[] =>
   actions.map((action) => ACTION_KIND_LABEL[action.kind]);
@@ -35,12 +61,7 @@ const captureReadEvent = (
     alternative_action_kinds: (payload.read.alternatives ?? []).map(
       (action) => action.kind,
     ),
-    selection:
-      payload.selection === undefined
-        ? undefined
-        : payload.selection === "primary"
-          ? "primary"
-          : `alternative:${payload.selection.alternativeIndex}`,
+    selection: formatSelection(payload.selection),
   });
 };
 
@@ -60,12 +81,7 @@ export async function acceptThreadRead(input: {
     replyDraft: input.replyDraft,
   });
 
-  const selectedActions =
-    input.selection === "primary"
-      ? input.read.primary
-      : input.read.alternatives?.[input.selection.alternativeIndex]
-        ? [input.read.alternatives[input.selection.alternativeIndex]]
-        : [];
+  const selectedActions = resolveSelectedActions(input.read, input.selection);
 
   captureReadEvent(input.ctx, "signal:read_accept", {
     threadId: input.threadId,

--- a/apps/web/src/components/signals/action-row/thread-read-card.tsx
+++ b/apps/web/src/components/signals/action-row/thread-read-card.tsx
@@ -2,37 +2,39 @@ import type { InferLiveObject } from "@live-state/sync";
 import { Link } from "@tanstack/react-router";
 import {
   ACTION_KIND_LABEL,
-  STATUS_LABELS,
+  ACTION_KIND_VERB,
   type Action,
+  fingerprintAgentRead,
   type InlineSuggestion,
   type ReplyAction,
-  type ThreadRead,
-  fingerprintAgentRead,
+  STATUS_LABELS,
   sanitizeAgentReadReasoning,
+  type ThreadRead,
   urgencyTierFromScore,
 } from "@workspace/schemas/signals";
 import { Avatar } from "@workspace/ui/components/avatar";
 import { ActionButton } from "@workspace/ui/components/button";
+import { Checkbox } from "@workspace/ui/components/checkbox";
 import {
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
 } from "@workspace/ui/components/hover-card";
-import type { schema } from "api/schema";
 import { formatRelativeTime } from "@workspace/ui/lib/utils";
+import type { schema } from "api/schema";
 import { Brain } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ThreadSummaryHoverCard } from "~/components/chips";
 import { RichMarkdown } from "~/components/markdown/rich-markdown";
 import { buildThreadParam } from "~/utils/thread";
 import { ActionRow } from "./action-row";
 import {
+  type ActorContext,
   acceptInlineSuggestion,
   acceptThreadRead,
   dismissInlineSuggestion,
   dismissThreadRead,
-  type ActorContext,
 } from "./handlers";
 import { SignalReplyDraftEditor } from "./signal-reply-draft-editor";
 
@@ -74,34 +76,155 @@ function ThreadRef({ thread }: { thread: ThreadWithRelations }) {
   );
 }
 
-function bundleLabel(actions: Action[]): string {
-  if (actions.length === 0) return "Apply";
-  if (actions.length === 1) return ACTION_KIND_LABEL[actions[0].kind];
-  return `Run primary (${actions.length} actions)`;
-}
+type SelectedAction = { action: Action; index: number };
 
 function primaryReplyAction(primary: Action[]): ReplyAction | undefined {
-  return primary.find((action): action is ReplyAction => action.kind === "reply");
-}
-
-function primaryIncludesReply(primary: Action[]): boolean {
-  return primaryReplyAction(primary) != null;
+  return primary.find(
+    (action): action is ReplyAction => action.kind === "reply",
+  );
 }
 
 function primaryReplyDraftMarkdown(primary: Action[]): string {
   return primaryReplyAction(primary)?.draftMarkdown ?? "";
 }
 
-function primarySendLabel(primary: Action[]): string {
-  if (primary.length === 1 && primary[0]?.kind === "reply") {
-    return ACTION_KIND_LABEL.reply;
+function capitalize(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+/**
+ * Selected bundle actions in display order: reply always leads, the rest keep
+ * their original bundle order.
+ */
+function orderReplyFirst(
+  primary: Action[],
+  selected: ReadonlySet<number>,
+): SelectedAction[] {
+  return primary
+    .map((action, index): SelectedAction => ({ action, index }))
+    .filter(({ index }) => selected.has(index))
+    .sort((a, b) => {
+      const aReply = a.action.kind === "reply" ? 0 : 1;
+      const bReply = b.action.kind === "reply" ? 0 : 1;
+      if (aReply !== bReply) return aReply - bReply;
+      return a.index - b.index;
+    });
+}
+
+/**
+ * Compose the compound-action button copy from the current selection, e.g.
+ * "Reply and close", "Reply and do 2 actions", or — once the reply editor is
+ * open — "Send and close". The leading verb becomes "Send" while editing.
+ */
+function compoundButtonLabel(
+  ordered: SelectedAction[],
+  replyEditorOpen: boolean,
+): string {
+  if (ordered.length === 0) return "Select an action";
+
+  const verbAt = (entry: SelectedAction, position: number): string => {
+    if (entry.action.kind === "reply" && replyEditorOpen) {
+      return position === 0 ? "Send" : "send";
+    }
+    return ACTION_KIND_VERB[entry.action.kind];
+  };
+
+  const first = capitalize(verbAt(ordered[0], 0));
+  if (ordered.length === 1) return first;
+  if (ordered.length === 2) return `${first} and ${verbAt(ordered[1], 1)}`;
+  return `${first} and do ${ordered.length - 1} actions`;
+}
+
+type CompoundActionButtonProps = {
+  label: string;
+  disabled: boolean;
+  onClick: () => void;
+  /** The full bundle to offer for selection, or null for a single action. */
+  actions: Action[] | null;
+  selectedIndices: ReadonlySet<number>;
+  lockedIndex: number;
+  disableToggles: boolean;
+  onToggle: (index: number) => void;
+};
+
+function CompoundActionButton({
+  label,
+  disabled,
+  onClick,
+  actions,
+  selectedIndices,
+  lockedIndex,
+  disableToggles,
+  onToggle,
+}: CompoundActionButtonProps) {
+  const fieldId = useId();
+
+  if (!actions) {
+    return (
+      <ActionButton
+        size="sm"
+        variant="primary"
+        onClick={onClick}
+        disabled={disabled}
+      >
+        {label}
+      </ActionButton>
+    );
   }
-  return "Send";
+
+  return (
+    <HoverCard>
+      <HoverCardTrigger
+        render={
+          <ActionButton
+            size="sm"
+            variant="primary"
+            onClick={onClick}
+            disabled={disabled}
+          />
+        }
+      >
+        {label}
+      </HoverCardTrigger>
+      <HoverCardContent
+        align="end"
+        className="flex w-60 flex-col gap-0.5 p-1.5"
+      >
+        <p className="px-1.5 py-1 text-xs text-foreground-secondary">
+          Actions in this bundle
+        </p>
+        {actions.map((action, index) => {
+          const locked = index === lockedIndex;
+          const checkboxId = `${fieldId}-${index}`;
+          return (
+            <div
+              key={`${action.kind}:${index}`}
+              className="flex items-center gap-2 rounded-sm px-1.5 py-1 hover:bg-accent has-disabled:opacity-60"
+            >
+              <Checkbox
+                id={checkboxId}
+                checked={selectedIndices.has(index)}
+                disabled={locked || disableToggles}
+                onCheckedChange={() => onToggle(index)}
+              />
+              <label
+                htmlFor={checkboxId}
+                className="flex-1 cursor-pointer select-none text-sm text-foreground-primary has-disabled:cursor-default"
+              >
+                {ACTION_KIND_LABEL[action.kind]}
+              </label>
+            </div>
+          );
+        })}
+      </HoverCardContent>
+    </HoverCard>
+  );
 }
 
 function inlineSuggestionLabel(suggestion: InlineSuggestion): string {
   if (suggestion.action.kind === "set_status") {
-    const status = STATUS_LABELS[suggestion.action.status] ?? suggestion.action.status;
+    const status =
+      STATUS_LABELS[suggestion.action.status] ?? suggestion.action.status;
     return `Set status: ${status}`;
   }
   return `Apply label (${suggestion.action.labelId})`;
@@ -149,7 +272,13 @@ export function ThreadReadCard({ thread, ctx }: Props) {
   const [replyEditorOpen, setReplyEditorOpen] = useState(false);
   const read = thread.agentRead;
   const readFingerprint = fingerprintAgentRead(read);
-  const primaryNeedsReplyEditor = primaryIncludesReply(read.primary);
+  const replyIndex = read.primary.findIndex(
+    (action) => action.kind === "reply",
+  );
+  const isCompound = read.primary.length > 1;
+  const [selectedIndices, setSelectedIndices] = useState<Set<number>>(
+    () => new Set(read.primary.map((_, index) => index)),
+  );
   const [replyDraft, setReplyDraft] = useState(() =>
     primaryReplyDraftMarkdown(read.primary),
   );
@@ -160,19 +289,29 @@ export function ThreadReadCard({ thread, ctx }: Props) {
 
   useEffect(() => {
     setReplyEditorOpen(false);
+    setSelectedIndices(new Set(read.primary.map((_, index) => index)));
     setReplyDraft(primaryReplyDraftMarkdown(read.primary));
     setReplyEditorRevision((revision) => revision + 1);
   }, [readFingerprint, read.primary]);
 
-  const handleAcceptPrimary = async (replyDraft?: string) => {
+  const orderedSelected = useMemo(
+    () => orderReplyFirst(read.primary, selectedIndices),
+    [read.primary, selectedIndices],
+  );
+  const selectionIncludesReply =
+    replyIndex >= 0 && selectedIndices.has(replyIndex);
+
+  const handleAcceptSelected = async (replyDraftValue?: string) => {
+    const indices = [...selectedIndices].sort((a, b) => a - b);
+    if (indices.length === 0) return;
     setBusyKey("primary");
     try {
       await acceptThreadRead({
         threadId: thread.id,
         read,
-        selection: "primary",
+        selection: { primaryActionIndices: indices },
         ctx,
-        replyDraft,
+        replyDraft: replyDraftValue,
       });
       setReplyEditorOpen(false);
     } catch (error) {
@@ -183,11 +322,11 @@ export function ThreadReadCard({ thread, ctx }: Props) {
   };
 
   const handlePrimaryClick = () => {
-    if (primaryNeedsReplyEditor) {
+    if (selectionIncludesReply) {
       setReplyEditorOpen(true);
       return;
     }
-    void handleAcceptPrimary();
+    void handleAcceptSelected();
   };
 
   const handleCancelReplyEditor = () => {
@@ -199,7 +338,18 @@ export function ThreadReadCard({ thread, ctx }: Props) {
   const handleSendReply = () => {
     const trimmed = replyDraft.trim();
     if (trimmed.length === 0) return;
-    void handleAcceptPrimary(trimmed);
+    void handleAcceptSelected(trimmed);
+  };
+
+  const toggleAction = (index: number) => {
+    // Reply stays locked-in while its editor is expanded.
+    if (replyEditorOpen && index === replyIndex) return;
+    setSelectedIndices((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
   };
 
   const handleAcceptAlternative = async (alternativeIndex: number) => {
@@ -315,10 +465,7 @@ export function ThreadReadCard({ thread, ctx }: Props) {
         )}
         <ActionRow.TopActions>
           <AgentReadReasoningTrigger reasoning={read.reasoning} />
-          <ActionRow.Dismiss
-            onClick={handleDismissRead}
-            label="Dismiss read"
-          />
+          <ActionRow.Dismiss onClick={handleDismissRead} label="Dismiss read" />
         </ActionRow.TopActions>
       </ActionRow.Header>
       <SignalReplyDraftEditor
@@ -339,34 +486,31 @@ export function ThreadReadCard({ thread, ctx }: Props) {
             {ACTION_KIND_LABEL[alternative.kind]}
           </ActionButton>
         ))}
-        {replyEditorOpen ? (
-          <>
-            <ActionButton
-              size="sm"
-              variant="ghost"
-              onClick={handleCancelReplyEditor}
-              disabled={busyKey !== null}
-            >
-              Cancel
-            </ActionButton>
-            <ActionButton
-              size="sm"
-              variant="primary"
-              onClick={handleSendReply}
-              disabled={busyKey !== null || replyDraft.trim().length === 0}
-            >
-              {primarySendLabel(read.primary)}
-            </ActionButton>
-          </>
-        ) : (
+        {replyEditorOpen && (
           <ActionButton
             size="sm"
-            variant="primary"
-            onClick={handlePrimaryClick}
+            variant="ghost"
+            onClick={handleCancelReplyEditor}
             disabled={busyKey !== null}
           >
-            {bundleLabel(read.primary)}
+            Cancel
           </ActionButton>
+        )}
+        {read.primary.length > 0 && (
+          <CompoundActionButton
+            label={compoundButtonLabel(orderedSelected, replyEditorOpen)}
+            disabled={
+              busyKey !== null ||
+              orderedSelected.length === 0 ||
+              (replyEditorOpen && replyDraft.trim().length === 0)
+            }
+            onClick={replyEditorOpen ? handleSendReply : handlePrimaryClick}
+            actions={isCompound ? read.primary : null}
+            selectedIndices={selectedIndices}
+            lockedIndex={replyEditorOpen ? replyIndex : -1}
+            disableToggles={busyKey !== null}
+            onToggle={toggleAction}
+          />
         )}
       </ActionRow.Actions>
     </ActionRow.Root>

--- a/apps/web/src/components/signals/action-row/thread-read-card.tsx
+++ b/apps/web/src/components/signals/action-row/thread-read-card.tsx
@@ -20,7 +20,7 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "@workspace/ui/components/hover-card";
-import { formatRelativeTime } from "@workspace/ui/lib/utils";
+import { cn, formatRelativeTime } from "@workspace/ui/lib/utils";
 import type { schema } from "api/schema";
 import { Brain } from "lucide-react";
 import { useEffect, useId, useMemo, useState } from "react";
@@ -137,7 +137,14 @@ function compoundButtonLabel(
 
 type CompoundActionButtonProps = {
   label: string;
+  /** Hard-disabled (e.g. busy executing): blocks the trigger entirely. */
   disabled: boolean;
+  /**
+   * Execution is invalid right now (nothing selected, or empty reply). The
+   * click is gated, but for a compound bundle the selector stays reachable so
+   * the user can re-select an action and recover.
+   */
+  executeDisabled: boolean;
   onClick: () => void;
   /** The full bundle to offer for selection, or null for a single action. */
   actions: Action[] | null;
@@ -150,6 +157,7 @@ type CompoundActionButtonProps = {
 function CompoundActionButton({
   label,
   disabled,
+  executeDisabled,
   onClick,
   actions,
   selectedIndices,
@@ -165,7 +173,7 @@ function CompoundActionButton({
         size="sm"
         variant="primary"
         onClick={onClick}
-        disabled={disabled}
+        disabled={disabled || executeDisabled}
       >
         {label}
       </ActionButton>
@@ -179,8 +187,10 @@ function CompoundActionButton({
           <ActionButton
             size="sm"
             variant="primary"
-            onClick={onClick}
+            onClick={executeDisabled ? undefined : onClick}
             disabled={disabled}
+            aria-disabled={executeDisabled || undefined}
+            className={cn(executeDisabled && "opacity-60")}
           />
         }
       >
@@ -499,8 +509,8 @@ export function ThreadReadCard({ thread, ctx }: Props) {
         {read.primary.length > 0 && (
           <CompoundActionButton
             label={compoundButtonLabel(orderedSelected, replyEditorOpen)}
-            disabled={
-              busyKey !== null ||
+            disabled={busyKey !== null}
+            executeDisabled={
               orderedSelected.length === 0 ||
               (replyEditorOpen && replyDraft.trim().length === 0)
             }

--- a/packages/schemas/src/signals.ts
+++ b/packages/schemas/src/signals.ts
@@ -80,6 +80,20 @@ export const ACTION_KIND_LABEL: Record<ActionKind, string> = {
   set_status: "Set status",
 };
 
+/**
+ * Short verb phrases used to compose compound-bundle button copy, e.g.
+ * "Reply and close" or "Reply and do 2 actions". Lower-cased so they read
+ * naturally mid-sentence; the leading verb is capitalized at render time.
+ */
+export const ACTION_KIND_VERB: Record<ActionKind, string> = {
+  reply: "reply",
+  mark_duplicate: "mark duplicate",
+  link_pr: "link PR",
+  close: "close",
+  apply_label: "apply label",
+  set_status: "set status",
+};
+
 // --- Reversibility + track partition --------------------------------------
 
 export const REVERSIBLE_ACTIONS: ReadonlySet<ActionKind> = new Set([


### PR DESCRIPTION
## Summary

Improves how signal read cards display compound (multi-action) bundles.

### Button text
The primary button now reads as natural language composed from the selected bundle:
- 1 action → `Reply`, `Close`, …
- 2 actions → `Reply and close`
- >2 actions → `Reply and do 2 actions`

Reply always leads; remaining actions keep their original bundle order. Once the reply editor is open, the leading verb swaps to **Send** (`Send and close`, `Send and do 2 actions`).

A short `ACTION_KIND_VERB` map was added to `@workspace/schemas/signals` to drive this copy.

### In-bundle selection
For compound reads (>1 primary action) the button is now a hover-card trigger. The card lists every action in the bundle with a checkbox to select/deselect each. The button text reflects the live selection. When the reply editor is expanded, the reply row is locked checked. Single-action reads render a plain button.

Clicking still opens the reply editor when reply is selected; otherwise it accepts the selected subset directly.

### Backend
Adds a new `{ primaryActionIndices: number[] }` read selection shape so only the kept actions execute (`agent-read.ts`, `thread-procedures.ts`, web `handlers.ts`). Deselected actions follow existing partial-execution semantics and remain on the read.

## Notes
- `typecheck` and Biome pass for web, api, and schemas.
- Not yet verified visually in the running app — worth a quick check of the hover-card interaction (base-ui `PreviewCard` is hover-driven).
- Product decision baked in: deselecting an action keeps it as a smaller pending read after running the rest, rather than discarding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds in-bundle selection and natural-language buttons to compound signal read cards. The backend executes only the selected primary actions and keeps the selector reachable even when nothing is selected.

- **New Features**
  - Button composes simple phrases from the bundle (“Reply and close”, “Reply and do 2 actions”) and switches to “Send …” while the reply editor is open; powered by new `ACTION_KIND_VERB` in `@workspace/schemas/signals`.
  - Compound reads use a hover-card to select/deselect actions; reply leads, the rest keep bundle order; selection live-updates the button; reply stays locked while its editor is open. Single-action reads remain a plain button.
  - Backend accepts `{ primaryActionIndices: number[] }` so only selected primary actions execute; invalid inputs are rejected.

- **Bug Fixes**
  - Preserve deselected primary actions on successful subset execution (they remain on the read); also normalize indices (dedupe + sort) to prevent replays/reordering.
  - Keep the compound selector hoverable when no actions are selected so users can re-select and recover; clicking is gated until the selection is valid.

<sup>Written for commit 8fc6758ce71aaf91c8c9da04e8a94dd4f079c024. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-select primary actions via a compound action button with per-action checkboxes; reply is prioritized and reply-send uses current multi-selection.
  * New short-verb labels used to build concise compound button copy.

* **Improvements**
  * stronger validation and normalization of multi-action selections (dedupe/sort/required non-empty).
  * Accept flow now preserves user-deselected primary entries and records canonical selection for analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->