### PR TITLE
feat(web): render thread & PR links as chips in the Tiptap editor

### DIFF
--- a/apps/web/src/components/markdown/rich-markdown.tsx
+++ b/apps/web/src/components/markdown/rich-markdown.tsx
@@ -21,7 +21,7 @@ const GithubPrSchema = z.object({
   url: z.string().url(),
 });
 
-function parseGithubPrUrl(href: string | undefined) {
+export function parseGithubPrUrl(href: string | undefined) {
   if (!href) return null;
   const match = href.match(GITHUB_PR_URL_REGEX);
   if (!match) return null;
@@ -142,7 +142,7 @@ type RichMarkdownProps = {
   components?: Components;
 };
 
-function PrChipInline(props: {
+export function PrChipInline(props: {
   owner: string;
   repo: string;
   number: number;
@@ -177,9 +177,9 @@ function PrChipInline(props: {
   );
 }
 
-function ThreadMention({ threadId }: { threadId: string }) {
+export function ThreadMention({ where }: { where: Record<string, unknown> }) {
   const thread = useLiveQuery(
-    query.thread.first({ id: threadId }).include({
+    query.thread.first(where).include({
       author: {
         include: { user: true },
       },
@@ -285,7 +285,7 @@ export const RichMarkdown = ({
           href?.startsWith(THREAD_LINK_PROXY_PREFIX)
         ) {
           const threadId = href.slice(THREAD_LINK_PROXY_PREFIX.length);
-          return <ThreadMention threadId={threadId} />;
+          return <ThreadMention where={{ id: threadId }} />;
         }
         const pr = parseGithubPrUrl(href);
         if (pr) {

--- a/apps/web/src/components/markdown/tiptap-link-renderer.tsx
+++ b/apps/web/src/components/markdown/tiptap-link-renderer.tsx
@@ -1,0 +1,95 @@
+import {
+  type TiptapLinkRenderer as TiptapLinkRendererFn,
+  TiptapLinkRendererProvider,
+} from "@workspace/ui/components/blocks/tiptap-link";
+import { useAtomValue } from "jotai";
+import {
+  PrChipInline,
+  parseGithubPrUrl,
+  ThreadMention,
+} from "~/components/markdown/rich-markdown";
+import { activeOrganizationAtom } from "~/lib/atoms";
+import { type ParsedThreadParam, parseThreadParam } from "~/utils/thread";
+
+const THREAD_LINK_PREFIX = "thread:";
+
+/**
+ * Matches an internal thread URL (e.g.
+ * `https://app.example.com/app/threads/14-some-slug` or a portal
+ * `/support/acme/threads/<param>`) and returns the parsed thread param.
+ */
+function parseThreadUrl(href: string): ParsedThreadParam | null {
+  if (typeof window === "undefined") return null;
+
+  let url: URL;
+  try {
+    url = new URL(href, window.location.origin);
+  } catch {
+    return null;
+  }
+
+  // Only treat same-origin links as internal thread references.
+  if (url.origin !== window.location.origin) return null;
+
+  const match = url.pathname.match(/\/threads\/([^/?#]+)/);
+  if (!match) return null;
+
+  return parseThreadParam(match[1]);
+}
+
+/**
+ * Resolves a thread param that may reference a thread by short id, which
+ * requires the active organization for scoping.
+ */
+function ThreadUrlMention({ param }: { param: ParsedThreadParam }) {
+  const activeOrg = useAtomValue(activeOrganizationAtom);
+
+  if (param.kind === "ulid") {
+    return <ThreadMention where={{ id: param.id }} />;
+  }
+
+  if (!activeOrg?.id) return null;
+
+  return (
+    <ThreadMention
+      where={{ shortId: param.shortId, organizationId: activeOrg.id }}
+    />
+  );
+}
+
+const renderLink: TiptapLinkRendererFn = ({ href }) => {
+  if (href.startsWith(THREAD_LINK_PREFIX)) {
+    return (
+      <ThreadMention where={{ id: href.slice(THREAD_LINK_PREFIX.length) }} />
+    );
+  }
+
+  const threadParam = parseThreadUrl(href);
+  if (threadParam) {
+    return <ThreadUrlMention param={threadParam} />;
+  }
+
+  const pr = parseGithubPrUrl(href);
+  if (pr) {
+    return <PrChipInline {...pr} />;
+  }
+
+  return null;
+};
+
+/**
+ * Makes the shared Tiptap editor/renderer render thread references and GitHub
+ * PR links as rich chips, mirroring {@link RichMarkdown}. Wrap any subtree that
+ * mounts the Tiptap components from `@workspace/ui/components/blocks/tiptap`.
+ */
+export function TiptapLinkRenderer({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <TiptapLinkRendererProvider renderLink={renderLink}>
+      {children}
+    </TiptapLinkRendererProvider>
+  );
+}

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -2,6 +2,7 @@ import { ThemeProvider as NextThemesProvider } from "next-themes";
 import type { PostHogConfig } from "posthog-js";
 import { PostHogProvider as PostHogProviderComponent } from "posthog-js/react";
 import type * as React from "react";
+import { TiptapLinkRenderer } from "~/components/markdown/tiptap-link-renderer";
 
 const posthogOptions: Partial<PostHogConfig> = {
   api_host: import.meta.env.VITE_POSTHOG_HOST,
@@ -37,7 +38,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
         enableColorScheme
         forcedTheme="dark"
       >
-        {children}
+        <TiptapLinkRenderer>{children}</TiptapLinkRenderer>
       </NextThemesProvider>
     </PosthogProvider>
   );

--- a/bun.lock
+++ b/bun.lock
@@ -308,6 +308,7 @@
         "@tanstack/react-router-devtools": "^1.132.0",
         "@tanstack/router-plugin": "^1.132.0",
         "@tiptap/extension-heading": "^3.4.1",
+        "@tiptap/extension-link": "^3.4.1",
         "@tiptap/extensions": "^3.4.1",
         "@tiptap/pm": "^3.4.1",
         "@tiptap/react": "^3.4.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,6 +43,7 @@
     "@tanstack/react-router-devtools": "^1.132.0",
     "@tanstack/router-plugin": "^1.132.0",
     "@tiptap/extension-heading": "^3.4.1",
+    "@tiptap/extension-link": "^3.4.1",
     "@tiptap/extensions": "^3.4.1",
     "@tiptap/pm": "^3.4.1",
     "@tiptap/react": "^3.4.1",

--- a/packages/ui/src/components/blocks/tiptap-link.tsx
+++ b/packages/ui/src/components/blocks/tiptap-link.tsx
@@ -1,0 +1,78 @@
+import Link from "@tiptap/extension-link";
+import {
+  MarkViewContent,
+  type MarkViewProps,
+  ReactMarkViewRenderer,
+} from "@tiptap/react";
+import { createContext, useContext } from "react";
+
+/**
+ * Renders a link with the given href as a custom element (e.g. a chip) instead
+ * of a plain anchor. Return `null`/`undefined` to fall back to the default
+ * anchor rendering.
+ */
+export type TiptapLinkRenderer = (props: {
+  href: string;
+  children: React.ReactNode;
+}) => React.ReactNode;
+
+const TiptapLinkRendererContext = createContext<TiptapLinkRenderer | undefined>(
+  undefined,
+);
+
+export function TiptapLinkRendererProvider({
+  renderLink,
+  children,
+}: {
+  renderLink: TiptapLinkRenderer;
+  children: React.ReactNode;
+}) {
+  return (
+    <TiptapLinkRendererContext.Provider value={renderLink}>
+      {children}
+    </TiptapLinkRendererContext.Provider>
+  );
+}
+
+function LinkMarkView({ mark }: MarkViewProps) {
+  const renderLink = useContext(TiptapLinkRendererContext);
+  const href = (mark.attrs.href as string | null | undefined) ?? "";
+
+  const rendered = renderLink?.({
+    href,
+    children: <MarkViewContent />,
+  });
+
+  if (rendered != null && rendered !== false) {
+    // Custom rendering (e.g. a chip) replaces the link entirely. Keep it out of
+    // the editable flow so the chip behaves as an atomic inline element.
+    return (
+      <span
+        contentEditable={false}
+        data-tiptap-link-chip=""
+        className="contents"
+      >
+        {rendered}
+      </span>
+    );
+  }
+
+  return (
+    <a href={href} target="_blank" rel="noreferrer">
+      <MarkViewContent />
+    </a>
+  );
+}
+
+/**
+ * Drop-in replacement for the StarterKit `link` mark that renders links through
+ * the {@link TiptapLinkRendererProvider} context, allowing the host app to swap
+ * specific links (thread references, GitHub PRs, …) for rich chips.
+ */
+export const LinkExtension = Link.extend({
+  addMarkView() {
+    return ReactMarkViewRenderer(LinkMarkView);
+  },
+}).configure({
+  openOnClick: false,
+});

--- a/packages/ui/src/lib/tiptap.ts
+++ b/packages/ui/src/lib/tiptap.ts
@@ -1,15 +1,20 @@
 import DefaultHeading from "@tiptap/extension-heading";
 import { type Editor, Extension, type JSONContent } from "@tiptap/react";
 import { StarterKit as DefaultStarterKit } from "@tiptap/starter-kit";
+import { LinkExtension } from "../components/blocks/tiptap-link";
 
 export const StarterKit = DefaultStarterKit.configure({
   heading: false,
   trailingNode: false,
+  // Replaced by LinkExtension below, which renders links through a host-app
+  // provided renderer (thread chips, GitHub PR chips, …).
+  link: false,
 });
 
 export const EditorExtensions = [
   StarterKit,
   DefaultHeading.configure({ levels: [1, 2, 3, 4] }),
+  LinkExtension,
 ];
 
 export const KeyBinds = Extension.create<{

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -326,7 +326,9 @@
   @apply bg-muted relative p-2 font-mono font-light rounded-sm mt-2;
 }
 
-.customProse a {
+/* Chips (thread/PR links) render their own anchor; exclude them from link
+   styling so they keep their native chip appearance. */
+.customProse a:not([data-tiptap-link-chip] a) {
   @apply text-primary border-b border-primary cursor-pointer;
 }
 


### PR DESCRIPTION
## What

Brings the shared Tiptap editor/renderer to parity with `RichMarkdown`: thread references and GitHub PR links now render as rich chips instead of plain anchors.

## How

- Added a React **mark view** on the link mark (`packages/ui/.../blocks/tiptap-link.tsx`). It renders links through a host-provided renderer (`TiptapLinkRendererProvider`), keeping `@workspace/ui` decoupled from app data/queries.
- The web app wires the renderer in `providers.tsx` (`tiptap-link-renderer.tsx`):
  - `thread:<id>` references → `ThreadChip`
  - internal thread **URLs** (same-origin `/threads/<param>`), resolved by ULID or by `shortId` + active org → `ThreadChip`
  - GitHub PR URLs → `PrChip`
  - anything else → plain anchor
- `ThreadMention` now takes a generic `where` (instead of `threadId`) so it can resolve by id or shortId; its existing markdown caller was updated.
- Chips reuse `RichMarkdown`'s components and a `display: contents` wrapper so baseline alignment matches the markdown surface, and are excluded from `.customProse a` styling so they keep their native chip border.

## UX

Pasting an internal thread URL (e.g. `…/app/threads/14-some-slug`) or a GitHub PR URL auto-links and collapses into a chip. Agent-authored `thread:<id>` links render as chips as before.

## Notes

- Only same-origin links are treated as thread references.
- Short-id resolution needs an active org; if missing/not found/deleted, it renders nothing — same as the existing agent thread links.

## Test plan

- [ ] Paste a GitHub PR URL into a reply → renders a PR chip.
- [ ] Paste an internal thread URL → renders a thread chip, correctly aligned.
- [ ] Existing agent `thread:<id>` content still renders chips.
- [ ] Plain links still render as anchors with the usual underline styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render thread references and GitHub PR links as inline chips in the shared Tiptap editor, matching `RichMarkdown`. Pasting an internal thread URL or a PR URL auto-collapses into a chip; other links remain anchors.

- **New Features**
  - Added custom link mark view via `LinkExtension` in `@workspace/ui`, rendering links through `TiptapLinkRendererProvider`.
  - Web wiring: `thread:<id>` and same-origin `/threads/<param>` → thread chip (resolve by ULID or shortId + active org); GitHub PR URLs → `PrChipInline`; else anchor.
  - Updated `ThreadMention` to accept `where`; chips reuse `RichMarkdown` components and skip `.customProse a` styling for correct borders and baseline.

<sup>Written for commit 8d4e7651382161d1a643099ad84d1fd83688a3ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

