### PR TITLE
feat(github): drift reconciliation cron for the mirror (FRO-184)

### DIFF
--- a/apps/github/src/index.ts
+++ b/apps/github/src/index.ts
@@ -1,6 +1,7 @@
 import Elysia from "elysia";
 import "./env";
 import { startBackfillWorker } from "./jobs/backfill";
+import { startReconcileWorker } from "./jobs/reconcile";
 import { app as githubApp } from "./lib/github";
 import { issuesRoutes, pullRequestsRoutes, setupRoutes } from "./routes";
 import { getPort } from "./utils";
@@ -8,6 +9,7 @@ import { setupWebhooks } from "./webhooks";
 
 setupWebhooks();
 startBackfillWorker();
+startReconcileWorker();
 
 const app = new Elysia()
   .use(issuesRoutes)

--- a/apps/github/src/jobs/reconcile.ts
+++ b/apps/github/src/jobs/reconcile.ts
@@ -41,6 +41,24 @@ class SystemicReconcileError extends Error {}
 type GithubRepoConfig = { fullName: string; owner: string; name: string };
 
 /**
+ * Guard against malformed repo entries in a (potentially hand-edited or legacy)
+ * integration config: all three fields must be non-empty strings to build a
+ * usable reconcile job.
+ */
+const isValidRepoConfig = (repo: unknown): repo is GithubRepoConfig => {
+  if (typeof repo !== "object" || repo === null) return false;
+  const { fullName, owner, name } = repo as Record<string, unknown>;
+  return (
+    typeof fullName === "string" &&
+    fullName.length > 0 &&
+    typeof owner === "string" &&
+    owner.length > 0 &&
+    typeof name === "string" &&
+    name.length > 0
+  );
+};
+
+/**
  * Re-page one endpoint's worth of entities and reconcile them against the
  * mirror snapshot. For each upstream item we record its key in `seen` (so the
  * deletion pass can tell what still exists) and upsert it only when GitHub's
@@ -235,8 +253,19 @@ export const handleReconcileDispatch = async () => {
     const { installationId, repos } = config;
     if (!installationId || !repos?.length) continue;
 
+    // The config is built from octokit data in setup.ts, but it's untrusted at
+    // read time (hand-edited/legacy rows). Drop malformed entries so they don't
+    // produce broken jobs that just fail-and-retry forever.
+    const validRepos = repos.filter(isValidRepoConfig);
+    if (validRepos.length < repos.length) {
+      console.error(
+        `[GitHub] Skipping ${repos.length - validRepos.length} malformed repo entr(y/ies) for integration ${integration.id}`
+      );
+    }
+    if (!validRepos.length) continue;
+
     const results = await Promise.allSettled(
-      repos.map((repo) =>
+      validRepos.map((repo) =>
         enqueueRepoReconcile({
           organizationId: integration.organizationId,
           installationId,
@@ -250,7 +279,7 @@ export const handleReconcileDispatch = async () => {
     for (const [index, result] of results.entries()) {
       if (result.status === "rejected") {
         console.error(
-          `[GitHub] Failed to enqueue reconcile for ${repos[index]?.fullName}:`,
+          `[GitHub] Failed to enqueue reconcile for ${validRepos[index]?.fullName}:`,
           result.reason
         );
       } else {

--- a/apps/github/src/jobs/reconcile.ts
+++ b/apps/github/src/jobs/reconcile.ts
@@ -1,0 +1,310 @@
+import { type Job, Worker } from "bullmq";
+import {
+  buildIssueFields,
+  buildPullRequestFields,
+  type ExternalEntityFields,
+  type RepoRef,
+  upsertExternalEntity,
+} from "../lib/external-entity";
+import { getOctokit } from "../lib/github";
+import { fetchClient, store } from "../lib/live-state";
+import {
+  createRedisConnection,
+  ensureReconcileScheduler,
+  enqueueRepoReconcile,
+  RECONCILE_DISPATCH_JOB_NAME,
+  RECONCILE_QUEUE,
+  RECONCILE_REPO_JOB_NAME,
+  type ReconcileRepoJobData,
+} from "../lib/queue";
+
+const PER_PAGE = 100;
+
+/**
+ * Abort the whole job after this many consecutive write failures. Isolated bad
+ * items are tolerated (logged + skipped); a run of back-to-back failures signals
+ * a systemic problem (auth, network, DB) and throwing lets BullMQ retry the
+ * whole job with backoff. Mirrors the backfill job's tolerance.
+ */
+const MAX_CONSECUTIVE_FAILURES = 10;
+
+type ReconcileTally = {
+  upserted: number;
+  unchanged: number;
+  deleted: number;
+  failed: number;
+};
+
+class SystemicReconcileError extends Error {}
+
+/** Shape of a connected repo as persisted in the github integration config. */
+type GithubRepoConfig = { fullName: string; owner: string; name: string };
+
+/**
+ * Re-page one endpoint's worth of entities and reconcile them against the
+ * mirror snapshot. For each upstream item we record its key in `seen` (so the
+ * deletion pass can tell what still exists) and upsert it only when GitHub's
+ * `updated_at` is newer than the timestamp we already stored — the stored
+ * `externalUpdatedAt` is our per-row "updated-since" cursor. Comparing GitHub
+ * timestamps to each other (rather than to `lastSyncedAt`, which is on our
+ * clock) avoids cross-clock skew.
+ *
+ * `toFields` returns null for items this pass should skip (the issues endpoint
+ * also returns PRs, which the PR pass owns).
+ */
+const reconcilePage = async <TItem>(
+  organizationId: string,
+  iterator: AsyncIterable<{ data: TItem[] }>,
+  toFields: (item: TItem) => ExternalEntityFields | null,
+  cursorByKey: Map<string, number>,
+  seen: Set<string>,
+  tally: ReconcileTally,
+  label: string
+): Promise<void> => {
+  let consecutiveFailures = 0;
+
+  for await (const { data: page } of iterator) {
+    for (const item of page) {
+      const fields = toFields(item);
+      if (!fields) continue;
+
+      seen.add(fields.externalKey);
+
+      const cursor = cursorByKey.get(fields.externalKey);
+      if (cursor !== undefined && fields.externalUpdatedAt.getTime() <= cursor) {
+        tally.unchanged++;
+        continue;
+      }
+
+      try {
+        await upsertExternalEntity(organizationId, fields);
+        tally.upserted++;
+        consecutiveFailures = 0;
+      } catch (error) {
+        tally.failed++;
+        consecutiveFailures++;
+        console.error(
+          `[GitHub] Failed to reconcile ${label} ${fields.repoFullName}#${fields.number}:`,
+          error
+        );
+        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+          throw new SystemicReconcileError(
+            `Aborting ${fields.repoFullName} ${label} reconcile after ${consecutiveFailures} consecutive write failures`
+          );
+        }
+      }
+    }
+  }
+};
+
+/**
+ * Reconcile a single repo's mirror with upstream GitHub.
+ *
+ * Re-pages the full issue + PR list (`state=all`) rather than relying on
+ * GitHub's server-side `since` filter: `since` would hide deleted entities, and
+ * we need the complete current key set to detect upstream deletions. The
+ * per-row cursor keeps this cheap on writes — only entities GitHub has touched
+ * since we last stored them are re-upserted. Any mirrored entity absent from the
+ * re-page (a missed `deleted`/`transferred` webhook) is soft-deleted.
+ */
+export const handleReconcileRepo = async (job: Job<ReconcileRepoJobData>) => {
+  const data = job.data;
+  const repo: RepoRef = {
+    owner: data.owner,
+    name: data.repo,
+    fullName: data.fullName,
+  };
+
+  console.log(
+    `[GitHub] Reconciling ${data.fullName} (org ${data.organizationId})`
+  );
+
+  // Snapshot the current (non-deleted) mirror rows for this repo: the cursor for
+  // skipping unchanged upserts, and the baseline for detecting deletions.
+  const mirrorRows = await fetchClient.query.externalEntity
+    .where({
+      organizationId: data.organizationId,
+      repoFullName: data.fullName,
+      deletedAt: null,
+    })
+    .get();
+
+  const cursorByKey = new Map<string, number>();
+  for (const row of mirrorRows) {
+    cursorByKey.set(row.externalKey, new Date(row.externalUpdatedAt).getTime());
+  }
+
+  const octokit = await getOctokit(data.installationId);
+  const seen = new Set<string>();
+  const tally: ReconcileTally = {
+    upserted: 0,
+    unchanged: 0,
+    deleted: 0,
+    failed: 0,
+  };
+
+  await reconcilePage(
+    data.organizationId,
+    octokit.paginate.iterator("GET /repos/{owner}/{repo}/issues", {
+      owner: data.owner,
+      repo: data.repo,
+      state: "all",
+      per_page: PER_PAGE,
+    }),
+    // The issues endpoint returns PRs too; the PR pass owns those.
+    (issue) => (issue.pull_request ? null : buildIssueFields(issue, repo)),
+    cursorByKey,
+    seen,
+    tally,
+    "issue"
+  );
+
+  await reconcilePage(
+    data.organizationId,
+    octokit.paginate.iterator("GET /repos/{owner}/{repo}/pulls", {
+      owner: data.owner,
+      repo: data.repo,
+      state: "all",
+      per_page: PER_PAGE,
+    }),
+    (pr) => buildPullRequestFields(pr, repo),
+    cursorByKey,
+    seen,
+    tally,
+    "pull request"
+  );
+
+  // Anything still in the mirror but not seen upstream was deleted/transferred
+  // out without us getting the webhook. Soft-delete it.
+  let consecutiveFailures = 0;
+  for (const row of mirrorRows) {
+    if (seen.has(row.externalKey)) continue;
+    try {
+      await fetchClient.mutate.externalEntity.softDelete({
+        organizationId: data.organizationId,
+        externalKey: row.externalKey,
+      });
+      tally.deleted++;
+      consecutiveFailures = 0;
+    } catch (error) {
+      tally.failed++;
+      consecutiveFailures++;
+      console.error(
+        `[GitHub] Failed to soft-delete ${row.repoFullName}#${row.number}:`,
+        error
+      );
+      if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+        throw new SystemicReconcileError(
+          `Aborting ${data.fullName} soft-delete pass after ${consecutiveFailures} consecutive failures`
+        );
+      }
+    }
+  }
+
+  console.log(
+    `[GitHub] Reconciled ${data.fullName}: ${tally.upserted} upserted, ` +
+      `${tally.unchanged} unchanged, ${tally.deleted} soft-deleted ` +
+      `(${tally.failed} failed)`
+  );
+
+  return { repoFullName: data.fullName, ...tally };
+};
+
+/**
+ * Fan out one reconcile job per connected repo across every enabled github
+ * integration. Reads the integrations from the live-state store (kept in sync in
+ * this process), mirroring how the webhook handler resolves installations.
+ */
+export const handleReconcileDispatch = async () => {
+  const integrations = store.query.integration.where({ type: "github" }).get();
+
+  let enqueued = 0;
+  for (const integration of integrations) {
+    if (!integration.enabled || !integration.configStr) continue;
+
+    let config: { installationId?: number; repos?: GithubRepoConfig[] };
+    try {
+      config = JSON.parse(integration.configStr);
+    } catch {
+      console.error(
+        `[GitHub] Skipping reconcile for integration ${integration.id}: malformed config`
+      );
+      continue;
+    }
+
+    const { installationId, repos } = config;
+    if (!installationId || !repos?.length) continue;
+
+    const results = await Promise.allSettled(
+      repos.map((repo) =>
+        enqueueRepoReconcile({
+          organizationId: integration.organizationId,
+          installationId,
+          owner: repo.owner,
+          repo: repo.name,
+          fullName: repo.fullName,
+        })
+      )
+    );
+
+    for (const [index, result] of results.entries()) {
+      if (result.status === "rejected") {
+        console.error(
+          `[GitHub] Failed to enqueue reconcile for ${repos[index]?.fullName}:`,
+          result.reason
+        );
+      } else {
+        enqueued++;
+      }
+    }
+  }
+
+  console.log(`[GitHub] Reconcile dispatch enqueued ${enqueued} repo job(s)`);
+  return { enqueued };
+};
+
+/**
+ * Start the reconcile worker and register the daily dispatch schedule. Called
+ * once at app startup alongside the webhook listeners and backfill worker.
+ */
+export const startReconcileWorker = (): Worker => {
+  const worker = new Worker(
+    RECONCILE_QUEUE,
+    async (job: Job) => {
+      if (job.name === RECONCILE_REPO_JOB_NAME) {
+        return handleReconcileRepo(job as Job<ReconcileRepoJobData>);
+      }
+      if (job.name === RECONCILE_DISPATCH_JOB_NAME) {
+        return handleReconcileDispatch();
+      }
+      console.warn(`[GitHub] Unknown reconcile job name: ${job.name}`);
+    },
+    {
+      connection: createRedisConnection(),
+      concurrency: 2,
+      removeOnComplete: { count: 50, age: 24 * 3600 },
+      removeOnFail: { count: 200 },
+    }
+  );
+
+  worker.on("completed", (job) => {
+    console.log(`[GitHub] Reconcile job ${job.id} (${job.name}) completed`);
+  });
+
+  worker.on("failed", (job, err) => {
+    console.error(
+      `[GitHub] Reconcile job ${job?.id} (${job?.name}) failed:`,
+      err
+    );
+  });
+
+  worker.on("error", (err) => {
+    console.error("[GitHub] Reconcile worker error:", err);
+  });
+
+  ensureReconcileScheduler().catch((err) => {
+    console.error("[GitHub] Failed to register reconcile scheduler:", err);
+  });
+
+  return worker;
+};

