### PR TITLE
feat(github): live webhook upserts to keep the externalEntity mirror current

### DIFF
--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -21,6 +21,7 @@ import { privateRoute, publicRoute } from "./factories";
 import { agentChatMessageRoute, agentChatRoute } from "./router/agent-chat";
 import autonomousActionRoute from "./router/autonomous-action";
 import documentationSourcesRoute from "./router/documentation-sources";
+import externalEntityRoute from "./router/external-entity";
 import labelsRoute from "./router/labels";
 import messageRoute from "./router/message";
 import onboardingRoute from "./router/onboarding";
@@ -792,28 +793,9 @@ export const router = createRouter({
         postMutation: ({ ctx }) => !!ctx?.internalApiKey,
       },
     }),
-    // Read-only mirror of external issues/PRs. Written only by the integration
-    // (internal API key); org members read their own org's entities.
-    externalEntity: privateRoute.collectionRoute(schema.externalEntity, {
-      read: ({ ctx }) => {
-        if (ctx?.internalApiKey) return true;
-        if (!ctx?.session) return false;
-
-        return {
-          organization: {
-            organizationUsers: {
-              userId: ctx.session.userId,
-              enabled: true,
-            },
-          },
-        };
-      },
-      insert: ({ ctx }) => !!ctx?.internalApiKey,
-      update: {
-        preMutation: ({ ctx }) => !!ctx?.internalApiKey,
-        postMutation: ({ ctx }) => !!ctx?.internalApiKey,
-      },
-    }),
+    // Mirror of external issues/PRs. Default mutators are disabled; writes go
+    // through the route's custom `upsert` / `softDelete` procedures.
+    externalEntity: externalEntityRoute,
     thread: threadsRoute,
     update: updateRoute,
     message: messageRoute,

--- a/apps/api/src/live-state/router/external-entity.ts
+++ b/apps/api/src/live-state/router/external-entity.ts
@@ -1,0 +1,133 @@
+// TODO refactor with new live-state mental model
+import { ulid } from "ulid";
+import { z } from "zod";
+import { privateRoute } from "../factories";
+import { schema } from "../schema";
+
+/**
+ * Org-scoped mirror of external issues/PRs.
+ *
+ * Default insert/update mutators are intentionally disabled: the mirror is only
+ * ever written through the custom `upsert` / `softDelete` procedures below,
+ * which own the `(organizationId, externalKey)` identity and the
+ * `lastSyncedAt` / `deletedAt` bookkeeping. Org members read their own org's
+ * entities; only the integration (internal API key) writes.
+ */
+
+const externalEntityFields = z.object({
+  organizationId: z.string(),
+  provider: z.string(),
+  externalKey: z.string(),
+  type: z.enum(["issue", "pull_request"]),
+  number: z.number(),
+  repoFullName: z.string(),
+  url: z.string(),
+  title: z.string(),
+  body: z.string().nullable(),
+  state: z.string(),
+  authorLogin: z.string().nullable(),
+  assignees: z.array(z.string()),
+  labels: z.array(z.string()),
+  externalCreatedAt: z.coerce.date(),
+  externalUpdatedAt: z.coerce.date(),
+  closedAt: z.coerce.date().nullable(),
+  merged: z.boolean().nullable(),
+  mergedAt: z.coerce.date().nullable(),
+  draft: z.boolean().nullable(),
+  headRef: z.string().nullable(),
+  baseRef: z.string().nullable(),
+});
+
+export default privateRoute
+  .collectionRoute(schema.externalEntity, {
+    read: ({ ctx }) => {
+      if (ctx?.internalApiKey) return true;
+      if (!ctx?.session) return false;
+
+      return {
+        organization: {
+          organizationUsers: {
+            userId: ctx.session.userId,
+            enabled: true,
+          },
+        },
+      };
+    },
+    // Writes go through the custom procedures only.
+    insert: () => false,
+    update: {
+      preMutation: () => false,
+      postMutation: () => false,
+    },
+  })
+  .withMutations(({ mutation }) => ({
+    /**
+     * Insert or update the mirror row identified by
+     * `(organizationId, externalKey)`. Refreshes `lastSyncedAt` and clears any
+     * previous `deletedAt` (a live event means the entity exists again).
+     */
+    upsert: mutation(externalEntityFields).handler(async ({ req, db }) => {
+      if (!req.context?.internalApiKey) {
+        throw new Error("UNAUTHORIZED");
+      }
+
+      const { organizationId, externalKey } = req.input;
+      const now = new Date();
+
+      const existing = Object.values(
+        await db.find(schema.externalEntity, {
+          where: { organizationId, externalKey },
+        }),
+      )[0];
+
+      if (existing) {
+        await db.externalEntity.update(existing.id, {
+          ...req.input,
+          lastSyncedAt: now,
+          deletedAt: null,
+        });
+        return existing.id;
+      }
+
+      const id = ulid().toLowerCase();
+      await db.insert(schema.externalEntity, {
+        id,
+        ...req.input,
+        lastSyncedAt: now,
+        deletedAt: null,
+      });
+      return id;
+    }),
+
+    /**
+     * Soft-delete the mirror row (issue deletion / transfer-out). No-op when the
+     * entity was never mirrored.
+     */
+    softDelete: mutation(
+      z.object({
+        organizationId: z.string(),
+        externalKey: z.string(),
+      }),
+    ).handler(async ({ req, db }) => {
+      if (!req.context?.internalApiKey) {
+        throw new Error("UNAUTHORIZED");
+      }
+
+      const { organizationId, externalKey } = req.input;
+
+      const existing = Object.values(
+        await db.find(schema.externalEntity, {
+          where: { organizationId, externalKey },
+        }),
+      )[0];
+
+      if (!existing) return null;
+
+      const now = new Date();
+      await db.externalEntity.update(existing.id, {
+        deletedAt: now,
+        lastSyncedAt: now,
+      });
+      return existing.id;
+    }),
+  }));

