### PR TITLE
feat(web): add reactive hooks for externalEntity mirror lookups

### DIFF
--- a/apps/web/src/components/threads/external-entities.ts
+++ b/apps/web/src/components/threads/external-entities.ts
@@ -5,6 +5,11 @@
  * retired on-demand GitHub fetch procedures.
  */
 
+import { useLiveQuery } from "@live-state/sync/client";
+import { useAtomValue } from "jotai/react";
+import { activeOrganizationAtom } from "~/lib/atoms";
+import { query } from "~/lib/live-state";
+
 /**
  * The subset of an `externalEntity` mirror row the link UI displays and searches
  * over. Mirrors the columns written by the GitHub integration's upsert.
@@ -61,4 +66,86 @@ export const entityMatchesQuery = (
     .toLowerCase();
 
   return haystack.includes(normalized);
+};
+
+/** Repo + number lookup for surfaces that only have a GitHub URL, not an `externalKey`. */
+export type MirrorEntityRef = {
+  type: "issue" | "pull_request";
+  repoFullName: string;
+  number: number;
+};
+
+type MirrorEntityRow = Pick<
+  MirrorEntity,
+  | "id"
+  | "externalKey"
+  | "type"
+  | "number"
+  | "repoFullName"
+  | "url"
+  | "title"
+  | "body"
+  | "state"
+  | "authorLogin"
+  | "assignees"
+  | "labels"
+>;
+
+const toMirrorEntity = (row: MirrorEntityRow): MirrorEntity => ({
+  id: row.id,
+  externalKey: row.externalKey,
+  type: row.type,
+  number: row.number,
+  repoFullName: row.repoFullName,
+  url: row.url,
+  title: row.title,
+  body: row.body,
+  state: row.state,
+  authorLogin: row.authorLogin,
+  assignees: row.assignees,
+  labels: row.labels,
+});
+
+/**
+ * Reactive lookup by `externalKey` — for surfaces that store the mirror reference
+ * (thread links, activity-feed metadata). Includes soft-deleted rows so
+ * historical events can still resolve a label when the entity remains mirrored.
+ */
+export const useMirrorEntityByKey = (
+  externalKey: string | null,
+): MirrorEntity | undefined => {
+  const currentOrg = useAtomValue(activeOrganizationAtom);
+
+  const row = useLiveQuery(
+    query.externalEntity.first({
+      organizationId: currentOrg?.id,
+      externalKey: externalKey ?? undefined,
+    }),
+  );
+
+  if (!externalKey || !currentOrg?.id || !row) return undefined;
+  return toMirrorEntity(row);
+};
+
+/**
+ * Reactive lookup by repo + number — for URL-derived surfaces (markdown chips)
+ * that only know `owner/repo` and the human-visible issue/PR number.
+ */
+export const useMirrorEntityByRef = (
+  ref: MirrorEntityRef | null,
+): MirrorEntity | undefined => {
+  const currentOrg = useAtomValue(activeOrganizationAtom);
+
+  const row = useLiveQuery(
+    query.externalEntity.first({
+      organizationId: currentOrg?.id,
+      type: ref?.type,
+      repoFullName: ref?.repoFullName,
+      number: ref?.number,
+      deletedAt: null,
+    }),
+  );
+
+  if (!ref || !currentOrg?.id || !row) return undefined;
+  return toMirrorEntity(row);
 };


### PR DESCRIPTION
## Summary
- Add `useMirrorEntityByKey` for surfaces that already hold an `externalKey` (thread links, activity-feed metadata)
- Add `useMirrorEntityByRef` for URL-derived surfaces that only know `owner/repo` and issue/PR number
- Both hooks read from the org-scoped `externalEntity` mirror via Live-State and return a typed `MirrorEntity` subset

## Test plan
- [x] `bun run --filter web typecheck` passes
- [ ] Wire into PR chips and activity feed in follow-up PRs
- [ ] Manually verify a linked issue/PR updates reactively after a GitHub sync


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two reactive hooks to look up GitHub mirror entities from the org-scoped `externalEntity` table, so issue/PR UIs can show live data without ad‑hoc fetches. Supports both `externalKey` and URL-derived repo+number references.

- **New Features**
  - `useMirrorEntityByKey(externalKey)` — resolves by `externalKey`; includes soft-deleted rows.
  - `useMirrorEntityByRef({ type, repoFullName, number })` — resolves by repo + number; excludes deleted rows.
  - Both use `useLiveQuery` from `@live-state/sync/client` and the current org from `jotai/react` (`activeOrganizationAtom`).
  - Return a typed `MirrorEntity` subset for chips and activity feed.

<sup>Written for commit 5020291ae3865283a7488ec2790e8bcc15e239f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