--- a/apps/github/src/lib/queue.ts
+++ b/apps/github/src/lib/queue.ts
@@ -10,6 +10,23 @@ export const BACKFILL_QUEUE = "github-backfill";
 const BACKFILL_JOB_NAME = "backfill-repo";
 
 /**
+ * Drift-reconciliation queue. A daily repeatable `dispatch` job fans out one
+ * `repo` job per connected repo; each repo job re-pages issues/PRs and
+ * reconciles the mirror against upstream (see `jobs/reconcile.ts`). Both job
+ * types share this queue and are routed by name in the worker.
+ */
+export const RECONCILE_QUEUE = "github-reconcile";
+export const RECONCILE_DISPATCH_JOB_NAME = "reconcile-dispatch";
+export const RECONCILE_REPO_JOB_NAME = "reconcile-repo";
+const RECONCILE_SCHEDULER_ID = "github-reconcile-daily";
+
+/**
+ * Daily at 04:00 UTC — a low-traffic backstop for missed/dropped webhooks.
+ * Tighten the cadence only if drift shows up in practice.
+ */
+const RECONCILE_CRON = "0 4 * * *";
+
+/**
  * Data for a repo backfill: everything the processor needs to authenticate as
  * the installation and page the repo's issues/PRs.
  */
@@ -20,6 +37,12 @@ export type BackfillJobData = {
   repo: string;
   fullName: string;
 };