--- a/apps/api/src/live-state/router/external-entity.ts
+++ b/apps/api/src/live-state/router/external-entity.ts
@@ -65,6 +65,9 @@ export default privateRoute
      * Insert or update the mirror row identified by
      * `(organizationId, externalKey)`. Refreshes `lastSyncedAt` and clears any
      * previous `deletedAt` (a live event means the entity exists again).
+     *
+     * The find-then-insert/update runs inside a transaction so concurrent
+     * events for the same entity don't race into duplicate rows.
      */
     upsert: mutation(externalEntityFields).handler(async ({ req, db }) => {
       if (!req.context?.internalApiKey) {
@@ -74,29 +77,31 @@ export default privateRoute
       const { organizationId, externalKey } = req.input;
       const now = new Date();
 
-      const existing = Object.values(
-        await db.find(schema.externalEntity, {
-          where: { organizationId, externalKey },
-        }),
-      )[0];
+      return db.transaction(async ({ trx }) => {
+        const existing = Object.values(
+          await trx.find(schema.externalEntity, {
+            where: { organizationId, externalKey },
+          }),
+        )[0];
 
-      if (existing) {
-        await db.externalEntity.update(existing.id, {
+        if (existing) {
+          await trx.update(schema.externalEntity, existing.id, {
+            ...req.input,
+            lastSyncedAt: now,
+            deletedAt: null,
+          });
+          return existing.id;
+        }
+
+        const id = ulid().toLowerCase();
+        await trx.insert(schema.externalEntity, {
+          id,
           ...req.input,
           lastSyncedAt: now,
           deletedAt: null,
         });
-        return existing.id;
-      }
-
-      const id = ulid().toLowerCase();
-      await db.insert(schema.externalEntity, {
-        id,
-        ...req.input,
-        lastSyncedAt: now,
-        deletedAt: null,
+        return id;
       });
-      return id;
     }),
 
     /**
@@ -115,19 +120,21 @@ export default privateRoute
 
       const { organizationId, externalKey } = req.input;
 
-      const existing = Object.values(
-        await db.find(schema.externalEntity, {
-          where: { organizationId, externalKey },
-        }),
-      )[0];
+      return db.transaction(async ({ trx }) => {
+        const existing = Object.values(
+          await trx.find(schema.externalEntity, {
+            where: { organizationId, externalKey },
+          }),
+        )[0];
 
-      if (!existing) return null;
+        if (!existing) return null;
 
-      const now = new Date();
-      await db.externalEntity.update(existing.id, {
-        deletedAt: now,
-        lastSyncedAt: now,
+        const now = new Date();
+        await trx.update(schema.externalEntity, existing.id, {
+          deletedAt: now,
+          lastSyncedAt: now,
+        });
+        return existing.id;
       });
-      return existing.id;
     }),
   }));

--- a/apps/github/package.json
+++ b/apps/github/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@live-state/sync": "catalog:",
-    "@octokit/webhooks": "^13.3.0",
+    "@octokit/webhooks": "^14.0.0",
     "@workspace/schemas": "workspace:*",
     "@workspace/ui": "workspace:*",
     "api": "workspace:*",

--- a/apps/github/src/webhooks/index.ts
+++ b/apps/github/src/webhooks/index.ts
@@ -31,7 +31,6 @@ type ExternalEntityFields = {
   draft: boolean | null;
   headRef: string | null;
   baseRef: string | null;
-  deletedAt: Date | null;
 };
 
 /**
@@ -70,31 +69,17 @@ const installationIdOf = (payload: unknown): number | undefined =>
   (payload as { installation?: { id?: number } | null }).installation?.id;
 
 /**
- * Insert or update the org-scoped mirror row for an issue/PR. Keyed by
- * `(organizationId, externalKey)` on the query side until live-state supports
- * composite indexes. Always refreshes `lastSyncedAt`.
+ * Insert or update the org-scoped mirror row for an issue/PR via the custom
+ * `externalEntity.upsert` procedure, which owns the
+ * `(organizationId, externalKey)` identity and `lastSyncedAt` bookkeeping.
  */
 const upsertExternalEntity = async (
   organizationId: string,
   fields: ExternalEntityFields
 ) => {
-  const existing = await fetchClient.query.externalEntity
-    .first({ organizationId, externalKey: fields.externalKey })
-    .get();
-
-  if (existing) {
-    await fetchClient.mutate.externalEntity.update(existing.id, {
-      ...fields,
-      lastSyncedAt: new Date(),
-    });
-    return;
-  }
-
-  await fetchClient.mutate.externalEntity.insert({
-    id: ulid().toLowerCase(),
+  await fetchClient.mutate.externalEntity.upsert({
     organizationId,
     ...fields,
-    lastSyncedAt: new Date(),
   });
 };
 
@@ -193,7 +178,6 @@ const buildIssueFields = (
     draft: null,
     headRef: null,
     baseRef: null,
-    deletedAt: null,
   };
 };
 
@@ -226,7 +210,6 @@ const buildPullRequestFields = (
     draft: pr.draft ?? false,
     headRef: pr.head.ref,
     baseRef: pr.base.ref,
-    deletedAt: null,
   };
 };
 
@@ -249,7 +232,11 @@ export const setupWebhooks = () => {
       const fields = buildIssueFields(payload);
 
       if (action === "deleted" || action === "transferred") {
-        fields.deletedAt = new Date();
+        await fetchClient.mutate.externalEntity.softDelete({
+          organizationId,
+          externalKey: fields.externalKey,
+        });
+        return;
       }
 
       await upsertExternalEntity(organizationId, fields);

--- a/apps/github/src/webhooks/index.ts
+++ b/apps/github/src/webhooks/index.ts
@@ -1,154 +1,293 @@
+import type { EmitterWebhookEvent } from "@octokit/webhooks";
 import { formatGitHubId } from "@workspace/schemas/external-issue";
 import { statusValues } from "@workspace/ui/components/indicator";
 import { ulid } from "ulid";
 import { app } from "../lib/github";
-import { store } from "../lib/live-state";
+import { fetchClient, store } from "../lib/live-state";
 import { STATUS_CLOSED, STATUS_OPEN, STATUS_RESOLVED } from "../utils";
 
-export const setupWebhooks = () => {
-  app.webhooks.on("issues.closed", async ({ payload }) => {
+/**
+ * Shape of an externalEntity mirror row, minus the columns the upsert helper
+ * fills in itself (`id`, `organizationId`, `lastSyncedAt`).
+ */
+type ExternalEntityFields = {
+  provider: string;
+  externalKey: string;
+  type: "issue" | "pull_request";
+  number: number;
+  repoFullName: string;
+  url: string;
+  title: string;
+  body: string | null;
+  state: string;
+  authorLogin: string | null;
+  assignees: string[];
+  labels: string[];
+  externalCreatedAt: Date;
+  externalUpdatedAt: Date;
+  closedAt: Date | null;
+  merged: boolean | null;
+  mergedAt: Date | null;
+  draft: boolean | null;
+  headRef: string | null;
+  baseRef: string | null;
+  deletedAt: Date | null;
+};
+
+/**
+ * Resolve the FrontDesk organization that owns a GitHub installation by
+ * matching the `installationId` persisted in the github integration config
+ * (see `routes/setup.ts`). Integrations are loaded into the live-state store,
+ * so this is an in-memory lookup.
+ */
+const resolveOrganizationId = (
+  installationId: number | undefined
+): string | null => {
+  if (!installationId) return null;
+
+  const integrations = store.query.integration.where({ type: "github" }).get();
+
+  for (const integration of integrations) {
+    if (!integration.configStr) continue;
     try {
-      const issueId = formatGitHubId(
-        payload.issue.id,
-        payload.repository.owner.login,
-        payload.repository.name
+      const config = JSON.parse(integration.configStr);
+      if (config.installationId === installationId) {
+        return integration.organizationId;
+      }
+    } catch {
+      // Ignore malformed config; other integrations may still match.
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Read the installation id from a webhook payload. Typed loosely because the
+ * octokit event unions don't expose `installation` uniformly across actions.
+ */
+const installationIdOf = (payload: unknown): number | undefined =>
+  (payload as { installation?: { id?: number } | null }).installation?.id;
+
+/**
+ * Insert or update the org-scoped mirror row for an issue/PR. Keyed by
+ * `(organizationId, externalKey)` on the query side until live-state supports
+ * composite indexes. Always refreshes `lastSyncedAt`.
+ */
+const upsertExternalEntity = async (
+  organizationId: string,
+  fields: ExternalEntityFields
+) => {
+  const existing = await fetchClient.query.externalEntity
+    .first({ organizationId, externalKey: fields.externalKey })
+    .get();
+
+  if (existing) {
+    await fetchClient.mutate.externalEntity.update(existing.id, {
+      ...fields,
+      lastSyncedAt: new Date(),
+    });
+    return;
+  }
+
+  await fetchClient.mutate.externalEntity.insert({
+    id: ulid().toLowerCase(),
+    organizationId,
+    ...fields,
+    lastSyncedAt: new Date(),
+  });
+};
+
+/**
+ * Reaction to the mirror moving into a closed/merged state: resolve any
+ * FrontDesk threads linked to the issue/PR. This is the only bespoke behaviour
+ * the integration still layers on top of the mirror upsert. Status changes are
+ * marked `replicatedStr: { github: true }` so they don't sync back to GitHub.
+ */
+const resolveLinkedThreads = (
+  fields: ExternalEntityFields,
+  meta: { merged?: boolean }
+) => {
+  const linkedThreads =
+    fields.type === "issue"
+      ? store.query.thread.where({ externalIssueId: fields.externalKey }).get()
+      : store.query.thread.where({ externalPrId: fields.externalKey }).get();
+
+  if (linkedThreads.length === 0) {
+    console.log(
+      `[GitHub] No threads linked to ${fields.type} ${fields.externalKey}`
+    );
+    return;
+  }
+
+  for (const thread of linkedThreads) {
+    if (
+      thread.status === STATUS_RESOLVED ||
+      thread.status === STATUS_CLOSED
+    ) {
+      console.log(
+        `[GitHub] Thread ${thread.id} already ${statusValues[thread.status]?.label}, skipping status update`
       );
-      const issueNumber = payload.issue.number;
-      const repoFullName = payload.repository.full_name;
+      continue;
+    }
 
-      const linkedThreads = store.query.thread
-        .where({ externalIssueId: issueId })
-        .get();
+    const oldStatus = thread.status ?? STATUS_OPEN;
+    const newStatus = STATUS_RESOLVED;
 
-      if (linkedThreads.length === 0) {
-        console.log(`[GitHub] No threads linked to issue ${issueId}`);
+    console.log(
+      `[GitHub] Updating thread ${thread.id} status from ${statusValues[oldStatus]?.label} to ${statusValues[newStatus]?.label}`
+    );
+
+    store.mutate.thread.update(thread.id, { status: newStatus });
+
+    store.mutate.update.insert({
+      id: ulid().toLowerCase(),
+      threadId: thread.id,
+      type: "status_changed",
+      createdAt: new Date(),
+      userId: null,
+      metadataStr: JSON.stringify({
+        oldStatus,
+        newStatus,
+        oldStatusLabel: statusValues[oldStatus]?.label,
+        newStatusLabel: statusValues[newStatus]?.label,
+        source: "github",
+        repoFullName: fields.repoFullName,
+        ...(fields.type === "issue"
+          ? { issueNumber: fields.number }
+          : { prNumber: fields.number, merged: meta.merged }),
+        userName: "GitHub Integration",
+      }),
+      // Mark as replicated from GitHub so it doesn't sync back
+      replicatedStr: JSON.stringify({ github: true }),
+    });
+  }
+};
+
+const buildIssueFields = (
+  payload: EmitterWebhookEvent<"issues">["payload"]
+): ExternalEntityFields => {
+  const { issue, repository } = payload;
+  return {
+    provider: "github",
+    externalKey: formatGitHubId(issue.id, repository.owner.login, repository.name),
+    type: "issue",
+    number: issue.number,
+    repoFullName: repository.full_name,
+    url: issue.html_url,
+    title: issue.title,
+    body: issue.body ?? null,
+    state: issue.state ?? "open",
+    authorLogin: issue.user?.login ?? null,
+    assignees: (issue.assignees ?? [])
+      .map((a) => a?.login)
+      .filter((login): login is string => Boolean(login)),
+    labels: (issue.labels ?? [])
+      .map((l) => (typeof l === "string" ? l : l?.name))
+      .filter((name): name is string => Boolean(name)),
+    externalCreatedAt: new Date(issue.created_at),
+    externalUpdatedAt: new Date(issue.updated_at),
+    closedAt: issue.closed_at ? new Date(issue.closed_at) : null,
+    merged: null,
+    mergedAt: null,
+    draft: null,
+    headRef: null,
+    baseRef: null,
+    deletedAt: null,
+  };
+};
+
+const buildPullRequestFields = (
+  payload: EmitterWebhookEvent<"pull_request">["payload"]
+): ExternalEntityFields => {
+  const { pull_request: pr, repository } = payload;
+  return {
+    provider: "github",
+    externalKey: formatGitHubId(pr.id, repository.owner.login, repository.name),
+    type: "pull_request",
+    number: pr.number,
+    repoFullName: repository.full_name,
+    url: pr.html_url,
+    title: pr.title,
+    body: pr.body ?? null,
+    state: pr.state,
+    authorLogin: pr.user?.login ?? null,
+    assignees: (pr.assignees ?? [])
+      .map((a) => a?.login)
+      .filter((login): login is string => Boolean(login)),
+    labels: (pr.labels ?? [])
+      .map((l) => l?.name)
+      .filter((name): name is string => Boolean(name)),
+    externalCreatedAt: new Date(pr.created_at),
+    externalUpdatedAt: new Date(pr.updated_at),
+    closedAt: pr.closed_at ? new Date(pr.closed_at) : null,
+    merged: pr.merged ?? false,
+    mergedAt: pr.merged_at ? new Date(pr.merged_at) : null,
+    draft: pr.draft ?? false,
+    headRef: pr.head.ref,
+    baseRef: pr.base.ref,
+    deletedAt: null,
+  };
+};
+
+export const setupWebhooks = () => {
+  // Keep the mirror current on every issue-mutating event. `deleted` and
+  // `transferred` (transfer-out) soft-delete the source row; `closed` resolves
+  // linked threads as a reaction to the mirror change.
+  app.webhooks.on("issues", async ({ payload }) => {
+    try {
+      const action = payload.action;
+      const organizationId = resolveOrganizationId(installationIdOf(payload));
+
+      if (!organizationId) {
+        console.warn(
+          `[GitHub] No organization for installation ${installationIdOf(payload)}, skipping issues.${action}`
+        );
         return;
       }
 
-      for (const thread of linkedThreads) {
-        if (thread.status === STATUS_CLOSED) {
-          console.log(
-            `[GitHub] Thread ${thread.id} is already closed, skipping status update`
-          );
-          continue;
-        }
+      const fields = buildIssueFields(payload);
 
-        const oldStatus = thread.status ?? STATUS_OPEN;
-        const newStatus = STATUS_RESOLVED;
+      if (action === "deleted" || action === "transferred") {
+        fields.deletedAt = new Date();
+      }
 
-        console.log(
-          `[GitHub] Updating thread ${thread.id} status from ${statusValues[oldStatus]?.label} to ${statusValues[newStatus]?.label}`
-        );
+      await upsertExternalEntity(organizationId, fields);
 
-        store.mutate.thread.update(thread.id, {
-          status: newStatus,
-        });
-
-        store.mutate.update.insert({
-          id: ulid().toLowerCase(),
-          threadId: thread.id,
-          type: "status_changed",
-          createdAt: new Date(),
-          userId: null,
-          metadataStr: JSON.stringify({
-            oldStatus,
-            newStatus,
-            oldStatusLabel: statusValues[oldStatus]?.label,
-            newStatusLabel: statusValues[newStatus]?.label,
-            source: "github",
-            issueNumber,
-            repoFullName,
-            userName: "GitHub Integration",
-          }),
-          // Mark as replicated from GitHub so it doesn't sync back
-          replicatedStr: JSON.stringify({ github: true }),
-        });
+      if (action === "closed") {
+        resolveLinkedThreads(fields, {});
       }
     } catch (error) {
-      console.error("[GitHub] Error handling issues.closed webhook:", error);
+      console.error("[GitHub] Error handling issues webhook:", error);
     }
   });
 
-  app.webhooks.on("pull_request.closed", async ({ payload }) => {
+  // Keep the mirror current on every pull-request-mutating event. `closed`
+  // (merged or not) resolves linked threads.
+  //
+  // NOTE: resolves the `pr_matched` TODO context — the mirror upsert lives
+  // here now. Re-enqueuing PR-matched synthesis stays out of scope.
+  app.webhooks.on("pull_request", async ({ payload }) => {
     try {
-      const pr = payload.pull_request;
-      const prNumber = pr.number;
-      const repoFullName = payload.repository.full_name;
-      const merged = pr.merged;
-      const owner = payload.repository.owner.login;
-      const repo = payload.repository.name;
+      const action = payload.action;
+      const organizationId = resolveOrganizationId(installationIdOf(payload));
 
-      console.log(
-        `[GitHub] Pull request ${
-          merged ? "merged" : "closed"
-        }: ${repoFullName}#${prNumber}`
-      );
-
-      // TODO(signals-overhaul issue 06): re-enqueue PR-matched synthesis via
-      // enqueueThreadRead({ kind: "pr_matched" }) here. The legacy embed-pr +
-      // match-pr-threads worker pipeline was dropped in issue 02.
-
-      // Update linked thread statuses
-      const prId = formatGitHubId(
-        pr.id,
-        owner,
-        repo,
-      );
-
-      const linkedThreads = store.query.thread
-        .where({ externalPrId: prId })
-        .get();
-
-      if (linkedThreads.length === 0) {
-        console.log(`[GitHub] No threads linked to PR ${prId}`);
+      if (!organizationId) {
+        console.warn(
+          `[GitHub] No organization for installation ${installationIdOf(payload)}, skipping pull_request.${action}`
+        );
         return;
       }
 
-      for (const thread of linkedThreads) {
-        if (thread.status === STATUS_CLOSED) {
-          console.log(
-            `[GitHub] Thread ${thread.id} is already closed, skipping status update`
-          );
-          continue;
-        }
+      const fields = buildPullRequestFields(payload);
 
-        const oldStatus = thread.status ?? STATUS_OPEN;
-        const newStatus = STATUS_RESOLVED;
+      await upsertExternalEntity(organizationId, fields);
 
-        console.log(
-          `[GitHub] Updating thread ${thread.id} status from ${statusValues[oldStatus]?.label} to ${statusValues[newStatus]?.label}`
-        );
-
-        store.mutate.thread.update(thread.id, {
-          status: newStatus,
-        });
-
-        store.mutate.update.insert({
-          id: ulid().toLowerCase(),
-          threadId: thread.id,
-          type: "status_changed",
-          createdAt: new Date(),
-          userId: null,
-          metadataStr: JSON.stringify({
-            oldStatus,
-            newStatus,
-            oldStatusLabel: statusValues[oldStatus]?.label,
-            newStatusLabel: statusValues[newStatus]?.label,
-            source: "github",
-            prNumber,
-            repoFullName,
-            merged,
-            userName: "GitHub Integration",
-          }),
-          // Mark as replicated from GitHub so it doesn't sync back
-          replicatedStr: JSON.stringify({ github: true }),
-        });
+      if (action === "closed") {
+        resolveLinkedThreads(fields, { merged: fields.merged ?? false });
       }
     } catch (error) {
-      console.error(
-        "[GitHub] Error handling pull_request.closed webhook:",
-        error
-      );
+      console.error("[GitHub] Error handling pull_request webhook:", error);
     }
   });
 

--- a/bun.lock
+++ b/bun.lock
@@ -113,7 +113,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@live-state/sync": "catalog:",
-        "@octokit/webhooks": "^13.3.0",
+        "@octokit/webhooks": "^14.0.0",
         "@workspace/schemas": "workspace:*",
         "@workspace/ui": "workspace:*",
         "api": "workspace:*",
@@ -969,7 +969,7 @@
 
     "@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
 
-    "@octokit/openapi-webhooks-types": ["@octokit/openapi-webhooks-types@11.0.0", "", {}, "sha512-ZBzCFj98v3SuRM7oBas6BHZMJRadlnDoeFfvm1olVxZnYeU6Vh97FhPxyS5aLh5pN51GYv2I51l/hVUAVkGBlA=="],
+    "@octokit/openapi-webhooks-types": ["@octokit/openapi-webhooks-types@12.1.0", "", {}, "sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA=="],
 
     "@octokit/plugin-paginate-graphql": ["@octokit/plugin-paginate-graphql@6.0.0", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-crfpnIoFiBtRkvPqOyLOsw12XsveYuY2ieP6uYDosoUegBJpSVxGwut9sxUgFFcll3VTOTqpUf8yGd8x1OmAkQ=="],
 
@@ -983,13 +983,13 @@
 
     "@octokit/request": ["@octokit/request@10.0.7", "", { "dependencies": { "@octokit/endpoint": "^11.0.2", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "fast-content-type-parse": "^3.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA=="],
 
-    "@octokit/request-error": ["@octokit/request-error@6.1.8", "", { "dependencies": { "@octokit/types": "^14.0.0" } }, "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ=="],
+    "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
 
     "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
 
-    "@octokit/webhooks": ["@octokit/webhooks@13.9.1", "", { "dependencies": { "@octokit/openapi-webhooks-types": "11.0.0", "@octokit/request-error": "^6.1.7", "@octokit/webhooks-methods": "^5.1.1" } }, "sha512-Nss2b4Jyn4wB3EAqAPJypGuCJFalz/ZujKBQQ5934To7Xw9xjf4hkr/EAByxQY7hp7MKd790bWGz7XYSTsHmaw=="],
+    "@octokit/webhooks": ["@octokit/webhooks@14.2.0", "", { "dependencies": { "@octokit/openapi-webhooks-types": "12.1.0", "@octokit/request-error": "^7.0.0", "@octokit/webhooks-methods": "^6.0.0" } }, "sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw=="],
 
-    "@octokit/webhooks-methods": ["@octokit/webhooks-methods@5.1.1", "", {}, "sha512-NGlEHZDseJTCj8TMMFehzwa9g7On4KJMPVHDSrHxCQumL6uSQR8wIkP/qesv52fXqV1BPf4pTxwtS31ldAt9Xg=="],
+    "@octokit/webhooks-methods": ["@octokit/webhooks-methods@6.0.0", "", {}, "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ=="],
 
     "@oozcitak/dom": ["@oozcitak/dom@2.0.2", "", { "dependencies": { "@oozcitak/infra": "^2.0.2", "@oozcitak/url": "^3.0.0", "@oozcitak/util": "^10.0.0" } }, "sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w=="],
 
@@ -1743,7 +1743,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -4471,22 +4471,6 @@
 
     "@node-minify/core/glob": ["glob@9.3.5", "", { "dependencies": { "fs.realpath": "^1.0.0", "minimatch": "^8.0.2", "minipass": "^4.2.4", "path-scurry": "^1.6.1" } }, "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q=="],
 
-    "@octokit/app/@octokit/webhooks": ["@octokit/webhooks@14.2.0", "", { "dependencies": { "@octokit/openapi-webhooks-types": "12.1.0", "@octokit/request-error": "^7.0.0", "@octokit/webhooks-methods": "^6.0.0" } }, "sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw=="],
-
-    "@octokit/auth-app/@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
-
-    "@octokit/auth-unauthenticated/@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
-
-    "@octokit/core/@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
-
-    "@octokit/oauth-methods/@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
-
-    "@octokit/plugin-retry/@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
-
-    "@octokit/request/@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
-
-    "@octokit/request-error/@octokit/types": ["@octokit/types@14.1.0", "", { "dependencies": { "@octokit/openapi-types": "^25.1.0" } }, "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g=="],
-
     "@opennextjs/aws/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "@opennextjs/aws/esbuild": ["esbuild@0.25.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.4", "@esbuild/android-arm": "0.25.4", "@esbuild/android-arm64": "0.25.4", "@esbuild/android-x64": "0.25.4", "@esbuild/darwin-arm64": "0.25.4", "@esbuild/darwin-x64": "0.25.4", "@esbuild/freebsd-arm64": "0.25.4", "@esbuild/freebsd-x64": "0.25.4", "@esbuild/linux-arm": "0.25.4", "@esbuild/linux-arm64": "0.25.4", "@esbuild/linux-ia32": "0.25.4", "@esbuild/linux-loong64": "0.25.4", "@esbuild/linux-mips64el": "0.25.4", "@esbuild/linux-ppc64": "0.25.4", "@esbuild/linux-riscv64": "0.25.4", "@esbuild/linux-s390x": "0.25.4", "@esbuild/linux-x64": "0.25.4", "@esbuild/netbsd-arm64": "0.25.4", "@esbuild/netbsd-x64": "0.25.4", "@esbuild/openbsd-arm64": "0.25.4", "@esbuild/openbsd-x64": "0.25.4", "@esbuild/sunos-x64": "0.25.4", "@esbuild/win32-arm64": "0.25.4", "@esbuild/win32-ia32": "0.25.4", "@esbuild/win32-x64": "0.25.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q=="],
@@ -4657,7 +4641,7 @@
 
     "@trigger.dev/sdk/ulid": ["ulid@2.4.0", "", { "bin": { "ulid": "bin/cli.js" } }, "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg=="],
 
-    "@types/bun/bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+    "@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
@@ -4811,10 +4795,6 @@
 
     "nypm/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
-    "octokit/@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
-
-    "octokit/@octokit/webhooks": ["@octokit/webhooks@14.2.0", "", { "dependencies": { "@octokit/openapi-webhooks-types": "12.1.0", "@octokit/request-error": "^7.0.0", "@octokit/webhooks-methods": "^6.0.0" } }, "sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw=="],
-
     "ora/log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
 
     "ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
@@ -4898,8 +4878,6 @@
     "web/lucide-react": ["lucide-react@0.475.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-NJzvVu1HwFVeZ+Gwq2q00KygM1aBhy/ZrhY9FsAgJtpB+E4R7uxRk9M2iKvHa6/vNxZydIB59htha4c2vvwvVg=="],
 
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
-
-    "worker/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "wrangler/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
 
@@ -5445,14 +5423,6 @@
 
     "@node-minify/core/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
-    "@octokit/app/@octokit/webhooks/@octokit/openapi-webhooks-types": ["@octokit/openapi-webhooks-types@12.1.0", "", {}, "sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA=="],
-
-    "@octokit/app/@octokit/webhooks/@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
-
-    "@octokit/app/@octokit/webhooks/@octokit/webhooks-methods": ["@octokit/webhooks-methods@6.0.0", "", {}, "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ=="],
-
-    "@octokit/request-error/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@25.1.0", "", {}, "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA=="],
-
     "@opennextjs/aws/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q=="],
 
     "@opennextjs/aws/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.4", "", { "os": "android", "cpu": "arm" }, "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ=="],
@@ -5751,10 +5721,6 @@
 
     "nypm/pkg-types/confbox": ["confbox@0.2.2", "", {}, "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ=="],
 
-    "octokit/@octokit/webhooks/@octokit/openapi-webhooks-types": ["@octokit/openapi-webhooks-types@12.1.0", "", {}, "sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA=="],
-
-    "octokit/@octokit/webhooks/@octokit/webhooks-methods": ["@octokit/webhooks-methods@6.0.0", "", {}, "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ=="],
-
     "ora/log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
     "ora/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
@@ -5882,8 +5848,6 @@
     "web/fumadocs-mdx/esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
     "web/fumadocs-mdx/zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
-
-    "worker/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
 


### PR DESCRIPTION
Implements [FRO-182](https://linear.app/front-desk/issue/FRO-182). Re-targets `main` now that FRO-181 (#280) is merged — supersedes #281, which was aimed at the (now-merged) FRO-181 branch.

## What

Keep the org-scoped `externalEntity` mirror current from GitHub webhook events, with all writes going through custom router procedures.

### Webhook handler (`apps/github`)
- Listens on the `issues` and `pull_request` umbrella events (covering `opened/edited/closed/reopened/labeled/unlabeled/assigned/unassigned/deleted/transferred` and the PR equivalents incl. `synchronize/ready_for_review/converted_to_draft`) and upserts a mirror row on each.
- `issues.deleted` / `transferred` (transfer-out) soft-delete the source row.
- The linked-thread resolve-on-close/merge logic is now a *reaction* to the mirror entering a closed state, not bespoke per-event handling. Preserves the `replicatedStr: { github: true }` "don't sync back" marker.
- Resolves the `pr_matched` TODO context — mirror upsert lives here now; synthesis re-enqueue stays out of scope.
- Org resolution matches `installation.id` against the integration config.

### Custom mutations (`apps/api`)
- `externalEntity` default insert/update mutators are disabled; writes go through custom `upsert` / `softDelete` procedures (internal API key only) that own the `(organizationId, externalKey)` identity and `lastSyncedAt` / `deletedAt` bookkeeping.
- Both procedures run their find-then-insert/update inside `db.transaction` so concurrent events for the same entity don't race into duplicate rows.

### Notes
- Bumped `apps/github`'s direct `@octokit/webhooks` from `^13` → `^14` to match the version `octokit@5` bundles, aligning handler payload types with `EmitterWebhookEvent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the org-scoped GitHub mirror (`externalEntity`) up to date by upserting on every `issues` and `pull_request` webhook, and resolves linked threads when items close or merge. Implements FRO-182.

- New Features
  - Upsert `externalEntity` on all issue/PR events; soft-delete on `issues.deleted` and `issues.transferred`.
  - Resolve linked threads when the mirror closes; preserve `replicatedStr: { github: true }`.
  - Route writes through `externalEntity.upsert` and `externalEntity.softDelete` (internal key only), owning `(organizationId, externalKey)` and `lastSyncedAt`/`deletedAt`, wrapped in a DB transaction.
  - Resolve org by matching GitHub `installation.id` to the integration config.

- Dependencies
  - Bumped `@octokit/webhooks` to `^14.0.0` to align with `octokit@5` types.

<sup>Written for commit e3c3ab0a8863f5e2f7e07812d61e8c3aa034928e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded GitHub integration to synchronize all issue and pull request states in real-time, not just closed events.
  * Added automatic handling for transferred and deleted issues and pull requests.
  * Enhanced status updates between external and internal tracking systems.

* **Chores**
  * Updated third-party dependencies for stability and performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->