### PR TITLE
feat(github): backfill a repo's full issue/PR history on connect (FRO-183)

### DIFF
--- a/apps/github/build.ts
+++ b/apps/github/build.ts
@@ -1,6 +1,7 @@
 await Bun.build({
   entrypoints: ["./src/index.ts"],
   outdir: "./dist",
+  target: "bun",
   minify: false,
   sourcemap: "none",
   external: [

--- a/apps/github/src/index.ts
+++ b/apps/github/src/index.ts
@@ -1,11 +1,13 @@
 import Elysia from "elysia";
 import "./env";
+import { startBackfillWorker } from "./jobs/backfill";
 import { app as githubApp } from "./lib/github";
 import { issuesRoutes, pullRequestsRoutes, setupRoutes } from "./routes";
 import { getPort } from "./utils";
 import { setupWebhooks } from "./webhooks";
 
 setupWebhooks();
+startBackfillWorker();
 
 const app = new Elysia()
   .use(issuesRoutes)

--- a/apps/github/src/jobs/backfill.ts
+++ b/apps/github/src/jobs/backfill.ts
@@ -14,17 +14,23 @@ import {
 
 const PER_PAGE = 100;
 
+type BackfillTally = { upserted: number; failed: number };
+
 /**
  * Page every issue in the repo and upsert it into the mirror. The issues
  * endpoint returns PRs too (they're issues under the hood); those are skipped
  * here and handled by `backfillPullRequests`, which has the PR-only facets.
+ *
+ * A single failing upsert is logged and skipped rather than thrown: otherwise it
+ * would kill the job and force a retry to restart paging from page 1, and a
+ * persistently bad item would block the whole repo forever.
  */
 const backfillIssues = async (
   octokit: Awaited<ReturnType<typeof getOctokit>>,
   data: BackfillJobData,
   repo: RepoRef
-): Promise<number> => {
-  let count = 0;
+): Promise<BackfillTally> => {
+  const tally: BackfillTally = { upserted: 0, failed: 0 };
 
   const iterator = octokit.paginate.iterator(
     "GET /repos/{owner}/{repo}/issues",
@@ -39,28 +45,36 @@ const backfillIssues = async (
   for await (const { data: page } of iterator) {
     for (const issue of page) {
       if (issue.pull_request) continue;
-      await upsertExternalEntity(
-        data.organizationId,
-        buildIssueFields(issue, repo)
-      );
-      count++;
+      try {
+        await upsertExternalEntity(
+          data.organizationId,
+          buildIssueFields(issue, repo)
+        );
+        tally.upserted++;
+      } catch (error) {
+        tally.failed++;
+        console.error(
+          `[GitHub] Failed to upsert issue ${repo.fullName}#${issue.number}:`,
+          error
+        );
+      }
     }
   }
 
-  return count;
+  return tally;
 };
 
 /**
  * Page every pull request in the repo and upsert it into the mirror. The list
  * endpoint omits the `merged` boolean; `buildPullRequestFields` derives it from
- * `merged_at`.
+ * `merged_at`. Per-item failures are logged and skipped (see `backfillIssues`).
  */
 const backfillPullRequests = async (
   octokit: Awaited<ReturnType<typeof getOctokit>>,
   data: BackfillJobData,
   repo: RepoRef
-): Promise<number> => {
-  let count = 0;
+): Promise<BackfillTally> => {
+  const tally: BackfillTally = { upserted: 0, failed: 0 };
 
   const iterator = octokit.paginate.iterator(
     "GET /repos/{owner}/{repo}/pulls",
@@ -74,15 +88,23 @@ const backfillPullRequests = async (
 
   for await (const { data: page } of iterator) {
     for (const pr of page) {
-      await upsertExternalEntity(
-        data.organizationId,
-        buildPullRequestFields(pr, repo)
-      );
-      count++;
+      try {
+        await upsertExternalEntity(
+          data.organizationId,
+          buildPullRequestFields(pr, repo)
+        );
+        tally.upserted++;
+      } catch (error) {
+        tally.failed++;
+        console.error(
+          `[GitHub] Failed to upsert PR ${repo.fullName}#${pr.number}:`,
+          error
+        );
+      }
     }
   }
 
-  return count;
+  return tally;
 };
 
 /**
@@ -109,7 +131,9 @@ export const handleBackfillJob = async (job: Job<BackfillJobData>) => {
   const pullRequests = await backfillPullRequests(octokit, data, repo);
 
   console.log(
-    `[GitHub] Backfilled ${data.fullName}: ${issues} issues, ${pullRequests} PRs`
+    `[GitHub] Backfilled ${data.fullName}: ${issues.upserted} issues ` +
+      `(${issues.failed} failed), ${pullRequests.upserted} PRs ` +
+      `(${pullRequests.failed} failed)`
   );
 
   return { repoFullName: data.fullName, issues, pullRequests };

--- a/apps/github/src/jobs/backfill.ts
+++ b/apps/github/src/jobs/backfill.ts
@@ -14,7 +14,17 @@ import {
 
 const PER_PAGE = 100;
 
+/**
+ * Abort the whole job after this many consecutive upsert failures. Isolated bad
+ * items are tolerated (logged + skipped), but a run of back-to-back failures
+ * signals a systemic problem (auth, network, DB) — throwing lets BullMQ retry
+ * the entire job with backoff instead of silently reporting success.
+ */
+const MAX_CONSECUTIVE_FAILURES = 10;
+
 type BackfillTally = { upserted: number; failed: number };
+
+class SystemicBackfillError extends Error {}
 
 /**
  * Page every issue in the repo and upsert it into the mirror. The issues
@@ -23,7 +33,8 @@ type BackfillTally = { upserted: number; failed: number };
  *
  * A single failing upsert is logged and skipped rather than thrown: otherwise it
  * would kill the job and force a retry to restart paging from page 1, and a
- * persistently bad item would block the whole repo forever.
+ * persistently bad item would block the whole repo forever. A run of
+ * `MAX_CONSECUTIVE_FAILURES` does abort, so a systemic outage retries the job.
  */
 const backfillIssues = async (
   octokit: Awaited<ReturnType<typeof getOctokit>>,
@@ -31,6 +42,7 @@ const backfillIssues = async (
   repo: RepoRef
 ): Promise<BackfillTally> => {
   const tally: BackfillTally = { upserted: 0, failed: 0 };
+  let consecutiveFailures = 0;
 
   const iterator = octokit.paginate.iterator(
     "GET /repos/{owner}/{repo}/issues",
@@ -51,12 +63,19 @@ const backfillIssues = async (
           buildIssueFields(issue, repo)
         );
         tally.upserted++;
+        consecutiveFailures = 0;
       } catch (error) {
         tally.failed++;
+        consecutiveFailures++;
         console.error(
           `[GitHub] Failed to upsert issue ${repo.fullName}#${issue.number}:`,
           error
         );
+        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+          throw new SystemicBackfillError(
+            `Aborting ${repo.fullName} issue backfill after ${consecutiveFailures} consecutive upsert failures`
+          );
+        }
       }
     }
   }
@@ -67,7 +86,8 @@ const backfillIssues = async (
 /**
  * Page every pull request in the repo and upsert it into the mirror. The list
  * endpoint omits the `merged` boolean; `buildPullRequestFields` derives it from
- * `merged_at`. Per-item failures are logged and skipped (see `backfillIssues`).
+ * `merged_at`. Per-item failures are logged and skipped, and a run of
+ * `MAX_CONSECUTIVE_FAILURES` aborts the job (see `backfillIssues`).
  */
 const backfillPullRequests = async (
   octokit: Awaited<ReturnType<typeof getOctokit>>,
@@ -75,6 +95,7 @@ const backfillPullRequests = async (
   repo: RepoRef
 ): Promise<BackfillTally> => {
   const tally: BackfillTally = { upserted: 0, failed: 0 };
+  let consecutiveFailures = 0;
 
   const iterator = octokit.paginate.iterator(
     "GET /repos/{owner}/{repo}/pulls",
@@ -94,12 +115,19 @@ const backfillPullRequests = async (
           buildPullRequestFields(pr, repo)
         );
         tally.upserted++;
+        consecutiveFailures = 0;
       } catch (error) {
         tally.failed++;
+        consecutiveFailures++;
         console.error(
           `[GitHub] Failed to upsert PR ${repo.fullName}#${pr.number}:`,
           error
         );
+        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+          throw new SystemicBackfillError(
+            `Aborting ${repo.fullName} PR backfill after ${consecutiveFailures} consecutive upsert failures`
+          );
+        }
       }
     }
   }

--- a/apps/github/src/jobs/backfill.ts
+++ b/apps/github/src/jobs/backfill.ts
@@ -1,0 +1,143 @@
+import { type Job, Worker } from "bullmq";
+import {
+  buildIssueFields,
+  buildPullRequestFields,
+  type RepoRef,
+  upsertExternalEntity,
+} from "../lib/external-entity";
+import { getOctokit } from "../lib/github";
+import {
+  BACKFILL_QUEUE,
+  type BackfillJobData,
+  createRedisConnection,
+} from "../lib/queue";
+
+const PER_PAGE = 100;
+
+/**
+ * Page every issue in the repo and upsert it into the mirror. The issues
+ * endpoint returns PRs too (they're issues under the hood); those are skipped
+ * here and handled by `backfillPullRequests`, which has the PR-only facets.
+ */
+const backfillIssues = async (
+  octokit: Awaited<ReturnType<typeof getOctokit>>,
+  data: BackfillJobData,
+  repo: RepoRef
+): Promise<number> => {
+  let count = 0;
+
+  const iterator = octokit.paginate.iterator(
+    "GET /repos/{owner}/{repo}/issues",
+    {
+      owner: data.owner,
+      repo: data.repo,
+      state: "all",
+      per_page: PER_PAGE,
+    }
+  );
+
+  for await (const { data: page } of iterator) {
+    for (const issue of page) {
+      if (issue.pull_request) continue;
+      await upsertExternalEntity(
+        data.organizationId,
+        buildIssueFields(issue, repo)
+      );
+      count++;
+    }
+  }
+
+  return count;
+};
+
+/**
+ * Page every pull request in the repo and upsert it into the mirror. The list
+ * endpoint omits the `merged` boolean; `buildPullRequestFields` derives it from
+ * `merged_at`.
+ */
+const backfillPullRequests = async (
+  octokit: Awaited<ReturnType<typeof getOctokit>>,
+  data: BackfillJobData,
+  repo: RepoRef
+): Promise<number> => {
+  let count = 0;
+
+  const iterator = octokit.paginate.iterator(
+    "GET /repos/{owner}/{repo}/pulls",
+    {
+      owner: data.owner,
+      repo: data.repo,
+      state: "all",
+      per_page: PER_PAGE,
+    }
+  );
+
+  for await (const { data: page } of iterator) {
+    for (const pr of page) {
+      await upsertExternalEntity(
+        data.organizationId,
+        buildPullRequestFields(pr, repo)
+      );
+      count++;
+    }
+  }
+
+  return count;
+};
+
+/**
+ * Mirror a repo's full issue + PR history. Idempotent: every write goes through
+ * the upsert-by-`externalKey` path, so re-running only refreshes existing rows.
+ * GitHub rate limits are absorbed by octokit's built-in throttling/retry plus
+ * the job-level exponential backoff configured on the queue.
+ */
+export const handleBackfillJob = async (job: Job<BackfillJobData>) => {
+  const data = job.data;
+  const repo: RepoRef = {
+    owner: data.owner,
+    name: data.repo,
+    fullName: data.fullName,
+  };
+
+  console.log(
+    `[GitHub] Backfilling ${data.fullName} (org ${data.organizationId})`
+  );
+
+  const octokit = await getOctokit(data.installationId);
+
+  const issues = await backfillIssues(octokit, data, repo);
+  const pullRequests = await backfillPullRequests(octokit, data, repo);
+
+  console.log(
+    `[GitHub] Backfilled ${data.fullName}: ${issues} issues, ${pullRequests} PRs`
+  );
+
+  return { repoFullName: data.fullName, issues, pullRequests };
+};
+
+/**
+ * Start the backfill worker. Called once at app startup alongside the webhook
+ * listeners.
+ */
+export const startBackfillWorker = (): Worker<BackfillJobData> => {
+  const worker = new Worker<BackfillJobData>(BACKFILL_QUEUE, handleBackfillJob, {
+    connection: createRedisConnection(),
+    concurrency: 2,
+    removeOnComplete: { count: 50, age: 24 * 3600 },
+    removeOnFail: { count: 200 },
+  });
+
+  worker.on("completed", (job) => {
+    console.log(`[GitHub] Backfill job ${job.id} completed`);
+  });
+
+  worker.on("failed", (job, err) => {
+    console.error(`[GitHub] Backfill job ${job?.id} failed:`, err);
+  });
+
+  worker.on("error", (err) => {
+    console.error("[GitHub] Backfill worker error:", err);
+  });
+
+  return worker;
+};

--- a/apps/github/src/lib/external-entity.ts
+++ b/apps/github/src/lib/external-entity.ts
@@ -1,0 +1,168 @@
+import { formatGitHubId } from "@workspace/schemas/external-issue";
+import { fetchClient } from "./live-state";
+
+/**
+ * Shape of an externalEntity mirror row, minus the columns the upsert helper
+ * fills in itself (`id`, `organizationId`, `lastSyncedAt`).
+ */
+export type ExternalEntityFields = {
+  provider: string;
+  externalKey: string;
+  type: "issue" | "pull_request";
+  number: number;
+  repoFullName: string;
+  url: string;
+  title: string;
+  body: string | null;
+  state: string;
+  authorLogin: string | null;
+  assignees: string[];
+  labels: string[];
+  externalCreatedAt: Date;
+  externalUpdatedAt: Date;
+  closedAt: Date | null;
+  merged: boolean | null;
+  mergedAt: Date | null;
+  draft: boolean | null;
+  headRef: string | null;
+  baseRef: string | null;
+};
+
+/**
+ * Repository descriptor needed to build an `externalKey`. Webhook payloads carry
+ * this on `payload.repository`; the backfill job carries it on the job data.
+ */
+export type RepoRef = {
+  owner: string;
+  name: string;
+  fullName: string;
+};
+
+/**
+ * Structural subset of a GitHub issue shared by the webhook payload and the REST
+ * list response. Typed loosely so both octokit shapes satisfy it.
+ */
+export type GitHubIssueLike = {
+  id: number;
+  number: number;
+  html_url: string;
+  title: string;
+  body?: string | null;
+  state?: string | null;
+  user?: { login?: string } | null;
+  assignees?: ({ login?: string } | null)[] | null;
+  labels?: (string | { name?: string } | null)[] | null;
+  created_at: string;
+  updated_at: string;
+  closed_at?: string | null;
+};
+
+/**
+ * Structural subset of a GitHub pull request shared by the webhook payload and
+ * the REST list response. The list endpoint omits the `merged` boolean, so it is
+ * derived from `merged_at` when absent.
+ */
+export type GitHubPullRequestLike = {
+  id: number;
+  number: number;
+  html_url: string;
+  title: string;
+  body?: string | null;
+  state: string;
+  user?: { login?: string } | null;
+  assignees?: ({ login?: string } | null)[] | null;
+  labels?: ({ name?: string } | null)[] | null;
+  created_at: string;
+  updated_at: string;
+  closed_at?: string | null;
+  merged?: boolean | null;
+  merged_at?: string | null;
+  draft?: boolean | null;
+  head: { ref: string };
+  base: { ref: string };
+};
+
+/**
+ * Map a GitHub issue (webhook payload or REST list item) onto the mirror row
+ * fields. Shared by the live webhook handler and the connect-time backfill job
+ * so both write identical rows.
+ */
+export const buildIssueFields = (
+  issue: GitHubIssueLike,
+  repo: RepoRef
+): ExternalEntityFields => ({
+  provider: "github",
+  externalKey: formatGitHubId(issue.id, repo.owner, repo.name),
+  type: "issue",
+  number: issue.number,
+  repoFullName: repo.fullName,
+  url: issue.html_url,
+  title: issue.title,
+  body: issue.body ?? null,
+  state: issue.state ?? "open",
+  authorLogin: issue.user?.login ?? null,
+  assignees: (issue.assignees ?? [])
+    .map((a) => a?.login)
+    .filter((login): login is string => Boolean(login)),
+  labels: (issue.labels ?? [])
+    .map((l) => (typeof l === "string" ? l : l?.name))
+    .filter((name): name is string => Boolean(name)),
+  externalCreatedAt: new Date(issue.created_at),
+  externalUpdatedAt: new Date(issue.updated_at),
+  closedAt: issue.closed_at ? new Date(issue.closed_at) : null,
+  merged: null,
+  mergedAt: null,
+  draft: null,
+  headRef: null,
+  baseRef: null,
+});
+
+/**
+ * Map a GitHub pull request (webhook payload or REST list item) onto the mirror
+ * row fields. `merged` is derived from `merged_at` when the source omits the
+ * boolean (the REST list endpoint does).
+ */
+export const buildPullRequestFields = (
+  pr: GitHubPullRequestLike,
+  repo: RepoRef
+): ExternalEntityFields => ({
+  provider: "github",
+  externalKey: formatGitHubId(pr.id, repo.owner, repo.name),
+  type: "pull_request",
+  number: pr.number,
+  repoFullName: repo.fullName,
+  url: pr.html_url,
+  title: pr.title,
+  body: pr.body ?? null,
+  state: pr.state,
+  authorLogin: pr.user?.login ?? null,
+  assignees: (pr.assignees ?? [])
+    .map((a) => a?.login)
+    .filter((login): login is string => Boolean(login)),
+  labels: (pr.labels ?? [])
+    .map((l) => l?.name)
+    .filter((name): name is string => Boolean(name)),
+  externalCreatedAt: new Date(pr.created_at),
+  externalUpdatedAt: new Date(pr.updated_at),
+  closedAt: pr.closed_at ? new Date(pr.closed_at) : null,
+  merged: pr.merged ?? pr.merged_at != null,
+  mergedAt: pr.merged_at ? new Date(pr.merged_at) : null,
+  draft: pr.draft ?? false,
+  headRef: pr.head.ref,
+  baseRef: pr.base.ref,
+});
+
+/**
+ * Insert or update the org-scoped mirror row for an issue/PR via the custom
+ * `externalEntity.upsert` procedure, which owns the
+ * `(organizationId, externalKey)` identity and `lastSyncedAt` bookkeeping.
+ */
+export const upsertExternalEntity = async (
+  organizationId: string,
+  fields: ExternalEntityFields
+) => {
+  await fetchClient.mutate.externalEntity.upsert({
+    organizationId,
+    ...fields,
+  });
+};

--- a/apps/github/src/lib/queue.ts
+++ b/apps/github/src/lib/queue.ts
@@ -1,0 +1,85 @@
+import { Queue } from "bullmq";
+import Redis from "ioredis";
+
+/**
+ * Queue + connection for the github app's own BullMQ jobs. Integration apps own
+ * their jobs (apps/worker is only the ingestion pipeline), so the queue and its
+ * processor both live inside this app.
+ */
+export const BACKFILL_QUEUE = "github-backfill";
+const BACKFILL_JOB_NAME = "backfill-repo";
+
+/**
+ * Data for a repo backfill: everything the processor needs to authenticate as
+ * the installation and page the repo's issues/PRs.
+ */
+export type BackfillJobData = {
+  organizationId: string;
+  installationId: number;
+  owner: string;
+  repo: string;
+  fullName: string;
+};
+
+/**
+ * Create a Redis connection configured for BullMQ (`maxRetriesPerRequest: null`
+ * is required by both Queue and Worker). Mirrors the worker app's connection
+ * resolution: prefer `REDIS_URL`, fall back to discrete host/port/etc.
+ */
+export const createRedisConnection = (): Redis => {
+  if (process.env.REDIS_URL) {
+    return new Redis(process.env.REDIS_URL, { maxRetriesPerRequest: null });
+  }
+
+  const redisConfig: {
+    host: string;
+    port?: number;
+    password?: string;
+    db?: number;
+    maxRetriesPerRequest: null;
+  } = {
+    host: process.env.REDIS_HOST ?? "localhost",
+    maxRetriesPerRequest: null,
+  };
+
+  if (process.env.REDIS_PORT) {
+    redisConfig.port = Number.parseInt(process.env.REDIS_PORT, 10);
+  }
+
+  if (process.env.REDIS_PASSWORD) {
+    redisConfig.password = process.env.REDIS_PASSWORD;
+  }
+
+  if (process.env.REDIS_DB) {
+    redisConfig.db = Number.parseInt(process.env.REDIS_DB, 10);
+  }
+
+  return new Redis(redisConfig);
+};
+
+let queue: Queue<BackfillJobData> | null = null;
+
+const getQueue = (): Queue<BackfillJobData> => {
+  if (!queue) {
+    queue = new Queue<BackfillJobData>(BACKFILL_QUEUE, {
+      connection: createRedisConnection(),
+    });
+  }
+  return queue;
+};
+
+/**
+ * Enqueue a backfill for a single repo. The job id is derived from
+ * `(organizationId, fullName)` so re-connecting or re-adding the same repo
+ * coalesces onto one pending job rather than piling up duplicates — the
+ * processor itself is also idempotent (upsert-by-externalKey).
+ */
+export const enqueueRepoBackfill = async (data: BackfillJobData) => {
+  await getQueue().add(BACKFILL_JOB_NAME, data, {
+    jobId: `backfill:${data.organizationId}:${data.fullName}`,
+    attempts: 3,
+    backoff: { type: "exponential", delay: 10_000 },
+    removeOnComplete: { count: 50, age: 24 * 3600 },
+    removeOnFail: { count: 200 },
+  });
+};

--- a/apps/github/src/lib/queue.ts
+++ b/apps/github/src/lib/queue.ts
@@ -73,10 +73,14 @@ const getQueue = (): Queue<BackfillJobData> => {
  * `(organizationId, fullName)` so re-connecting or re-adding the same repo
  * coalesces onto one pending job rather than piling up duplicates — the
  * processor itself is also idempotent (upsert-by-externalKey).
+ *
+ * BullMQ reserves `:` as a Redis key separator and rejects it in custom job
+ * ids, so the parts are joined with `_` (and `fullName`'s `/` is replaced too).
  */
 export const enqueueRepoBackfill = async (data: BackfillJobData) => {
+  const jobId = `backfill_${data.organizationId}_${data.fullName.replace("/", "_")}`;
   await getQueue().add(BACKFILL_JOB_NAME, data, {
-    jobId: `backfill:${data.organizationId}:${data.fullName}`,
+    jobId,
     attempts: 3,
     backoff: { type: "exponential", delay: 10_000 },
     removeOnComplete: { count: 50, age: 24 * 3600 },

--- a/apps/github/src/routes/setup.ts
+++ b/apps/github/src/routes/setup.ts
@@ -2,6 +2,7 @@ import Elysia from "elysia";
 import { z } from "zod";
 import { getOctokit } from "../lib/github";
 import { fetchClient } from "../lib/live-state";
+import { enqueueRepoBackfill } from "../lib/queue";
 import { getBaseUrl } from "../utils";
 
 const setupQuerySchema = z.object({
@@ -82,6 +83,20 @@ export const setupRoutes = new Elysia({ prefix: "/api/github" }).get(
           repos,
         }),
       });
+
+      // Mirror each in-scope repo's full issue/PR history. Idempotent and
+      // coalesced per repo, so re-running setup is safe.
+      await Promise.all(
+        repos.map((repo) =>
+          enqueueRepoBackfill({
+            organizationId: orgId,
+            installationId,
+            owner: repo.owner,
+            repo: repo.name,
+            fullName: repo.fullName,
+          })
+        )
+      );
 
       set.redirect = `${getBaseUrl()}/app/settings/organization/integration/github`;
     } catch (error) {

--- a/apps/github/src/routes/setup.ts
+++ b/apps/github/src/routes/setup.ts
@@ -58,17 +58,13 @@ export const setupRoutes = new Elysia({ prefix: "/api/github" }).get(
 
       const octokit = await getOctokit(installationId);
 
-      const { data: reposData } = await octokit.request(
+      // Paginate so installations with >100 repos are fully captured.
+      const installationRepos = await octokit.paginate(
         "GET /installation/repositories",
-        {
-          per_page: 100,
-          headers: {
-            "X-GitHub-Api-Version": "2022-11-28",
-          },
-        }
+        { per_page: 100 }
       );
 
-      const repos = reposData.repositories.map((repo) => ({
+      const repos = installationRepos.map((repo) => ({
         fullName: repo.full_name,
         owner: repo.owner.login,
         name: repo.name,
@@ -85,8 +81,10 @@ export const setupRoutes = new Elysia({ prefix: "/api/github" }).get(
       });
 
       // Mirror each in-scope repo's full issue/PR history. Idempotent and
-      // coalesced per repo, so re-running setup is safe.
-      await Promise.all(
+      // coalesced per repo, so re-running setup is safe. The integration config
+      // is already persisted at this point, so a failed enqueue (e.g. transient
+      // Redis outage) must not fail the setup redirect — log and move on.
+      const enqueueResults = await Promise.allSettled(
         repos.map((repo) =>
           enqueueRepoBackfill({
             organizationId: orgId,
@@ -97,6 +95,15 @@ export const setupRoutes = new Elysia({ prefix: "/api/github" }).get(
           })
         )
       );
+
+      for (const [index, result] of enqueueResults.entries()) {
+        if (result.status === "rejected") {
+          console.error(
+            `[GitHub] Failed to enqueue backfill for ${repos[index]?.fullName}:`,
+            result.reason
+          );
+        }
+      }
 
       set.redirect = `${getBaseUrl()}/app/settings/organization/integration/github`;
     } catch (error) {

--- a/apps/github/src/webhooks/index.ts
+++ b/apps/github/src/webhooks/index.ts
@@ -1,37 +1,14 @@
-import type { EmitterWebhookEvent } from "@octokit/webhooks";
-import { formatGitHubId } from "@workspace/schemas/external-issue";
 import { statusValues } from "@workspace/ui/components/indicator";
 import { ulid } from "ulid";
+import {
+  buildIssueFields,
+  buildPullRequestFields,
+  type ExternalEntityFields,
+  upsertExternalEntity,
+} from "../lib/external-entity";
 import { app } from "../lib/github";
 import { fetchClient, store } from "../lib/live-state";
 import { STATUS_CLOSED, STATUS_OPEN, STATUS_RESOLVED } from "../utils";
-
-/**
- * Shape of an externalEntity mirror row, minus the columns the upsert helper
- * fills in itself (`id`, `organizationId`, `lastSyncedAt`).
- */
-type ExternalEntityFields = {
-  provider: string;
-  externalKey: string;
-  type: "issue" | "pull_request";
-  number: number;
-  repoFullName: string;
-  url: string;
-  title: string;
-  body: string | null;
-  state: string;
-  authorLogin: string | null;
-  assignees: string[];
-  labels: string[];
-  externalCreatedAt: Date;
-  externalUpdatedAt: Date;
-  closedAt: Date | null;
-  merged: boolean | null;
-  mergedAt: Date | null;
-  draft: boolean | null;
-  headRef: string | null;
-  baseRef: string | null;
-};
 
 /**
  * Resolve the FrontDesk organization that owns a GitHub installation by
@@ -67,21 +44,6 @@ const resolveOrganizationId = (
  */
 const installationIdOf = (payload: unknown): number | undefined =>
   (payload as { installation?: { id?: number } | null }).installation?.id;
-
-/**
- * Insert or update the org-scoped mirror row for an issue/PR via the custom
- * `externalEntity.upsert` procedure, which owns the
- * `(organizationId, externalKey)` identity and `lastSyncedAt` bookkeeping.
- */
-const upsertExternalEntity = async (
-  organizationId: string,
-  fields: ExternalEntityFields
-) => {
-  await fetchClient.mutate.externalEntity.upsert({
-    organizationId,
-    ...fields,
-  });
-};
 
 /**
  * Reaction to the mirror moving into a closed/merged state: resolve any
@@ -149,69 +111,18 @@ const resolveLinkedThreads = (
   }
 };
 
-const buildIssueFields = (
-  payload: EmitterWebhookEvent<"issues">["payload"]
-): ExternalEntityFields => {
-  const { issue, repository } = payload;
-  return {
-    provider: "github",
-    externalKey: formatGitHubId(issue.id, repository.owner.login, repository.name),
-    type: "issue",
-    number: issue.number,
-    repoFullName: repository.full_name,
-    url: issue.html_url,
-    title: issue.title,
-    body: issue.body ?? null,
-    state: issue.state ?? "open",
-    authorLogin: issue.user?.login ?? null,
-    assignees: (issue.assignees ?? [])
-      .map((a) => a?.login)
-      .filter((login): login is string => Boolean(login)),
-    labels: (issue.labels ?? [])
-      .map((l) => (typeof l === "string" ? l : l?.name))
-      .filter((name): name is string => Boolean(name)),
-    externalCreatedAt: new Date(issue.created_at),
-    externalUpdatedAt: new Date(issue.updated_at),
-    closedAt: issue.closed_at ? new Date(issue.closed_at) : null,
-    merged: null,
-    mergedAt: null,
-    draft: null,
-    headRef: null,
-    baseRef: null,
-  };
-};
-
-const buildPullRequestFields = (
-  payload: EmitterWebhookEvent<"pull_request">["payload"]
-): ExternalEntityFields => {
-  const { pull_request: pr, repository } = payload;
-  return {
-    provider: "github",
-    externalKey: formatGitHubId(pr.id, repository.owner.login, repository.name),
-    type: "pull_request",
-    number: pr.number,
-    repoFullName: repository.full_name,
-    url: pr.html_url,
-    title: pr.title,
-    body: pr.body ?? null,
-    state: pr.state,
-    authorLogin: pr.user?.login ?? null,
-    assignees: (pr.assignees ?? [])
-      .map((a) => a?.login)
-      .filter((login): login is string => Boolean(login)),
-    labels: (pr.labels ?? [])
-      .map((l) => l?.name)
-      .filter((name): name is string => Boolean(name)),
-    externalCreatedAt: new Date(pr.created_at),
-    externalUpdatedAt: new Date(pr.updated_at),
-    closedAt: pr.closed_at ? new Date(pr.closed_at) : null,
-    merged: pr.merged ?? false,
-    mergedAt: pr.merged_at ? new Date(pr.merged_at) : null,
-    draft: pr.draft ?? false,
-    headRef: pr.head.ref,
-    baseRef: pr.base.ref,
-  };
-};
+/**
+ * Build a `RepoRef` from a webhook `repository` payload.
+ */
+const repoRefFromWebhook = (repository: {
+  owner: { login: string };
+  name: string;
+  full_name: string;
+}) => ({
+  owner: repository.owner.login,
+  name: repository.name,
+  fullName: repository.full_name,
+});
 
 export const setupWebhooks = () => {
   // Keep the mirror current on every issue-mutating event. `deleted` and
@@ -229,7 +140,10 @@ export const setupWebhooks = () => {
         return;
       }
 
-      const fields = buildIssueFields(payload);
+      const fields = buildIssueFields(
+        payload.issue,
+        repoRefFromWebhook(payload.repository)
+      );
 
       if (action === "deleted" || action === "transferred") {
         await fetchClient.mutate.externalEntity.softDelete({
@@ -266,7 +180,10 @@ export const setupWebhooks = () => {
         return;
       }
 
-      const fields = buildPullRequestFields(payload);
+      const fields = buildPullRequestFields(
+        payload.pull_request,
+        repoRefFromWebhook(payload.repository)
+      );
 
       await upsertExternalEntity(organizationId, fields);
 


### PR DESCRIPTION
## What

Implements [FRO-183](https://linear.app/front-desk/issue/FRO-183): a connect-time backfill that mirrors a repo's full issue/PR history into `externalEntity`.

New `github-backfill` BullMQ queue + worker living **inside the github app** (integration apps own their jobs; `apps/worker` is only the ingestion pipeline). On integration connect, a backfill job is enqueued per in-scope repo; the processor pages the GitHub REST API for all issues + PRs and upserts each through the same `externalEntity.upsert` path the webhooks use.

## Changes

- **`lib/external-entity.ts`** (new) — extracts the GitHub→mirror mapping helper shared with the FRO-182 webhook path. `buildIssueFields`/`buildPullRequestFields` now take a structural issue/PR + `RepoRef`, so both the webhook payload and the REST list response satisfy them. `merged` is derived from `merged_at` when the source omits the boolean (the REST list endpoint does).
- **`lib/queue.ts`** (new) — `github-backfill` queue + Redis connection (same `REDIS_URL`/host fallback as the worker app). `enqueueRepoBackfill` uses a deterministic `jobId` (`backfill:{org}:{repo}`) so re-connecting coalesces; 3 attempts with exponential backoff.
- **`jobs/backfill.ts`** (new) — the processor. Pages `/issues` (skipping PRs) and `/pulls` with `octokit.paginate.iterator`, upserting each row. Idempotent (upsert-by-`externalKey`); rate limits absorbed by octokit throttle/retry + job-level backoff. `startBackfillWorker()` boots the worker.
- **`webhooks/index.ts`** — now imports the shared helpers instead of defining its own.
- **`index.ts`** — calls `startBackfillWorker()` alongside `setupWebhooks()`.
- **`routes/setup.ts`** — enqueues a backfill per repo after the integration config is saved on connect.
- **`build.ts`** — `target: "bun"` so bullmq/ioredis Node builtins bundle (was defaulting to a browser build).

## Notes

The issue mentions "integration connect / repo added to config" — the connect path is the only entry point that currently writes `repos`. There's no separate "repo added" flow today, so that case is covered by re-running setup, which the dedup `jobId` + idempotent upsert make safe.

## Verification

`bun run --filter github typecheck`, `lint`, and `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfills a repo’s full GitHub issue and PR history on connect, mirroring into the `externalEntity` table. Implements FRO-183 with an in-app `bullmq` queue/worker; jobs are idempotent, coalesced per repo, and abort on systemic failures.

- **New Features**
  - Added `github-backfill` `bullmq` queue and worker inside the GitHub app; started alongside webhooks using `ioredis`.
  - On connect, enqueue one backfill per repo with deterministic `jobId` (`backfill_{orgId}_{owner_repo}`; no `:`, `/` replaced), 3 attempts, exponential backoff.
  - Processor pages issues and PRs via `octokit.paginate.iterator`, skips PRs from issues, and upserts each; per-item failures are logged and skipped with tallies. Abort after 10 consecutive upsert failures to trigger a retry.
  - Derives PR `merged` from `merged_at` when the REST list omits it; safe to re-run setup.
  - Setup now paginates installation repositories (>100) and enqueues; failed enqueues are logged and don’t block the redirect.

- **Refactors**
  - Extracted shared GitHub→mirror mappers to `lib/external-entity.ts` and updated webhooks to use them for identical rows.
  - Set `build.ts` `target: "bun"` so `bullmq`/`ioredis` Node builtins bundle correctly.

<sup>Written for commit f700a5937f5eb06e789ed90b2cea04340b0813f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated historical backfill during setup to sync existing issues and pull requests into the mirror.
  * Introduced a queued background backfill worker with concurrency, progress/error logging, and automatic job cleanup.
* **Refactor**
  * Centralized issue and pull request mirror field mapping so both webhooks and backfill write consistent data.
  * Updated webhook handling to use the shared mapping/upsert helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->