+
+/**
+ * Data for a single-repo reconcile. Structurally identical to a backfill (same
+ * auth + paging inputs); kept as a distinct type for intent.
+ */
+export type ReconcileRepoJobData = BackfillJobData;
 
 /**
  * Create a Redis connection configured for BullMQ (`maxRetriesPerRequest: null`
@@ -84,6 +107,52 @@ export const enqueueRepoBackfill = async (data: BackfillJobData) => {
     attempts: 3,
     backoff: { type: "exponential", delay: 10_000 },
     removeOnComplete: { count: 50, age: 24 * 3600 },
+    removeOnFail: { count: 200 },
+  });
+};
+
+let reconcileQueue: Queue | null = null;
+
+const getReconcileQueue = (): Queue => {
+  if (!reconcileQueue) {
+    reconcileQueue = new Queue(RECONCILE_QUEUE, {
+      connection: createRedisConnection(),
+    });
+  }
+  return reconcileQueue;
+};
+
+/**
+ * Register (or refresh) the daily repeatable dispatch job. `upsertJobScheduler`
+ * is idempotent, so this is safe to call on every app boot.
+ */
+export const ensureReconcileScheduler = async () => {
+  await getReconcileQueue().upsertJobScheduler(
+    RECONCILE_SCHEDULER_ID,
+    { pattern: RECONCILE_CRON },
+    {
+      name: RECONCILE_DISPATCH_JOB_NAME,
+      opts: {
+        removeOnComplete: { count: 20, age: 7 * 24 * 3600 },
+        removeOnFail: { count: 50 },
+      },
+    }
+  );
+};
+
+/**
+ * Enqueue a reconcile for a single repo. The job id is derived from
+ * `(organizationId, fullName)` so overlapping dispatch runs coalesce onto one
+ * pending job per repo rather than piling up duplicates — the processor itself
+ * is also idempotent (upsert-by-externalKey).
+ */
+export const enqueueRepoReconcile = async (data: ReconcileRepoJobData) => {
+  const jobId = `reconcile_${data.organizationId}_${data.fullName.replace("/", "_")}`;
+  await getReconcileQueue().add(RECONCILE_REPO_JOB_NAME, data, {
+    jobId,
+    attempts: 3,
+    backoff: { type: "exponential", delay: 10_000 },
+    removeOnComplete: { count: 100, age: 24 * 3600 },
     removeOnFail: { count: 200 },
   });
 };


