### PR TITLE
feat(schema): add org-scoped externalEntity mirror table (FRO-181)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,6 +60,10 @@ A deterministic, no-LLM helper (not a pipeline processor) that action-emitting p
 
 A receipt of work the Agent performed without human approval. Stored in `autonomousAction`. Carries an undo affordance when the action is reversible by construction.
 
+### Thread
+
+The unit of customer conversation in FrontDesk: a single stream of messages carrying its own state (status, labels, assignee) and the surface the Agent reads and acts on. A thread originates from one place — its `externalId` / `externalOrigin` record *where it came from* (Discord channel, Slack message, portal) — and may **link** to an [external issue](#external-issue) or [external pull request](#external-pull-request) without owning it. Stored in `thread`; the Agent's output for one lives on `thread.agentRead` (see [thread read](#thread-read)).
+
 ### External issue
 
 An issue in an external developer system (today only GitHub) that FrontDesk **mirrors** read-only. GitHub is authoritative; our copy is a downstream replica updated only from inbound webhooks/backfill, never written canonically from our side. Identified provider-agnostically as `provider:owner/repo#number` (see `formatGitHubId`). A [thread](#thread) may **link** to an external issue; the link is a reference, not ownership.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,3 +59,22 @@ A deterministic, no-LLM helper (not a pipeline processor) that action-emitting p
 ### Autonomous action
 
 A receipt of work the Agent performed without human approval. Stored in `autonomousAction`. Carries an undo affordance when the action is reversible by construction.
+
+### External issue
+
+An issue in an external developer system (today only GitHub) that FrontDesk **mirrors** read-only. GitHub is authoritative; our copy is a downstream replica updated only from inbound webhooks/backfill, never written canonically from our side. Identified provider-agnostically as `provider:owner/repo#number` (see `formatGitHubId`). A [thread](#thread) may **link** to an external issue; the link is a reference, not ownership.
+_Avoid_: "GitHub issue" (we are provider-agnostic), "ticket".
+
+### External pull request
+
+A pull request in an external developer system that FrontDesk mirrors under the same read-mirror rules as an [external issue](#external-issue). Distinct from an external issue because it carries PR-only facets (merge state, draft, branches). A thread may link to one.
+_Avoid_: "PR" alone when ambiguous, "merge request".
+
+### Mirror
+
+FrontDesk's local, read-only replica of authoritative external data ([external issues](#external-issue) and [external pull requests](#external-pull-request)). The external system is the source of truth; the mirror is only ever updated *from* it (webhooks + backfill + drift reconciliation), never written canonically from our side. Actions taken in FrontDesk go out to the external system and round-trip back into the mirror. Used as a verb ("we mirror the repo's issues") and a noun ("the mirror").
+_Avoid_: "cache" (implies disposable/expiry; the mirror is durable and queried as primary), "sync copy".
+
+### Flagged ambiguities
+
+**"External" is overloaded.** On a thread, `externalId` / `externalOrigin` mean *where the thread itself originated* (Discord channel, Slack message). This is **not** the same as a linked [external issue](#external-issue) / [external pull request](#external-pull-request), which is a separate developer-system entity the thread points to. When the origin is meant, say "thread origin"; when the linked entity is meant, say "external issue / pull request".

--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -792,6 +792,28 @@ export const router = createRouter({
         postMutation: ({ ctx }) => !!ctx?.internalApiKey,
       },
     }),
+    // Read-only mirror of external issues/PRs. Written only by the integration
+    // (internal API key); org members read their own org's entities.
+    externalEntity: privateRoute.collectionRoute(schema.externalEntity, {
+      read: ({ ctx }) => {
+        if (ctx?.internalApiKey) return true;
+        if (!ctx?.session) return false;
+
+        return {
+          organization: {
+            organizationUsers: {
+              userId: ctx.session.userId,
+              enabled: true,
+            },
+          },
+        };
+      },
+      insert: ({ ctx }) => !!ctx?.internalApiKey,
+      update: {
+        preMutation: ({ ctx }) => !!ctx?.internalApiKey,
+        postMutation: ({ ctx }) => !!ctx?.internalApiKey,
+      },
+    }),
     thread: threadsRoute,
     update: updateRoute,
     message: messageRoute,

--- a/apps/api/src/live-state/schema.ts
+++ b/apps/api/src/live-state/schema.ts
@@ -58,6 +58,7 @@ const thread = object("thread", {
   deletedAt: timestamp().nullable(),
   /** @deprecated use externalId and externalOrigin instead */
   discordChannelId: string().nullable(),
+  // Link to a mirrored externalEntity by its externalKey (`provider:owner/repo#number`).
   externalIssueId: string().nullable(),
   externalPrId: string().nullable(),
   status: number().default(0),
@@ -210,6 +211,46 @@ const documentationSource = object("documentationSource", {
   updatedAt: timestamp(),
 });
 
+/**
+ * A read-only mirror of an issue or pull request from an external developer
+ * system (today only GitHub). The external system is authoritative; rows here
+ * are only ever written from inbound webhooks/backfill/drift reconciliation,
+ * never canonically from our side. See docs/adr/0007-mirror-external-issues-prs.md.
+ *
+ * Synced to clients so the UI can display and search issue/PR data reactively.
+ */
+// TODO(live-state): composite index (organizationId, externalKey) when supported.
+// Until then, externalKey single-column index plus query-side organizationId filter.
+const externalEntity = object("externalEntity", {
+  id: id(),
+  organizationId: reference("organization.id"),
+  provider: string(),
+  /** Provider-agnostic key: `provider:owner/repo#number` (see formatGitHubId). */
+  externalKey: string().index(),
+  /** "issue" | "pull_request" */
+  type: string(),
+  number: number(),
+  repoFullName: string(),
+  url: string(),
+  title: string(),
+  body: string().nullable(),
+  state: string(),
+  authorLogin: string().nullable(),
+  assignees: json<string[]>().default([]),
+  labels: json<string[]>().default([]),
+  externalCreatedAt: timestamp(),
+  externalUpdatedAt: timestamp(),
+  closedAt: timestamp().nullable(),
+  // PR-only facets, null for issues.
+  merged: boolean().default(false),
+  mergedAt: timestamp().nullable(),
+  draft: boolean().default(false),
+  headRef: string().nullable(),
+  baseRef: string().nullable(),
+  lastSyncedAt: timestamp(),
+  deletedAt: timestamp().nullable(),
+});
+
 const organizationRelations = createRelations(organization, ({ many }) => ({
   organizationUsers: many(organizationUser, "organizationId"),
   threads: many(thread, "organizationId"),
@@ -222,6 +263,7 @@ const organizationRelations = createRelations(organization, ({ many }) => ({
   onboardings: many(onboarding, "organizationId"),
   documentationSources: many(documentationSource, "organizationId"),
   agentChats: many(agentChat, "organizationId"),
+  externalEntities: many(externalEntity, "organizationId"),
 }));
 
 const subscriptionRelations = createRelations(subscription, ({ one }) => ({
@@ -310,6 +352,10 @@ const documentationSourceRelations = createRelations(
   }),
 );
 
+const externalEntityRelations = createRelations(externalEntity, ({ one }) => ({
+  organization: one(organization, "organizationId"),
+}));
+
 // This is a list of emails that are allowed to access the app - will be removed after the beta.
 const allowlist = object("allowlist", {
   id: id(),
@@ -366,6 +412,7 @@ export const schema = createSchema({
   documentationSource,
   agentChat,
   agentChatMessage,
+  externalEntity,
   migration,
   // relations
   organizationUserRelations,
@@ -384,4 +431,5 @@ export const schema = createSchema({
   documentationSourceRelations,
   agentChatRelations,
   agentChatMessageRelations,
+  externalEntityRelations,
 });

--- a/apps/api/src/live-state/schema.ts
+++ b/apps/api/src/live-state/schema.ts
@@ -242,9 +242,9 @@ const externalEntity = object("externalEntity", {
   externalUpdatedAt: timestamp(),
   closedAt: timestamp().nullable(),
   // PR-only facets, null for issues.
-  merged: boolean().default(false),
+  merged: boolean().nullable(),
   mergedAt: timestamp().nullable(),
-  draft: boolean().default(false),
+  draft: boolean().nullable(),
   headRef: string().nullable(),
   baseRef: string().nullable(),
   lastSyncedAt: timestamp(),

--- a/docs/adr/0007-mirror-external-issues-prs.md
+++ b/docs/adr/0007-mirror-external-issues-prs.md
@@ -1,0 +1,20 @@
+# Mirror external issues/PRs as a fully client-synced, read-only replica
+
+We mirror all issues and pull requests from the repos selected in an org's GitHub integration into a single, org-scoped `externalEntity` table, kept current by GitHub webhooks (live upserts), an initial backfill, and a periodic drift reconciliation. GitHub stays authoritative: the mirror is never written canonically from our side — actions taken in FrontDesk go out to the GitHub API and round-trip back into the mirror via webhook; optimistic UI stays client-only. This replaces the previous on-demand fetch-from-GitHub approach so we can display and search issue/PR data effectively.
+
+## Status
+
+accepted
+
+## Considered options
+
+- **Read-mirror with GitHub round-trip (chosen).** One writer per field (inbound only), so "authoritative" is literally true and the mirror can't diverge.
+- **Bidirectional / optimistically-written mirror.** Rejected: two writers per field invites divergence and reconciliation complexity for no product gain at this stage.
+- **Server-side mirror queried via procedures (no client sync).** Rejected for now: structured search and reactive thread updates are simpler client-side, and we accept the footprint bet below.
+
+## Consequences
+
+- The mirror is **fully Live-State-synced to clients**, deliberately deviating from the established "ingestion tables aren't synced to clients" precedent (`apps/api/src/live-state/schema.ts`). At current scale the reactive/offline UX wins, and Live-State is expected to gain native data slicing before mirror volume becomes a problem. If volume bites before then, the fallback is a server-side query path for the browse/search corpus.
+- Backfill and drift reconciliation run as **BullMQ jobs inside the github integration app** (not the central `apps/worker`), which owns its own background work.
+- A created/edited issue is not visible in the mirror until its webhook lands (usually sub-second); UI bridges the gap optimistically.
+- Removals are **soft-deleted** (`deletedAt`) so linked-thread history never dangles.


### PR DESCRIPTION
## Summary

Foundation for mirroring external issues & PRs (FRO-180). Adds a provider-agnostic, client-synced **read-only** `externalEntity` table. GitHub stays authoritative — rows are written only by the integration (internal API key) and read by org members; nothing is written canonically from our side.

See [ADR 0007](docs/adr/0007-mirror-external-issues-prs.md) (included) for the read-mirror design and trade-offs.

## Changes

- **`externalEntity` object** (`apps/api/src/live-state/schema.ts`): `id`, `organizationId`, `provider`, `externalKey` (indexed), `type`, `number`, `repoFullName`, `url`, `title`, `body`, `state`, `authorLogin`, `assignees`/`labels` (`json<string[]>`), `externalCreatedAt`/`externalUpdatedAt`, `closedAt`, PR-only `merged`/`mergedAt`/`draft`/`headRef`/`baseRef`, `lastSyncedAt`, `deletedAt`.
- Single-column index on `externalKey` only; org-scoping filtered query-side (`TODO(live-state)` left for the composite index, per convention).
- `organization.externalEntities` / `externalEntity.organization` relations; registered object + relations + router route.
- Router route: writes gated to `internalApiKey`, reads scoped to enabled org members.
- Documented that `thread.externalIssueId`/`externalPrId` now hold the `externalKey` (semantics redefined; no migration shim — no prod data).
- Includes ADR 0007 and CONTEXT.md glossary terms (External issue / External pull request / Mirror).

## Notes

- No DDL migration needed — `SQLStorage` auto-creates the table; it starts empty and is populated by the backfill job (FRO-183).
- Unblocks FRO-182 → FRO-185.

## Verification

- `bun run typecheck` — all 9 packages pass.
- `bun run --filter api lint` — exit 0, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an org-scoped, provider-agnostic `externalEntity` mirror of external issues and pull requests, synced to clients and read-only. Satisfies FRO-181; no migration needed — the GitHub integration backfills and keeps it updated.

- **New Features**
  - Added `externalEntity` object (issue/PR core fields + PR-only facets) with indexed `externalKey`.
  - Linked to orgs via `organization.externalEntities` and `externalEntity.organization`; registered in schema and `apps/api` router.
  - Exposed `externalEntity` route: writes require `internalApiKey`; reads are scoped to enabled org members.
  - `thread.externalIssueId` / `thread.externalPrId` now store the `externalKey`; ADR 0007 documents the mirror design.

- **Bug Fixes**
  - Made `externalEntity.merged` and `externalEntity.draft` nullable for issue rows; PR-only fields are null on issues.
  - Added a "Thread" glossary term in `CONTEXT.md` to fix a broken fragment link.

<sup>Written for commit c5422aa83a03b33be54baa5c9a1688b7e24ba522. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mirror external GitHub issues and PRs as org-scoped, read-only records; kept current via webhooks, initial backfill, and periodic reconciliation.

* **Documentation**
  * Added ADR describing the mirroring strategy and operational considerations.
  * Expanded glossary with definitions for external entities, mirrored items, and flagged ambiguous terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->