### PR TITLE
feat(github): reactive externalEntity mirror for issue/PR linking (FRO-185)

### DIFF
--- a/apps/api/src/lib/queue.ts
+++ b/apps/api/src/lib/queue.ts
@@ -232,7 +232,10 @@ export const enqueueGithubBackfill = async (
     return null;
   }
 
-  const jobId = `backfill_${data.organizationId}_${data.fullName.replace("/", "_")}`;
+  // Escape existing underscores before swapping the `/` separator so the jobId
+  // stays injective (e.g. `a_b/c` and `a/b_c` map to distinct ids).
+  const safeFullName = data.fullName.replaceAll("_", "__").replace("/", "_");
+  const jobId = `backfill_${data.organizationId}_${safeFullName}`;
   const job = await queue.add(GITHUB_BACKFILL_JOB_NAME, data, {
     jobId,
     attempts: 3,

--- a/apps/api/src/lib/queue.ts
+++ b/apps/api/src/lib/queue.ts
@@ -1,9 +1,9 @@
-import { Queue } from "bullmq";
-import Redis from "ioredis";
 import type {
   ThreadReadJobData,
   ThreadReadKind,
 } from "@workspace/schemas/signals";
+import { Queue } from "bullmq";
+import Redis from "ioredis";
 import "../env";
 
 // TEMP: Worker service stopped on Railway — re-enable in prod when worker is
@@ -100,8 +100,7 @@ export const enqueueThreadRead = async (
   }
 
   const delay = opts.delayMs ?? DEFAULT_DEBOUNCE_MS;
-  const priority =
-    THREAD_READ_PRIORITY_VALUES[opts.priority ?? "normal"];
+  const priority = THREAD_READ_PRIORITY_VALUES[opts.priority ?? "normal"];
 
   // TODO(issue-09): manual kind should bypass dedup (unique jobId + delay 0)
   // and invalidate synthesis-track idempotency keys before enqueueing. For now
@@ -174,6 +173,72 @@ export const enqueueCrawlDocumentation = async (
 
   const job = await queue.add("crawl-documentation", data, {
     jobId: `crawl-${data.documentationSourceId}`,
+  });
+
+  return job.id ?? null;
+};
+
+// GitHub backfill queue
+//
+// The github app owns this job: it runs the processor (apps/github/src/jobs/
+// backfill.ts) and defines the canonical queue/job constants and enqueue helper
+// (apps/github/src/lib/queue.ts). The API only *enqueues* onto the same Redis
+// queue — currently for the dev-only manual sync that stands in for webhooks
+// locally. Keep the queue name, job name and jobId scheme in sync with the
+// owner.
+const GITHUB_BACKFILL_QUEUE = "github-backfill";
+const GITHUB_BACKFILL_JOB_NAME = "backfill-repo";
+
+export type GithubBackfillJobData = {
+  organizationId: string;
+  installationId: number;
+  owner: string;
+  repo: string;
+  fullName: string;
+};
+
+let githubBackfillQueue: Queue<GithubBackfillJobData> | null = null;
+
+const getGithubBackfillQueue = (): Queue<GithubBackfillJobData> | null => {
+  if (githubBackfillQueue) {
+    return githubBackfillQueue;
+  }
+
+  connection ??= createRedisConnection();
+  if (!connection) {
+    return null;
+  }
+
+  githubBackfillQueue = new Queue<GithubBackfillJobData>(
+    GITHUB_BACKFILL_QUEUE,
+    {
+      connection,
+    },
+  );
+  return githubBackfillQueue;
+};
+
+/**
+ * Enqueue a full issue/PR backfill for a single repo onto the github app's
+ * queue. The jobId is derived from `(organizationId, fullName)` so re-running
+ * coalesces onto one pending job per repo — the processor is idempotent
+ * (upsert-by-externalKey), so re-running only refreshes existing rows.
+ */
+export const enqueueGithubBackfill = async (
+  data: GithubBackfillJobData,
+): Promise<string | null> => {
+  const queue = getGithubBackfillQueue();
+  if (!queue) {
+    return null;
+  }
+
+  const jobId = `backfill_${data.organizationId}_${data.fullName.replace("/", "_")}`;
+  const job = await queue.add(GITHUB_BACKFILL_JOB_NAME, data, {
+    jobId,
+    attempts: 3,
+    backoff: { type: "exponential", delay: 10_000 },
+    removeOnComplete: { count: 50, age: 24 * 3600 },
+    removeOnFail: { count: 200 },
   });
 
   return job.id ?? null;

--- a/apps/api/src/live-state/router/external-entity.ts
+++ b/apps/api/src/live-state/router/external-entity.ts
@@ -15,6 +15,19 @@ import { schema } from "../schema";
  * entities; only the integration (internal API key) writes.
  */
 
+const githubBackfillConfigSchema = z.object({
+  installationId: z.number().int().positive().optional(),
+  repos: z
+    .array(
+      z.object({
+        owner: z.string().min(1),
+        name: z.string().min(1),
+        fullName: z.string().min(1),
+      }),
+    )
+    .default([]),
+});
+
 const externalEntityFields = z.object({
   organizationId: z.string(),
   provider: z.string(),
@@ -184,12 +197,18 @@ export default privateRoute
         throw new Error("GITHUB_INTEGRATION_NOT_CONFIGURED");
       }
 
-      const config = JSON.parse(integration.configStr) as {
-        installationId?: number;
-        repos?: Array<{ owner: string; name: string; fullName: string }>;
-      };
-      const { repos, installationId } = config;
-      if (!repos || repos.length === 0) {
+      let rawConfig: unknown;
+      try {
+        rawConfig = JSON.parse(integration.configStr);
+      } catch {
+        throw new Error("GITHUB_INTEGRATION_NOT_CONFIGURED");
+      }
+      const parsedConfig = githubBackfillConfigSchema.safeParse(rawConfig);
+      if (!parsedConfig.success) {
+        throw new Error("GITHUB_INTEGRATION_NOT_CONFIGURED");
+      }
+      const { repos, installationId } = parsedConfig.data;
+      if (repos.length === 0) {
         throw new Error("GITHUB_REPOSITORIES_NOT_CONFIGURED");
       }
       if (!installationId) {
@@ -209,7 +228,8 @@ export default privateRoute
       );
 
       const enqueued = results.filter(
-        (result) => result.status === "fulfilled",
+        (result): result is PromiseFulfilledResult<string> =>
+          result.status === "fulfilled" && result.value !== null,
       ).length;
 
       return { enqueued, repos: repos.length };

--- a/apps/api/src/live-state/router/external-entity.ts
+++ b/apps/api/src/live-state/router/external-entity.ts
@@ -1,6 +1,7 @@
 // TODO refactor with new live-state mental model
 import { ulid } from "ulid";
 import { z } from "zod";
+import { enqueueGithubBackfill } from "../../lib/queue";
 import { privateRoute } from "../factories";
 import { schema } from "../schema";
 
@@ -136,5 +137,81 @@ export default privateRoute
         });
         return existing.id;
       });
+    }),
+
+    /**
+     * Dev-only manual sync: enqueue a full issue/PR backfill for each connected
+     * repo, populating the mirror without webhooks (which aren't wired up
+     * locally). The github app owns the backfill worker that processes the jobs;
+     * this just kicks them off. Refuses to run in production, where webhooks +
+     * the daily reconcile keep the mirror current.
+     */
+    syncFromGithub: mutation(
+      z.object({
+        organizationId: z.string(),
+      }),
+    ).handler(async ({ req, db }) => {
+      if (process.env.NODE_ENV === "production") {
+        throw new Error("DEV_ONLY");
+      }
+
+      const { organizationId } = req.input;
+
+      // Authorize: internal key, or a session user who belongs to the org.
+      let authorized = !!req.context?.internalApiKey;
+      if (!authorized && req.context?.session?.userId) {
+        const selfOrgUser = Object.values(
+          await db.find(schema.organizationUser, {
+            where: {
+              organizationId,
+              userId: req.context.session.userId,
+              enabled: true,
+            },
+          }),
+        )[0];
+        authorized = !!selfOrgUser;
+      }
+      if (!authorized) {
+        throw new Error("UNAUTHORIZED");
+      }
+
+      const integration = Object.values(
+        await db.find(schema.integration, {
+          where: { organizationId, type: "github", enabled: true },
+        }),
+      )[0];
+      if (!integration || !integration.configStr) {
+        throw new Error("GITHUB_INTEGRATION_NOT_CONFIGURED");
+      }
+
+      const config = JSON.parse(integration.configStr) as {
+        installationId?: number;
+        repos?: Array<{ owner: string; name: string; fullName: string }>;
+      };
+      const { repos, installationId } = config;
+      if (!repos || repos.length === 0) {
+        throw new Error("GITHUB_REPOSITORIES_NOT_CONFIGURED");
+      }
+      if (!installationId) {
+        throw new Error("GITHUB_INSTALLATION_NOT_CONFIGURED");
+      }
+
+      const results = await Promise.allSettled(
+        repos.map((repo) =>
+          enqueueGithubBackfill({
+            organizationId,
+            installationId,
+            owner: repo.owner,
+            repo: repo.name,
+            fullName: repo.fullName,
+          }),
+        ),
+      );
+
+      const enqueued = results.filter(
+        (result) => result.status === "fulfilled",
+      ).length;
+
+      return { enqueued, repos: repos.length };
     }),
   }));

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -1,13 +1,8 @@
 // TODO refactor with new live-state mental model