### PR DESCRIPTION
## Summary

Daily backstop that catches missed/dropped webhooks so the `externalEntity` mirror doesn't drift from GitHub. Closes FRO-184.

- New `github-reconcile` queue in the github app (integration apps own their jobs). A daily repeatable **dispatch** job (`upsertJobScheduler`, cron `0 4 * * *`, idempotent on boot) fans out one reconcile job per connected repo across enabled integrations.
- `handleReconcileRepo` snapshots the repo's non-deleted mirror rows, re-pages the full issue + PR list (`state=all`), upserts via the shared `upsertExternalEntity` path, and soft-deletes any mirrored entity not seen upstream.
- Reuses the backfill job's `MAX_CONSECUTIVE_FAILURES` tolerance and per-repo job-id coalescing.

## Design notes

- **Cursor is per-row `externalUpdatedAt`, not `lastSyncedAt`.** Upserts are gated by comparing GitHub's `updated_at` against the timestamp we stored — both on GitHub's clock — so unchanged entities are skipped without cross-clock skew.
- **Full re-page rather than GitHub's server-side `since`.** The `since` filter hides deleted/transferred entities, which would make "soft-delete rows that no longer exist upstream" impossible. Full enumeration gives the current key set for deletion detection; the per-row cursor keeps writes cheap. Cadence can tighten later if drift shows up in practice.

## Test plan

- [x] `bun run --filter github typecheck`
- [x] `bun run --filter github lint` (only pre-existing `event as any` warning in `index.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a daily GitHub drift-reconciliation cron to keep the `externalEntity` mirror in sync and backstop missed webhooks, per FRO-184. Dispatches per-repo reconcile jobs and runs a worker on boot.

- **New Features**
  - New `github-reconcile` queue with a daily 04:00 UTC cron (`0 4 * * *`) that dispatches one `reconcile-repo` job per connected repo across enabled integrations.
  - Re-page issues and PRs (`state=all`), upsert only when GitHub `updated_at` > stored `externalUpdatedAt`, and soft-delete mirrored rows not seen upstream (full enumeration to catch deletions).
  - Coalesced job IDs per org/repo, retries with exponential backoff, and abort after consecutive write failures.
  - Idempotent scheduler via `ensureReconcileScheduler`; worker started at boot with `startReconcileWorker`.

- **Bug Fixes**
  - Validate and skip malformed repo entries in integration configs before enqueueing, preventing broken jobs from retrying forever.

<sup>Written for commit 4042c7cd12048a109967341697c18ab1d2cbee80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

