### PR TITLE
feat(web): reactive issue/PR labels in activity feed

### DIFF
--- a/apps/web/src/components/threads/external-entities.ts
+++ b/apps/web/src/components/threads/external-entities.ts
@@ -173,3 +173,17 @@ export const useMirrorEntityByRef = (
   if (!ref || !currentOrg?.id || !row) return undefined;
   return toMirrorEntity(row);
 };
+
+/** Display label for a mirrored issue or PR (`owner/repo#number`). */
+export const formatMirrorEntityLabel = (
+  entity: Pick<MirrorEntity, "repoFullName" | "number">,
+): string => `${entity.repoFullName}#${entity.number}`;
+
+/** Prefer a live mirror label; fall back to the baked snapshot when absent. */
+export const resolveMirrorEntityLabel = (
+  entity: MirrorEntity | undefined,
+  fallback: string | null | undefined,
+): string | null => {
+  if (entity) return formatMirrorEntityLabel(entity);
+  return fallback ?? null;
+};

--- a/apps/web/src/components/threads/updates.tsx
+++ b/apps/web/src/components/threads/updates.tsx
@@ -142,7 +142,8 @@ const GithubIssueCreatedUpdateText = ({
 
   return (
     <>
-      created issue <span className="text-foreground">{issueLabel}</span>
+      created issue{" "}
+      <span className="text-foreground">{issueLabel ?? "an issue"}</span>
     </>
   );
 };

--- a/apps/web/src/components/threads/updates.tsx
+++ b/apps/web/src/components/threads/updates.tsx
@@ -10,8 +10,20 @@ import { formatRelativeTime } from "@workspace/ui/lib/utils";
 import type { schema } from "api/schema";
 import { Bot, CircleUserIcon, CopySlash, Github, Tag } from "lucide-react";
 import { ThreadChipWithSummary } from "~/components/chips";
+import {
+  resolveMirrorEntityLabel,
+  useMirrorEntityByKey,
+} from "~/components/threads/external-entities";
 import { query } from "~/lib/live-state";
 import { buildThreadParam } from "~/utils/thread";
+
+const getMetadataString = (
+  metadata: { [key: string]: unknown } | null,
+  key: string,
+): string | null => {
+  const value = metadata?.[key];
+  return typeof value === "string" ? value : null;
+};
 
 export function Update({
   update,
@@ -31,17 +43,56 @@ export function Update({
     }
   }
 
+  const isIssueChanged = update.type === "issue_changed";
+  const isPrChanged = update.type === "pr_changed";
+  const isGithubIssueCreated = update.type === "github_issue_created";
+
+  const oldIssueEntity = useMirrorEntityByKey(
+    isIssueChanged ? getMetadataString(metadata, "oldIssueId") : null,
+  );
+  const newIssueEntity = useMirrorEntityByKey(
+    isIssueChanged ? getMetadataString(metadata, "newIssueId") : null,
+  );
+  const oldPrEntity = useMirrorEntityByKey(
+    isPrChanged ? getMetadataString(metadata, "oldPrId") : null,
+  );
+  const newPrEntity = useMirrorEntityByKey(
+    isPrChanged ? getMetadataString(metadata, "newPrId") : null,
+  );
+  const createdIssueEntity = useMirrorEntityByKey(
+    isGithubIssueCreated ? getMetadataString(metadata, "issueId") : null,
+  );
+
+  const oldIssueLabel = resolveMirrorEntityLabel(
+    oldIssueEntity,
+    getMetadataString(metadata, "oldIssueLabel"),
+  );
+  const newIssueLabel = resolveMirrorEntityLabel(
+    newIssueEntity,
+    getMetadataString(metadata, "newIssueLabel"),
+  );
+  const oldPrLabel = resolveMirrorEntityLabel(
+    oldPrEntity,
+    getMetadataString(metadata, "oldPrLabel"),
+  );
+  const newPrLabel = resolveMirrorEntityLabel(
+    newPrEntity,
+    getMetadataString(metadata, "newPrLabel"),
+  );
+  const createdIssueLabel = resolveMirrorEntityLabel(
+    createdIssueEntity,
+    getMetadataString(metadata, "issueLabel"),
+  );
+
   const assignedUser = useLiveQuery(
     query.user.first({ id: metadata?.newAssignedUserId }),
   );
 
   const duplicateThread = useLiveQuery(
-    query.thread
-      .first({ id: metadata?.duplicateOfThreadId })
-      .include({
-        author: { include: { user: true } },
-        assignedUser: { include: { user: true } },
-      }),
+    query.thread.first({ id: metadata?.duplicateOfThreadId }).include({
+      author: { include: { user: true } },
+      assignedUser: { include: { user: true } },
+    }),
   );
 
   const isAutonomous = metadata?.source === "autonomous";
@@ -104,30 +155,30 @@ export function Update({
     }
 
     if (update.type === "issue_changed") {
-      if (!metadata?.oldIssueLabel && metadata?.newIssueLabel) {
+      if (!oldIssueLabel && newIssueLabel) {
         return (
           <>
             linked issue{" "}
-            <span className="text-foreground">{metadata.newIssueLabel}</span>
+            <span className="text-foreground">{newIssueLabel}</span>
           </>
         );
       }
 
-      if (metadata?.oldIssueLabel && !metadata?.newIssueLabel) {
+      if (oldIssueLabel && !newIssueLabel) {
         return (
           <>
             unlinked issue{" "}
-            <span className="text-foreground">{metadata.oldIssueLabel}</span>
+            <span className="text-foreground">{oldIssueLabel}</span>
           </>
         );
       }
 
-      if (metadata?.oldIssueLabel && metadata?.newIssueLabel) {
+      if (oldIssueLabel && newIssueLabel) {
         return (
           <>
             changed issue from{" "}
-            <span className="text-foreground">{metadata.oldIssueLabel}</span> to{" "}
-            <span className="text-foreground">{metadata.newIssueLabel}</span>
+            <span className="text-foreground">{oldIssueLabel}</span> to{" "}
+            <span className="text-foreground">{newIssueLabel}</span>
           </>
         );
       }
@@ -136,30 +187,29 @@ export function Update({
     }
 
     if (update.type === "pr_changed") {
-      if (!metadata?.oldPrLabel && metadata?.newPrLabel) {
+      if (!oldPrLabel && newPrLabel) {
         return (
           <>
             {verbPrefix}linked PR{" "}
-            <span className="text-foreground">{metadata.newPrLabel}</span>
+            <span className="text-foreground">{newPrLabel}</span>
           </>
         );
       }
 
-      if (metadata?.oldPrLabel && !metadata?.newPrLabel) {
+      if (oldPrLabel && !newPrLabel) {
         return (
           <>
-            unlinked PR{" "}
-            <span className="text-foreground">{metadata.oldPrLabel}</span>
+            unlinked PR <span className="text-foreground">{oldPrLabel}</span>
           </>
         );
       }
 
-      if (metadata?.oldPrLabel && metadata?.newPrLabel) {
+      if (oldPrLabel && newPrLabel) {
         return (
           <>
             changed PR from{" "}
-            <span className="text-foreground">{metadata.oldPrLabel}</span> to{" "}
-            <span className="text-foreground">{metadata.newPrLabel}</span>
+            <span className="text-foreground">{oldPrLabel}</span> to{" "}
+            <span className="text-foreground">{newPrLabel}</span>
           </>
         );
       }
@@ -171,7 +221,7 @@ export function Update({
       return (
         <>
           created issue{" "}
-          <span className="text-foreground">{metadata?.issueLabel}</span>
+          <span className="text-foreground">{createdIssueLabel}</span>
         </>
       );
     }

--- a/apps/web/src/components/threads/updates.tsx
+++ b/apps/web/src/components/threads/updates.tsx
@@ -25,6 +25,128 @@ const getMetadataString = (
   return typeof value === "string" ? value : null;
 };
 
+const useResolvedMirrorLabel = (
+  externalKey: string | null,
+  metadata: { [key: string]: unknown } | null,
+  fallbackKey: string,
+): string | null => {
+  const entity = useMirrorEntityByKey(externalKey);
+  return resolveMirrorEntityLabel(
+    entity,
+    getMetadataString(metadata, fallbackKey),
+  );
+};
+
+const IssueChangedUpdateText = ({
+  metadata,
+}: {
+  metadata: { [key: string]: unknown } | null;
+}) => {
+  const oldIssueLabel = useResolvedMirrorLabel(
+    getMetadataString(metadata, "oldIssueId"),
+    metadata,
+    "oldIssueLabel",
+  );
+  const newIssueLabel = useResolvedMirrorLabel(
+    getMetadataString(metadata, "newIssueId"),
+    metadata,
+    "newIssueLabel",
+  );
+
+  if (!oldIssueLabel && newIssueLabel) {
+    return (
+      <>
+        linked issue <span className="text-foreground">{newIssueLabel}</span>
+      </>
+    );
+  }
+
+  if (oldIssueLabel && !newIssueLabel) {
+    return (
+      <>
+        unlinked issue <span className="text-foreground">{oldIssueLabel}</span>
+      </>
+    );
+  }
+
+  if (oldIssueLabel && newIssueLabel) {
+    return (
+      <>
+        changed issue from{" "}
+        <span className="text-foreground">{oldIssueLabel}</span> to{" "}
+        <span className="text-foreground">{newIssueLabel}</span>
+      </>
+    );
+  }
+
+  return "changed issue";
+};
+
+const PrChangedUpdateText = ({
+  metadata,
+  verbPrefix,
+}: {
+  metadata: { [key: string]: unknown } | null;
+  verbPrefix: string;
+}) => {
+  const oldPrLabel = useResolvedMirrorLabel(
+    getMetadataString(metadata, "oldPrId"),
+    metadata,
+    "oldPrLabel",
+  );
+  const newPrLabel = useResolvedMirrorLabel(
+    getMetadataString(metadata, "newPrId"),
+    metadata,
+    "newPrLabel",
+  );
+
+  if (!oldPrLabel && newPrLabel) {
+    return (
+      <>
+        {verbPrefix}linked PR{" "}
+        <span className="text-foreground">{newPrLabel}</span>
+      </>
+    );
+  }
+
+  if (oldPrLabel && !newPrLabel) {
+    return (
+      <>
+        unlinked PR <span className="text-foreground">{oldPrLabel}</span>
+      </>
+    );
+  }
+
+  if (oldPrLabel && newPrLabel) {
+    return (
+      <>
+        changed PR from <span className="text-foreground">{oldPrLabel}</span> to{" "}
+        <span className="text-foreground">{newPrLabel}</span>
+      </>
+    );
+  }
+
+  return "changed PR";
+};
+
+const GithubIssueCreatedUpdateText = ({
+  metadata,
+}: {
+  metadata: { [key: string]: unknown } | null;
+}) => {
+  const issueLabel = useResolvedMirrorLabel(
+    getMetadataString(metadata, "issueId"),
+    metadata,
+    "issueLabel",
+  );
+
+  return (
+    <>
+      created issue <span className="text-foreground">{issueLabel}</span>
+    </>
+  );
+};
+
 export function Update({
   update,
   user,
@@ -42,47 +164,6 @@ export function Update({
       console.error("Error parsing update metadata:", error);
     }
   }
-
-  const isIssueChanged = update.type === "issue_changed";
-  const isPrChanged = update.type === "pr_changed";
-  const isGithubIssueCreated = update.type === "github_issue_created";
-
-  const oldIssueEntity = useMirrorEntityByKey(
-    isIssueChanged ? getMetadataString(metadata, "oldIssueId") : null,
-  );
-  const newIssueEntity = useMirrorEntityByKey(
-    isIssueChanged ? getMetadataString(metadata, "newIssueId") : null,
-  );
-  const oldPrEntity = useMirrorEntityByKey(
-    isPrChanged ? getMetadataString(metadata, "oldPrId") : null,
-  );
-  const newPrEntity = useMirrorEntityByKey(
-    isPrChanged ? getMetadataString(metadata, "newPrId") : null,
-  );
-  const createdIssueEntity = useMirrorEntityByKey(
-    isGithubIssueCreated ? getMetadataString(metadata, "issueId") : null,
-  );
-
-  const oldIssueLabel = resolveMirrorEntityLabel(
-    oldIssueEntity,
-    getMetadataString(metadata, "oldIssueLabel"),
-  );
-  const newIssueLabel = resolveMirrorEntityLabel(
-    newIssueEntity,
-    getMetadataString(metadata, "newIssueLabel"),
-  );
-  const oldPrLabel = resolveMirrorEntityLabel(
-    oldPrEntity,
-    getMetadataString(metadata, "oldPrLabel"),
-  );
-  const newPrLabel = resolveMirrorEntityLabel(
-    newPrEntity,
-    getMetadataString(metadata, "newPrLabel"),
-  );
-  const createdIssueLabel = resolveMirrorEntityLabel(
-    createdIssueEntity,
-    getMetadataString(metadata, "issueLabel"),
-  );
 
   const assignedUser = useLiveQuery(
     query.user.first({ id: metadata?.newAssignedUserId }),
@@ -155,75 +236,17 @@ export function Update({
     }
 
     if (update.type === "issue_changed") {
-      if (!oldIssueLabel && newIssueLabel) {
-        return (
-          <>
-            linked issue{" "}
-            <span className="text-foreground">{newIssueLabel}</span>
-          </>
-        );
-      }
-
-      if (oldIssueLabel && !newIssueLabel) {
-        return (
-          <>
-            unlinked issue{" "}
-            <span className="text-foreground">{oldIssueLabel}</span>
-          </>
-        );
-      }
-
-      if (oldIssueLabel && newIssueLabel) {
-        return (
-          <>
-            changed issue from{" "}
-            <span className="text-foreground">{oldIssueLabel}</span> to{" "}
-            <span className="text-foreground">{newIssueLabel}</span>
-          </>
-        );
-      }
-
-      return `changed issue`;
+      return <IssueChangedUpdateText metadata={metadata} />;
     }
 
     if (update.type === "pr_changed") {
-      if (!oldPrLabel && newPrLabel) {
-        return (
-          <>
-            {verbPrefix}linked PR{" "}
-            <span className="text-foreground">{newPrLabel}</span>
-          </>
-        );
-      }
-
-      if (oldPrLabel && !newPrLabel) {
-        return (
-          <>
-            unlinked PR <span className="text-foreground">{oldPrLabel}</span>
-          </>
-        );
-      }
-
-      if (oldPrLabel && newPrLabel) {
-        return (
-          <>
-            changed PR from{" "}
-            <span className="text-foreground">{oldPrLabel}</span> to{" "}
-            <span className="text-foreground">{newPrLabel}</span>
-          </>
-        );
-      }
-
-      return `changed PR`;
+      return (
+        <PrChangedUpdateText metadata={metadata} verbPrefix={verbPrefix} />
+      );
     }
 
     if (update.type === "github_issue_created") {
-      return (
-        <>
-          created issue{" "}
-          <span className="text-foreground">{createdIssueLabel}</span>
-        </>
-      );
+      return <GithubIssueCreatedUpdateText metadata={metadata} />;
     }
 
     if (update.type === "marked_duplicate") {


### PR DESCRIPTION
## Summary
- Activity feed events (`issue_changed`, `pr_changed`, `github_issue_created`) now resolve labels from the org-scoped `externalEntity` mirror via `useMirrorEntityByKey`, keeping labels current when upstream data changes.
- Adds `formatMirrorEntityLabel` and `resolveMirrorEntityLabel` helpers to `external-entities.ts` for consistent label formatting with baked-metadata fallback.
- Fixes autonomous undo events that stored the generic `"linked PR"` fallback — the mirror now supplies the real label when `oldPrId` is present.

## Test plan
- [ ] `bun run --filter web typecheck` passes
- [ ] Link an issue/PR to a thread and confirm the activity feed shows the correct label
- [ ] Change the issue/PR title or state on GitHub (or via devtools sync) and confirm the activity feed label updates without reload
- [ ] Unlink an issue/PR and confirm the unlinked label still renders (mirror or fallback)
- [ ] Confirm events for deleted/unsynced entities still show the baked fallback label

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes issue/PR labels in the activity feed reactive by reading from the org-scoped `externalEntity` mirror. Labels update with upstream changes, fall back to baked snapshots, and mirror lookups are scoped to relevant rows.

- **New Features**
  - Resolve labels for `issue_changed`, `pr_changed`, and `github_issue_created` via `useMirrorEntityByKey`, with mirror-first resolution and fallback.
  - Add `formatMirrorEntityLabel`/`resolveMirrorEntityLabel` for consistent `owner/repo#number` labels.

- **Bug Fixes**
  - Autonomous undo events now show the real PR label when `oldPrId` is present.
  - When both mirror and metadata are missing for `github_issue_created`, show "an issue".

<sup>Written for commit d713acd9df35c0ef9136b2323500d5fb4d6ce61b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved accuracy of mirrored issue and pull request labels shown in thread updates by resolving labels from live mirror entity data rather than cached snapshot values.
  * Standardized how mirrored entities are formatted in update text, ensuring consistent `owner/repo#number` display across related update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->