-import {
-  type ExternalIssue,
-  type ExternalPullRequest,
-  formatGitHubId,
-} from "@workspace/schemas/external-issue";
+import { formatGitHubId } from "@workspace/schemas/external-issue";
 import { ulid } from "ulid";
 import z from "zod";
 import { authorize } from "../../lib/authorize";
-import { createReadThroughCache } from "../../lib/cache/read-through.js";
 import {
   acceptInlineSuggestionInputSchema,
   acceptReadInputSchema,
@@ -30,173 +25,6 @@ import { schema } from "../schema";
 
 const GITHUB_SERVER_URL =
   process.env.BASE_GITHUB_SERVER_URL || "http://localhost:3334";
-
-type FetchIssuesInput = {
-  organizationId: string;
-  state: string;
-  repos: Array<{ owner: string; name: string; fullName: string }>;
-  installationId: number;
-};
-
-type FetchPRsInput = {
-  organizationId: string;
-  state: string;
-  repos: Array<{ owner: string; name: string; fullName: string }>;
-  installationId: number;
-};
-
-// Helper function to fetch issues from GitHub
-const fetchIssuesFromGitHub = async (
-  input: FetchIssuesInput,
-): Promise<{ issues: ExternalIssue[]; count: number }> => {
-  const allIssues: ExternalIssue[] = [];
-
-  const results = await Promise.allSettled(
-    input.repos.map(async (repo) => {
-      const url = new URL("/api/issues", GITHUB_SERVER_URL);
-      url.searchParams.set("installation_id", input.installationId.toString());
-      url.searchParams.set("owner", repo.owner);
-      url.searchParams.set("repo", repo.name);
-      url.searchParams.set("state", input.state);
-
-      const response = await fetch(url.toString());
-
-      if (!response.ok) {
-        throw new Error(
-          `Failed to fetch issues for ${repo.fullName}: ${response.statusText}`,
-        );
-      }
-
-      const data = (await response.json()) as {
-        issues: Array<{
-          id: number;
-          number: number;
-          title: string;
-          body: string;
-          state: string;
-          html_url: string;
-        }>;
-      };
-
-      return data.issues.map((issue) => ({
-        id: formatGitHubId(issue.id, repo.owner, repo.name),
-        number: issue.number,
-        title: issue.title,
-        body: issue.body,
-        state: issue.state,
-        url: issue.html_url,
-        repository: {
-          owner: repo.owner,
-          name: repo.name,
-          fullName: repo.fullName,
-        },
-      }));
-    }),
-  );
-
-  for (const result of results) {
-    if (result.status === "fulfilled") {
-      allIssues.push(...result.value);
-    } else {
-      console.error(`Error fetching issues:`, result.reason);
-    }
-  }
-
-  return { issues: allIssues, count: allIssues.length };
-};
-
-// Helper function to fetch pull requests from GitHub
-const fetchPRsFromGitHub = async (
-  input: FetchPRsInput,
-): Promise<{ pullRequests: ExternalPullRequest[]; count: number }> => {
-  const allPullRequests: ExternalPullRequest[] = [];
-
-  const results = await Promise.allSettled(
-    input.repos.map(async (repo) => {
-      const url = new URL("/api/pull-requests", GITHUB_SERVER_URL);
-      url.searchParams.set("installation_id", input.installationId.toString());
-      url.searchParams.set("owner", repo.owner);
-      url.searchParams.set("repo", repo.name);
-      url.searchParams.set("state", input.state);
-
-      const response = await fetch(url.toString());
-
-      if (!response.ok) {
-        throw new Error(
-          `Failed to fetch pull requests for ${repo.fullName}: ${response.statusText}`,
-        );
-      }
-
-      const data = (await response.json()) as {
-        pullRequests: Array<{
-          id: number;
-          number: number;
-          title: string;
-          body: string;
-          state: string;
-          html_url: string;
-        }>;
-      };
-
-      return data.pullRequests.map((pr) => ({
-        id: formatGitHubId(pr.id, repo.owner, repo.name),
-        number: pr.number,
-        title: pr.title,
-        body: pr.body,
-        state: pr.state,
-        url: pr.html_url,
-        repository: {
-          owner: repo.owner,
-          name: repo.name,
-          fullName: repo.fullName,
-        },
-      }));
-    }),
-  );
-
-  for (const result of results) {
-    if (result.status === "fulfilled") {
-      allPullRequests.push(...result.value);
-    } else {
-      console.error(`Error fetching pull requests:`, result.reason);
-    }
-  }
-
-  return {
-    pullRequests: allPullRequests,
-    count: allPullRequests.length,
-  };
-};
-
-// Create cache instances for issues and PRs
-// Cache for 5 minutes with 1 minute stale-while-revalidate window
-const issuesCache = createReadThroughCache<
-  FetchIssuesInput,
-  { issues: ExternalIssue[]; count: number }
->({
-  namespace: "github-issues",
-  fetch: fetchIssuesFromGitHub,
-  ttl: 300000, // 5 minutes
-  swr: 30000, // 30 seconds stale-while-revalidate
-  keyGenerator: (input) =>
-    `${input.organizationId}:${input.state}:${JSON.stringify(
-      input.repos.map((r) => r.fullName).sort(),
-    )}:${input.installationId}`,
-});
-
-const pullRequestsCache = createReadThroughCache<
-  FetchPRsInput,
-  { pullRequests: ExternalPullRequest[]; count: number }
->({
-  namespace: "github-pull-requests",
-  fetch: fetchPRsFromGitHub,
-  ttl: 300000, // 5 minutes
-  swr: 30000, // 30 seconds stale-while-revalidate
-  keyGenerator: (input) =>
-    `${input.organizationId}:${input.state}:${JSON.stringify(
-      input.repos.map((r) => r.fullName).sort(),
-    )}:${input.installationId}`,
-});
 
 export default publicRoute
   .collectionRoute(schema.thread, {
@@ -498,139 +326,35 @@ export default publicRoute
     ).handler(async () => {
       return [];
     }),
+    /**
+     * @deprecated The web client now reads issues reactively from the
+     * org-scoped `externalEntity` mirror (synced via Live-State). This on-demand
+     * fetch is retired and stubbed to an empty result; the procedure surface is
+     * kept so the Router type stays stable until all consumers are confirmed
+     * migrated (FRO-185).
+     */
     fetchGithubIssues: mutation(
       z.object({
         organizationId: z.string(),
         state: z.enum(["open", "closed", "all"]).optional().default("open"),
       }),
-    ).handler(async ({ req, db }) => {
-      const organizationId = req.input.organizationId;
-
-      if (!organizationId) {
-        throw new Error("MISSING_ORGANIZATION_ID");
-      }
-
-      // Verify user has access to the organization
-      let authorized = !!req.context?.internalApiKey;
-
-      if (!authorized && req.context?.session?.userId) {
-        const selfOrgUser = Object.values(
-          await db.find(schema.organizationUser, {
-            where: {
-              organizationId,
-              userId: req.context.session.userId,
-              enabled: true,
-            },
-          }),
-        )[0];
-
-        authorized = !!selfOrgUser;
-      }
-
-      if (!authorized) {
-        throw new Error("UNAUTHORIZED");
-      }
-
-      // Get GitHub integration config
-      const integration = Object.values(
-        await db.find(schema.integration, {
-          where: {
-            organizationId,
-            type: "github",
-            enabled: true,
-          },
-        }),
-      )[0];
-
-      if (!integration || !integration.configStr) {
-        throw new Error("GITHUB_INTEGRATION_NOT_CONFIGURED");
-      }
-
-      const config = JSON.parse(integration.configStr);
-      const { repos, installationId } = config;
-
-      if (!repos || repos.length === 0) {
-        throw new Error("GITHUB_REPOSITORIES_NOT_CONFIGURED");
-      }
-
-      if (!installationId) {
-        throw new Error("GITHUB_INSTALLATION_NOT_CONFIGURED");
-      }
-
-      const result = await issuesCache.get({
-        organizationId,
-        state: req.input.state,
-        repos,
-        installationId,
-      });
-
-      return result;
+    ).handler(async () => {
+      return { issues: [], count: 0 };
     }),
+    /**
+     * @deprecated The web client now reads pull requests reactively from the
+     * org-scoped `externalEntity` mirror (synced via Live-State). This on-demand
+     * fetch is retired and stubbed to an empty result; the procedure surface is
+     * kept so the Router type stays stable until all consumers are confirmed
+     * migrated (FRO-185).
+     */
     fetchGithubPullRequests: mutation(
       z.object({
         organizationId: z.string(),
         state: z.enum(["open", "closed", "all"]).optional().default("open"),
       }),
-    ).handler(async ({ req, db }) => {
-      const organizationId = req.input.organizationId;
-
-      if (!organizationId) {
-        throw new Error("MISSING_ORGANIZATION_ID");
-      }
-
-      let authorized = !!req.context?.internalApiKey;
-
-      if (!authorized && req.context?.session?.userId) {
-        const selfOrgUser = Object.values(
-          await db.find(schema.organizationUser, {
-            where: {
-              organizationId,
-              userId: req.context.session.userId,
-              enabled: true,
-            },
-          }),
-        )[0];
-
-        authorized = !!selfOrgUser;
-      }
-
-      if (!authorized) {
-        throw new Error("UNAUTHORIZED");
-      }
-
-      const integration = Object.values(
-        await db.find(schema.integration, {
-          where: {
-            organizationId,
-            type: "github",
-            enabled: true,
-          },
-        }),
-      )[0];
-
-      if (!integration || !integration.configStr) {
-        throw new Error("GITHUB_INTEGRATION_NOT_CONFIGURED");
-      }
-
-      const config = JSON.parse(integration.configStr);
-      const { repos, installationId } = config;
-
-      if (!repos || repos.length === 0) {
-        throw new Error("GITHUB_REPOSITORIES_NOT_CONFIGURED");
-      }
-
-      if (!installationId) {
-        throw new Error("GITHUB_INSTALLATION_NOT_CONFIGURED");
-      }
-
-      const result = await pullRequestsCache.get({
-        organizationId,
-        state: req.input.state,
-        repos,
-        installationId,
-      });
-
-      return result;
+    ).handler(async () => {
+      return { pullRequests: [], count: 0 };
     }),
     createGithubIssue: mutation(
       z.object({
@@ -764,21 +488,8 @@ export default publicRoute
         replicatedStr: null,
       });
 
-      // Invalidate issues cache for "open" state since new issues are always open
-      await issuesCache.invalidate({
-        organizationId,
-        state: "open",
-        repos,
-        installationId,
-      });
-
-      // Also invalidate "all" state cache
-      await issuesCache.invalidate({
-        organizationId,
-        state: "all",
-        repos,
-        installationId,
-      });
+      // The created issue propagates into the `externalEntity` mirror via the
+      // GitHub webhook upsert, which syncs reactively to the web client.
 
       return {
         issue: {

--- a/apps/github/src/lib/queue.ts
+++ b/apps/github/src/lib/queue.ts
@@ -99,9 +99,14 @@ const getQueue = (): Queue<BackfillJobData> => {
  *
  * BullMQ reserves `:` as a Redis key separator and rejects it in custom job
  * ids, so the parts are joined with `_` (and `fullName`'s `/` is replaced too).
+ * Underscores in `fullName` are escaped first so the id stays injective and
+ * matches the scheme used by the API's `enqueueGithubBackfill`.
  */
+const safeFullName = (fullName: string): string =>
+  fullName.replaceAll("_", "__").replace("/", "_");
+
 export const enqueueRepoBackfill = async (data: BackfillJobData) => {
-  const jobId = `backfill_${data.organizationId}_${data.fullName.replace("/", "_")}`;
+  const jobId = `backfill_${data.organizationId}_${safeFullName(data.fullName)}`;
   await getQueue().add(BACKFILL_JOB_NAME, data, {
     jobId,
     attempts: 3,
@@ -147,7 +152,7 @@ export const ensureReconcileScheduler = async () => {
  * is also idempotent (upsert-by-externalKey).
  */
 export const enqueueRepoReconcile = async (data: ReconcileRepoJobData) => {
-  const jobId = `reconcile_${data.organizationId}_${data.fullName.replace("/", "_")}`;
+  const jobId = `reconcile_${data.organizationId}_${safeFullName(data.fullName)}`;
   await getReconcileQueue().add(RECONCILE_REPO_JOB_NAME, data, {
     jobId,
     attempts: 3,

--- a/apps/web/src/components/chips.tsx
+++ b/apps/web/src/components/chips.tsx
@@ -171,9 +171,9 @@ export function ThreadSummaryHoverCard({
   );
 }
 
-// TODO: fetch live PR data (title + state) via
-// fetchClient.mutate.thread.fetchGithubPullRequests and surface it in a hover
-// card, mirroring ThreadChipWithSummary.
+// TODO: surface live PR data (title + state) in a hover card by reading the
+// org-scoped `externalEntity` mirror via useLiveQuery, mirroring
+// ThreadChipWithSummary.
 export function PrChip({
   owner,
   repo,

--- a/apps/web/src/components/devtools/devtools-menu/devtools-menu.tsx
+++ b/apps/web/src/components/devtools/devtools-menu/devtools-menu.tsx
@@ -14,6 +14,7 @@ import {
 import { useState } from "react";
 import { useReactScanEnabled } from "../react-scan";
 import { CreateThreadDialog } from "./create-thread-dialog";
+import { GithubSubmenu } from "./github-submenu";
 import { SignalsSubmenu } from "./signals-submenu";
 import { ThreadsSubmenu } from "./threads-submenu";
 
@@ -54,6 +55,12 @@ export const DevtoolsMenu = ({ onHideToolbar }: DevtoolsMenuProps) => {
             <SubmenuTrigger>Signals</SubmenuTrigger>
             <SubmenuContent>
               <SignalsSubmenu />
+            </SubmenuContent>
+          </Submenu>
+          <Submenu>
+            <SubmenuTrigger>GitHub</SubmenuTrigger>
+            <SubmenuContent>
+              <GithubSubmenu />
             </SubmenuContent>
           </Submenu>
           <Submenu>

--- a/apps/web/src/components/devtools/devtools-menu/github-submenu.tsx
+++ b/apps/web/src/components/devtools/devtools-menu/github-submenu.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { MenuItem } from "@workspace/ui/components/menu";
+import { useAtomValue } from "jotai/react";
+import { toast } from "sonner";
+import { activeOrganizationAtom } from "~/lib/atoms";
+import { fetchClient } from "~/lib/live-state";
+
+// Dev-only: webhooks aren't wired up locally, so the externalEntity mirror never
+// fills in. This manually enqueues a backfill for every connected repo.
+const SyncGithubMenuItem = () => {
+  const currentOrg = useAtomValue(activeOrganizationAtom);
+
+  const handleSync = async () => {
+    if (!currentOrg?.id) {
+      toast.error("No organization selected");
+      return;
+    }
+
+    try {
+      const result = await fetchClient.mutate.externalEntity.syncFromGithub({
+        organizationId: currentOrg.id,
+      });
+      toast.success(
+        `Queued backfill for ${result.enqueued}/${result.repos} repositor${
+          result.repos === 1 ? "y" : "ies"
+        }`,
+      );
+    } catch (err) {
+      console.error("[GitHub] Manual sync failed:", err);
+      toast.error("Failed to start sync");
+    }
+  };
+
+  return (
+    <MenuItem
+      onClick={handleSync}
+      aria-label="Backfill the GitHub issue/PR mirror without webhooks"
+    >
+      Sync issues & PRs
+    </MenuItem>
+  );
+};
+
+export const GithubSubmenu = () => {
+  return <SyncGithubMenuItem />;
+};

--- a/apps/web/src/components/threads/external-entities.ts
+++ b/apps/web/src/components/threads/external-entities.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared helpers for consuming the org-scoped `externalEntity` mirror in the
+ * web client. Issue/PR data is synced reactively via Live-State, so the UI reads
+ * it through `useLiveQuery(query.externalEntity.where(...))` instead of the
+ * retired on-demand GitHub fetch procedures.
+ */
+
+/**
+ * The subset of an `externalEntity` mirror row the link UI displays and searches
+ * over. Mirrors the columns written by the GitHub integration's upsert.
+ */
+export type MirrorEntity = {
+  id: string;
+  externalKey: string;
+  type: string;
+  number: number;
+  repoFullName: string;
+  url: string;
+  title: string;
+  body: string | null;
+  state: string;
+  authorLogin: string | null;
+  assignees: string[];
+  labels: string[];
+};
+
+/**
+ * Structured substring match across an entity's searchable facets: number,
+ * title, body, state, repo, author, labels and assignees. An empty query
+ * matches everything. Used as the Combobox `filter` so search stays reactive
+ * over the local mirror rather than refetching.
+ */
+export const entityMatchesQuery = (
+  entity: Pick<
+    MirrorEntity,
+    | "number"
+    | "title"
+    | "body"
+    | "state"
+    | "repoFullName"
+    | "authorLogin"
+    | "labels"
+    | "assignees"
+  >,
+  query: string,
+): boolean => {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return true;
+
+  const haystack = [
+    `#${entity.number}`,
+    entity.title,
+    entity.body ?? "",
+    entity.state,
+    entity.repoFullName,
+    entity.authorLogin ?? "",
+    ...entity.labels,
+    ...entity.assignees,
+  ]
+    .join(" ")
+    .toLowerCase();
+
+  return haystack.includes(normalized);
+};

--- a/apps/web/src/components/threads/issues.tsx
+++ b/apps/web/src/components/threads/issues.tsx
@@ -1,9 +1,6 @@
 import { useLiveQuery } from "@live-state/sync/client";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import type {
-  ExternalIssue,
-  ExternalRepository,
-} from "@workspace/schemas/external-issue";
+import { useMutation } from "@tanstack/react-query";
+import type { ExternalRepository } from "@workspace/schemas/external-issue";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -46,11 +43,18 @@ import {
 import { Textarea } from "@workspace/ui/components/textarea";
 import { useAtomValue } from "jotai/react";
 import { Github, Loader2, Plus, X } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { ulid } from "ulid";
 import { activeOrganizationAtom } from "~/lib/atoms";
 import { fetchClient, mutate, query } from "~/lib/live-state";
+import { entityMatchesQuery, type MirrorEntity } from "./external-entities";
+
+/** The facets the link UI needs to display a linked issue (mirror row subset). */
+type LinkedIssue = Pick<
+  MirrorEntity,
+  "externalKey" | "number" | "title" | "repoFullName"
+>;
 
 interface IssuesSectionProps {
   threadId: string;
@@ -59,7 +63,7 @@ interface IssuesSectionProps {
   threadName?: string;
   captureThreadEvent: (
     eventName: string,
-    properties?: Record<string, unknown>
+    properties?: Record<string, unknown>,
   ) => void;
 }
 
@@ -76,46 +80,47 @@ export function IssuesSection({
   const [issueBody, setIssueBody] = useState("");
   const [selectedRepo, setSelectedRepo] = useState<string>("");
   const [search, setSearch] = useState("");
-  const [optimisticIssue, setOptimisticIssue] = useState<ExternalIssue | null>(
-    null
+  const [optimisticIssue, setOptimisticIssue] = useState<LinkedIssue | null>(
+    null,
   );
 
   const githubIntegration = useLiveQuery(
     query.integration.first({
       organizationId: currentOrg?.id,
       type: "github",
-    })
+    }),
   );
 
-  const { data: allIssues, refetch: refetchIssues } = useQuery({
-    queryKey: [
-      "github-issues",
-      currentOrg?.id,
-      githubIntegration?.enabled,
-      githubIntegration?.configStr,
-    ],
-    queryFn: () => {
-      if (!currentOrg) return { issues: [], count: 0 };
+  // Reactive mirror of the org's GitHub issues, synced via Live-State. Replaces
+  // the on-demand `thread.fetchGithubIssues` fetch.
+  const issues =
+    useLiveQuery(
+      query.externalEntity.where({
+        organizationId: currentOrg?.id,
+        type: "issue",
+        deletedAt: null,
+      }),
+    ) ?? [];
 
-      // Check if GitHub integration is enabled and configured
-      if (!githubIntegration?.enabled || !githubIntegration?.configStr) {
-        return { issues: [], count: 0 };
-      }
+  // Once the created issue lands in the mirror (via webhook upsert), drop the
+  // optimistic placeholder and let the synced row take over.
+  useEffect(() => {
+    if (
+      optimisticIssue &&
+      issues.some((issue) => issue.externalKey === optimisticIssue.externalKey)
+    ) {
+      setOptimisticIssue(null);
+    }
+  }, [issues, optimisticIssue]);
 
-      return fetchClient.mutate.thread.fetchGithubIssues({
-        organizationId: currentOrg.id,
-        state: "open",
-      });
-    },
-    enabled: !!currentOrg && !!githubIntegration?.enabled,
-  });
-
-  const issues = (allIssues?.issues ?? []) as ExternalIssue[];
+  // The link list only offers open issues; the linked issue itself resolves from
+  // the full mirror so an already-linked closed issue still displays.
+  const openIssues = issues.filter((issue) => issue.state === "open");
 
   const comboboxItems = prepareFooter(
-    issues.map((issue) => ({
-      value: issue.id ?? "",
-      label: `${issue.repository.fullName}#${issue.number} ${issue.title}`,
+    openIssues.map((issue) => ({
+      value: issue.externalKey,
+      label: `${issue.repoFullName}#${issue.number} ${issue.title}`,
       issue,
     })),
     [
@@ -123,12 +128,14 @@ export function IssuesSection({
         value: `footer:create_issue`,
         label: `Create issue ${search}`, // This forces item to always be shown even though it's not visible
       },
-    ]
+    ],
   );
 
-  const linkedIssue = optimisticIssue
-    ? optimisticIssue
-    : issues.find((issue) => issue.id === externalIssueId);
+  const linkedIssue: LinkedIssue | undefined =
+    issues.find((issue) => issue.externalKey === externalIssueId) ??
+    (optimisticIssue?.externalKey === externalIssueId
+      ? optimisticIssue
+      : undefined);
 
   const repos: ExternalRepository[] = githubIntegration?.configStr
     ? (() => {
@@ -181,25 +188,16 @@ export function IssuesSection({
       const repo = repos.find((r) => r.fullName === selectedRepo);
       if (!repo || !result?.issue) return;
 
-      // Create optimistic issue object
-      const optimisticIssueData: ExternalIssue = {
-        id: result.issue.id,
+      // Optimistic placeholder so the link shows immediately; the real mirror
+      // row arrives shortly after via the GitHub webhook upsert.
+      setOptimisticIssue({
+        externalKey: result.issue.id,
         number: result.issue.number,
         title: result.issue.title || variables.title,
-        body: result.issue.body || variables.body,
-        state: result.issue.state || "open",
-        url: result.issue.url,
-        repository: {
-          owner: repo.owner,
-          name: repo.name,
-          fullName: repo.fullName,
-        },
-      };
+        repoFullName: repo.fullName,
+      });
 
-      // Set optimistic issue state
-      setOptimisticIssue(optimisticIssueData);
-
-      // Link the thread to the newly created issue
+      // Link the thread to the newly created issue by its externalKey.
       mutate.thread.update(threadId, {
         externalIssueId: result.issue.id,
       });
@@ -220,13 +218,6 @@ export function IssuesSection({
       });
 
       setShowCreateDialog(false);
-
-      // After 3 seconds, invalidate query and remove optimistic value
-      setTimeout(() => {
-        refetchIssues().finally(() => {
-          setOptimisticIssue(null);
-        });
-      }, 3000);
     },
     onError: (error) => {
       console.error("Failed to create issue:", error);
@@ -265,7 +256,7 @@ export function IssuesSection({
       metadataStr: JSON.stringify({
         oldIssueId: externalIssueId,
         newIssueId: null,
-        oldIssueLabel: `${linkedIssue.repository.fullName}#${linkedIssue.number}`,
+        oldIssueLabel: `${linkedIssue.repoFullName}#${linkedIssue.number}`,
         newIssueLabel: null,
         userName: user.name,
       }),
@@ -275,7 +266,7 @@ export function IssuesSection({
     captureThreadEvent("thread:issue_unlink", {
       old_issue_id: externalIssueId,
       old_issue_number: linkedIssue.number,
-      repository: linkedIssue.repository.fullName,
+      repository: linkedIssue.repoFullName,
     });
   };
 
@@ -288,11 +279,16 @@ export function IssuesSection({
         <div className="flex gap-1 items-center group w-full max-w-52">
           <Combobox
             items={comboboxItems}
-            value={linkedIssue?.id ?? ""}
-            onOpenChange={(open) => {
-              if (open) {
-                refetchIssues();
-              }
+            value={linkedIssue?.externalKey ?? ""}
+            filter={(item, q) => {
+              const it = item as { value?: string; issue?: MirrorEntity };
+              if (
+                typeof it.value === "string" &&
+                it.value.startsWith("footer:")
+              )
+                return true;
+              if (!it.issue) return true;
+              return entityMatchesQuery(it.issue, q);
             }}
             onValueChange={(value) => {
               if (value?.startsWith("footer:")) {
@@ -300,11 +296,13 @@ export function IssuesSection({
               }
 
               const oldIssueId = externalIssueId ?? null;
-              const oldIssue = issues.find((issue) => issue.id === oldIssueId);
+              const oldIssue = issues.find(
+                (issue) => issue.externalKey === oldIssueId,
+              );
               // If clicking the same issue, unlink it
               const newIssueId = oldIssueId === value ? null : value || null;
               const newIssue = newIssueId
-                ? issues.find((issue) => issue.id === newIssueId)
+                ? issues.find((issue) => issue.externalKey === newIssueId)
                 : undefined;
               mutate.thread.update(threadId, {
                 externalIssueId: newIssueId,
@@ -319,10 +317,10 @@ export function IssuesSection({
                   oldIssueId,
                   newIssueId,
                   oldIssueLabel: oldIssue
-                    ? `${oldIssue.repository.fullName}#${oldIssue.number}`
+                    ? `${oldIssue.repoFullName}#${oldIssue.number}`
                     : null,
                   newIssueLabel: newIssue
-                    ? `${newIssue.repository.fullName}#${newIssue.number}`
+                    ? `${newIssue.repoFullName}#${newIssue.number}`
                     : null,
                   userName: user.name,
                 }),
@@ -335,13 +333,13 @@ export function IssuesSection({
                   new_issue_id: newIssueId,
                   old_issue_number: oldIssue?.number,
                   new_issue_number: newIssue?.number,
-                  repository: newIssue?.repository.fullName,
+                  repository: newIssue?.repoFullName,
                 });
               } else {
                 captureThreadEvent("thread:issue_unlink", {
                   old_issue_id: oldIssueId,
                   old_issue_number: oldIssue?.number,
-                  repository: oldIssue?.repository.fullName,
+                  repository: oldIssue?.repoFullName,
                 });
               }
             }}
@@ -375,7 +373,6 @@ export function IssuesSection({
               }
             />
             <ComboboxContent className="w-60 max-h-120" side="left">
-              {/* //TODO: Improve search functionality by searching the issue number */}
               <ComboboxInput
                 placeholder="Search..."
                 value={search}
@@ -391,7 +388,7 @@ export function IssuesSection({
                       className="overflow-auto grow shrink"
                     >
                       <ComboboxGroupContent>
-                        {(item: BaseItem & { issue: ExternalIssue }) => (
+                        {(item: BaseItem & { issue: MirrorEntity }) => (
                           <ComboboxItem key={item.value} value={item.value}>
                             <span>#{item.issue.number}</span>
                             <span className="truncate">{item.issue.title}</span>

--- a/apps/web/src/components/threads/pull-requests.tsx
+++ b/apps/web/src/components/threads/pull-requests.tsx
@@ -1,6 +1,4 @@
 import { useLiveQuery } from "@live-state/sync/client";
-import { useQuery } from "@tanstack/react-query";
-import type { ExternalPullRequest } from "@workspace/schemas/external-issue";
 import { ActionButton } from "@workspace/ui/components/button";
 import {
   Combobox,
@@ -16,7 +14,8 @@ import { GitPullRequest, X } from "lucide-react";
 import { useState } from "react";
 import { ulid } from "ulid";
 import { activeOrganizationAtom } from "~/lib/atoms";
-import { fetchClient, mutate, query } from "~/lib/live-state";
+import { mutate, query } from "~/lib/live-state";
+import { entityMatchesQuery, type MirrorEntity } from "./external-entities";
 import { LinkedPrSuggestionsSection } from "./linked-pr-suggestions-section";
 
 interface PullRequestsSectionProps {
@@ -45,40 +44,30 @@ export function PullRequestsSection({
     }),
   );
 
-  const { data: allPullRequests, refetch: refetchPullRequests } = useQuery({
-    queryKey: [
-      "github-pull-requests",
-      currentOrg?.id,
-      githubIntegration?.enabled,
-      githubIntegration?.configStr,
-    ],
-    queryFn: () => {
-      if (!currentOrg) return { pullRequests: [], count: 0 };
+  // Reactive mirror of the org's pull requests, synced via Live-State. Replaces
+  // the on-demand `thread.fetchGithubPullRequests` fetch.
+  const pullRequests =
+    useLiveQuery(
+      query.externalEntity.where({
+        organizationId: currentOrg?.id,
+        type: "pull_request",
+        deletedAt: null,
+      }),
+    ) ?? [];
 
-      if (!githubIntegration?.enabled || !githubIntegration?.configStr) {
-        return { pullRequests: [], count: 0 };
-      }
+  // The link list only offers open PRs; the linked PR itself resolves from the
+  // full mirror so an already-linked closed/merged PR still displays.
+  const openPullRequests = pullRequests.filter((pr) => pr.state === "open");
 
-      return fetchClient.mutate.thread.fetchGithubPullRequests({
-        organizationId: currentOrg.id,
-        state: "open",
-      });
-    },
-    enabled: !!currentOrg && !!githubIntegration?.enabled,
-  });
-
-  const pullRequests = (allPullRequests?.pullRequests ??
-    []) as ExternalPullRequest[];
-
-  const comboboxItems = pullRequests.map((pr) => ({
-    value: pr.id ?? "",
-    label: `${pr.repository.fullName}#${pr.number} ${pr.title}`,
+  const comboboxItems = openPullRequests.map((pr) => ({
+    value: pr.externalKey,
+    label: `${pr.repoFullName}#${pr.number} ${pr.title}`,
     pr,
   }));
 
   type PRItem = (typeof comboboxItems)[number];
 
-  const linkedPr = pullRequests.find((pr) => pr.id === externalPrId);
+  const linkedPr = pullRequests.find((pr) => pr.externalKey === externalPrId);
 
   const handleUnlinkPr = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -97,7 +86,7 @@ export function PullRequestsSection({
       metadataStr: JSON.stringify({
         oldPrId: externalPrId,
         newPrId: null,
-        oldPrLabel: `${linkedPr.repository.fullName}#${linkedPr.number}`,
+        oldPrLabel: `${linkedPr.repoFullName}#${linkedPr.number}`,
         newPrLabel: null,
         userName: user.name,
       }),
@@ -107,7 +96,7 @@ export function PullRequestsSection({
     captureThreadEvent("thread:pr_unlink", {
       old_pr_id: externalPrId,
       old_pr_number: linkedPr.number,
-      repository: linkedPr.repository.fullName,
+      repository: linkedPr.repoFullName,
     });
   };
 
@@ -120,19 +109,21 @@ export function PullRequestsSection({
         <div className="flex gap-1 items-center group w-full max-w-52">
           <Combobox
             items={comboboxItems}
-            value={linkedPr?.id ?? ""}
-            onOpenChange={(open) => {
-              if (open) {
-                refetchPullRequests();
-              }
+            value={linkedPr?.externalKey ?? ""}
+            filter={(item, q) => {
+              const it = item as { pr?: MirrorEntity };
+              if (!it.pr) return true;
+              return entityMatchesQuery(it.pr, q);
             }}
             onValueChange={(value) => {
               const oldPrId = externalPrId ?? null;
-              const oldPr = pullRequests.find((pr) => pr.id === oldPrId);
+              const oldPr = pullRequests.find(
+                (pr) => pr.externalKey === oldPrId,
+              );
               // If clicking the same PR, unlink it
               const newPrId = oldPrId === value ? null : value || null;
               const newPr = newPrId
-                ? pullRequests.find((pr) => pr.id === newPrId)
+                ? pullRequests.find((pr) => pr.externalKey === newPrId)
                 : undefined;
               mutate.thread.update(threadId, {
                 externalPrId: newPrId,
@@ -147,10 +138,10 @@ export function PullRequestsSection({
                   oldPrId,
                   newPrId,
                   oldPrLabel: oldPr
-                    ? `${oldPr.repository.fullName}#${oldPr.number}`
+                    ? `${oldPr.repoFullName}#${oldPr.number}`
                     : null,
                   newPrLabel: newPr
-                    ? `${newPr.repository.fullName}#${newPr.number}`
+                    ? `${newPr.repoFullName}#${newPr.number}`
                     : null,
                   userName: user.name,
                 }),
@@ -164,8 +155,7 @@ export function PullRequestsSection({
                   new_pr_id: newPrId,
                   old_pr_number: oldPr?.number,
                   new_pr_number: newPr?.number,
-                  repository:
-                    newPr?.repository.fullName ?? oldPr?.repository.fullName,
+                  repository: newPr?.repoFullName ?? oldPr?.repoFullName,
                 },
               );
             }}

--- a/apps/web/src/routes/app/_workspace/settings/organization/integration/github/index.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/integration/github/index.tsx
@@ -228,7 +228,7 @@ function RouteComponent() {
             )}
           </CardContent>
         </Card>
-{/* SyncStatus omitted: GitHub integration does not support backfill */}
+        {/* SyncStatus omitted: GitHub integration does not support backfill */}
       </div>
     </>
   );

--- a/apps/web/src/routes/app/route.tsx
+++ b/apps/web/src/routes/app/route.tsx
@@ -106,6 +106,7 @@ function App() {
               include: { messages: true },
             },
             autonomousActions: true,
+            externalEntities: true,
           },
         },
       }),


### PR DESCRIPTION
## Summary

Switches the web client from on-demand GitHub fetches to reactive Live-State queries over the org-scoped `externalEntity` mirror.

- Issue/PR link comboboxes read & filter the mirror via `useLiveQuery`; linked entities resolve by `externalKey`
- Structured search over title/body substring, state, label, assignee, repo, and type (shared `entityMatchesQuery` helper in `external-entities.ts`)
- Open issues only in the link list; optimistic placeholder on create, cleared once the webhook-synced row appears
- Retire (stub, per the keep-UI-during-migration convention) the now-unused `thread.fetchGithubIssues` / `thread.fetchGithubPullRequests` live-fetch procedures and their read-through caches
- Sync `externalEntities` into the client store

### Devtool

Adds a dev-only **GitHub › Sync issues & PRs** item to the Devtools toolbar (gated by the toolbar's existing `import.meta.env.DEV` mount). It calls a dev-gated `externalEntity.syncFromGithub` procedure that enqueues a `github-backfill` job per connected repo — standing in for webhooks locally. The API enqueues onto the github app's queue (which owns the processor), consistent with "integration apps own their jobs".

## Notes

- With the mirror as source of truth, a newly created issue appears in the link list only after the GitHub webhook upserts it; the linked-issue display is covered by an optimistic placeholder in the meantime.

## Test plan

- [x] `bun run --filter web typecheck` passes
- [x] biome clean on changed files
- [ ] Manual: connect a repo locally, run Devtools › GitHub › Sync issues & PRs, confirm the mirror populates and link comboboxes/search work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches GitHub issue/PR linking to reactive Live-State over the org `externalEntity` mirror to make search and linking instant and consistent (FRO-185). Adds a dev-only sync to backfill the mirror locally.

- **New Features**
  - Issues/PR comboboxes read the `externalEntity` mirror via `useLiveQuery`; items filter with `entityMatchesQuery` (title/body/number/state/label/assignee/repo).
  - Linked entities resolve by `externalKey`. New issues show an optimistic placeholder until the webhook upsert arrives.
  - Devtools: GitHub › Sync issues & PRs enqueues a backfill per connected repo via `externalEntity.syncFromGithub`; API enqueues onto the github app’s `github-backfill` queue. Now validates integration config, counts only successful enqueues, and uses an injective, underscore-safe jobId shared by API and app (backfill/reconcile) to avoid collisions.
  - Client store now syncs `externalEntities`.

- **Migration**
  - `thread.fetchGithubIssues` and `thread.fetchGithubPullRequests` are stubbed to empty results. Migrate any remaining consumers to `query.externalEntity`.
  - Local dev: use Devtools › GitHub › Sync issues & PRs to populate the mirror (webhooks are not wired locally).

<sup>Written for commit 1e5901c0df40c46f215f655463eb0f2db816bdc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GitHub repository synchronization for live data availability
  * Introduced developer tool to manually trigger GitHub repository backfills

* **Improvements**
  * GitHub issues and pull requests now sync in real-time instead of on-demand
  * Enhanced consistency through webhook-driven data propagation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->