### PR TITLE
feat(signals): redesign empty states with centered illustration

### DIFF
--- a/apps/web/src/components/signals/action-list.tsx
+++ b/apps/web/src/components/signals/action-list.tsx
@@ -7,15 +7,17 @@ import {
   type ThreadWithRelations,
 } from "~/components/signals/action-row";
 import { CaughtUpEmpty, NewOrgEmpty } from "~/components/signals/empty-states";
+import { Greeting } from "~/components/signals/greeting";
 import { query } from "~/lib/live-state";
 
 type Props = {
   organizationId: string;
   ctx: ActorContext;
   isNewOrg?: boolean;
+  userName: string;
 };
 
-export function ActionList({ organizationId, ctx, isNewOrg }: Props) {
+export function ActionList({ organizationId, ctx, isNewOrg, userName }: Props) {
   const threads = useLiveQuery(
     query.thread
       .where({
@@ -51,11 +53,14 @@ export function ActionList({ organizationId, ctx, isNewOrg }: Props) {
 
   if (!threads) {
     return (
-      <div className="mx-auto flex w-full max-w-4xl flex-col gap-2">
-        <ActionRowSkeleton />
-        <ActionRowSkeleton />
-        <ActionRowSkeleton />
-      </div>
+      <>
+        <Greeting userName={userName} />
+        <div className="mx-auto flex w-full max-w-4xl flex-col gap-2">
+          <ActionRowSkeleton />
+          <ActionRowSkeleton />
+          <ActionRowSkeleton />
+        </div>
+      </>
     );
   }
 
@@ -65,6 +70,7 @@ export function ActionList({ organizationId, ctx, isNewOrg }: Props) {
 
   return (
     <div className="mx-auto flex w-full max-w-4xl flex-col gap-3">
+      <Greeting userName={userName} />
       <div className="px-1 text-lg text-foreground-primary">
         {feedThreads.length === 1 ? "Here's" : "Here are"} {feedThreads.length}{" "}
         {feedThreads.length === 1

--- a/apps/web/src/components/signals/action-list.tsx
+++ b/apps/web/src/components/signals/action-list.tsx
@@ -53,14 +53,11 @@ export function ActionList({ organizationId, ctx, isNewOrg, userName }: Props) {
 
   if (!threads) {
     return (
-      <>
-        <Greeting userName={userName} />
-        <div className="mx-auto flex w-full max-w-4xl flex-col gap-2">
-          <ActionRowSkeleton />
-          <ActionRowSkeleton />
-          <ActionRowSkeleton />
-        </div>
-      </>
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-2">
+        <ActionRowSkeleton />
+        <ActionRowSkeleton />
+        <ActionRowSkeleton />
+      </div>
     );
   }
 

--- a/apps/web/src/components/signals/empty-states.tsx
+++ b/apps/web/src/components/signals/empty-states.tsx
@@ -2,7 +2,7 @@ function SignalsIllustration({ className }: { className?: string }) {
   return (
     <svg
       width="160"
-      height="160"
+      height="103"
       viewBox="0 0 134 86"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/apps/web/src/components/signals/empty-states.tsx
+++ b/apps/web/src/components/signals/empty-states.tsx
@@ -1,38 +1,71 @@
-import { Card, CardContent } from "@workspace/ui/components/card";
-import { CheckCheck, Eye } from "lucide-react";
+function SignalsIllustration({ className }: { className?: string }) {
+  return (
+    <svg
+      width="160"
+      height="160"
+      viewBox="0 0 134 86"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M111.805 40.87C111.805 43.1 111.105 44.62 109.685 45.42L61.7348 72.91L44.9048 82.56C43.4848 83.37 41.8448 83.23 39.9548 82.14C38.0748 81.05 36.4248 79.29 35.0148 76.85L4.65479 24.48C3.23479 22.05 2.56479 19.73 2.62479 17.54C2.67479 15.34 3.41477 13.84 4.82477 13.04L5.27482 12.82C6.58482 12.27 8.11477 12.51 9.85477 13.51C11.7948 14.63 13.4748 16.41 14.8848 18.85L39.9548 62.29L49.2848 56.97L59.3448 51.24L99.8048 28.17L100.275 27.94C101.075 27.61 101.955 27.56 102.905 27.8C103.485 27.95 104.105 28.22 104.745 28.59C106.625 29.68 108.275 31.44 109.685 33.87C111.105 36.31 111.805 38.64 111.805 40.87Z"
+        stroke="currentColor"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M131.805 30.87C131.805 33.1 131.105 34.62 129.685 35.42L64.9048 72.56L64.4448 72.79L44.9048 82.56L61.7348 72.91L109.685 45.42C111.105 44.62 111.805 43.1 111.805 40.87C111.805 38.64 111.105 36.31 109.685 33.87C108.275 31.44 106.625 29.68 104.745 28.59C104.105 28.22 103.485 27.95 102.905 27.8C101.955 27.56 101.075 27.61 100.275 27.94L119.015 18.62L120.605 17.83C121.825 17.44 123.215 17.7 124.745 18.59C126.625 19.68 128.275 21.44 129.685 23.87C131.105 26.31 131.805 28.64 131.805 30.87Z"
+        stroke="currentColor"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M59.3448 51.2399L49.2849 56.9699L39.9549 62.2899L14.8849 18.8499C13.4749 16.4099 11.7949 14.6299 9.85486 13.5099C8.11486 12.5099 6.5849 12.2699 5.2749 12.8199L24.8249 3.03995C26.2349 2.22995 27.9149 2.38994 29.8549 3.50994C31.7949 4.62994 33.4749 6.40995 34.8849 8.84995L59.3448 51.2399Z"
+        stroke="currentColor"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function EmptyState({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-8 text-center">
+      <SignalsIllustration className="text-border" />
+      <div className="max-w-lg space-y-3">
+        <div className="text-foreground-primary text-2xl font-medium">
+          {title}
+        </div>
+        <div className="text-foreground-secondary text-base">{description}</div>
+      </div>
+    </div>
+  );
+}
 
 export function NewOrgEmpty() {
   return (
-    <Card>
-      <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
-        <Eye className="size-8 text-foreground-secondary" />
-        <div className="max-w-sm">
-          <div className="text-foreground-primary text-sm font-medium">
-            FrontDesk is watching your threads
-          </div>
-          <div className="text-foreground-secondary text-xs">
-            Signals will appear here as we catch things.
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+    <EmptyState
+      title="Getting to know your threads"
+      description="FrontDesk is reading through your threads. Your first signals will show up here shortly."
+    />
   );
 }
 
 export function CaughtUpEmpty() {
   return (
-    <Card>
-      <CardContent className="flex flex-col items-center gap-3 py-8 text-center">
-        <CheckCheck className="size-6 text-foreground-secondary" />
-        <div className="max-w-sm">
-          <div className="text-foreground-primary text-sm font-medium">
-            You're all caught up
-          </div>
-          <div className="text-foreground-secondary text-xs">
-            FrontDesk handled everything in the background.
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+    <EmptyState
+      title="You're all caught up"
+      description="Nothing needs you right now. FrontDesk has the rest."
+    />
   );
 }

--- a/apps/web/src/routes/app/_workspace/_main/signal/index.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/signal/index.tsx
@@ -9,7 +9,6 @@ import { usePostHog } from "posthog-js/react";
 import { useMemo } from "react";
 import { ActionList } from "~/components/signals/action-list";
 import type { ActorContext } from "~/components/signals/action-row";
-import { Greeting } from "~/components/signals/greeting";
 // import { LeverageReport } from "~/components/signals/leverage-report";
 import { activeOrganizationAtom } from "~/lib/atoms";
 
@@ -49,7 +48,6 @@ function RouteComponent() {
         <CardTitle>Signals</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-col gap-4 overflow-y-auto py-10!">
-        <Greeting userName={user.name} />
         {/* <LeverageReport
           organizationId={currentOrg.id}
           organizationCreatedAt={orgCreatedAt}
@@ -61,6 +59,7 @@ function RouteComponent() {
           organizationId={currentOrg.id}
           ctx={ctx}
           isNewOrg={isNewOrg}
+          userName={user.name}
         />
       </CardContent>
     </>


### PR DESCRIPTION
## What

Redesigns the Signals empty states (caught-up and new-org) to feel intentional and on-brand.

- Centers the empty state on the page (horizontal + vertical) with a paper-plane illustration (`stroke="currentColor"`, theme-aware).
- Larger copy and more generous spacing.
- Moves the `Greeting` into `ActionList` so it only renders when there are signals — no more "Good evening, …" hanging above an empty state.

## Copy

| State | Title | Description |
|---|---|---|
| Caught-up | You're all caught up | Nothing needs you right now. FrontDesk has the rest. |
| New-org | Getting to know your threads | FrontDesk is reading through your threads. Your first signals will show up here shortly. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned Signals empty states with a centered, theme-aware paper‑plane illustration and clearer copy to make empty views feel intentional. Fixed the illustration aspect ratio and adjusted greeting behavior to prevent flicker.

- **New Features**
  - Centered empty states (vertical + horizontal) with an SVG illustration (`stroke="currentColor"`), larger typography, and spacing.
  - Updated messaging for Caught-up and New-org states.
  - Corrected illustration aspect ratio to match the 134:86 viewBox.

- **Refactors**
  - Moved `Greeting` into `ActionList` (with `userName`) and removed it from the route; it no longer renders during loading to avoid flicker and only shows when there are signals.

<sup>Written for commit ec0edff924de7c2b45e4aedadfac4e40dfb1fc38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Enhanced action list display with integrated greeting message during load states
  * Redesigned empty state interface with visual illustrations for improved clarity
  * Updated messaging in empty states for better user guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->