### PR TITLE
feat(web): render GitHub issue links as reactive chips in markdown

### DIFF
--- a/apps/web/src/components/chips.tsx
+++ b/apps/web/src/components/chips.tsx
@@ -221,91 +221,155 @@ function PrStateIndicator({ state }: { state: PullRequestState }) {
   );
 }
 
-function PrSummaryCard({ entity }: { entity: MirrorEntity }) {
-  const prState = getPullRequestState(entity);
-  const { label } = pullRequestStateConfig[prState];
+function ExternalEntitySummaryHeader({
+  stateIndicator,
+  entity,
+  stateLabel,
+  subtitle,
+}: {
+  stateIndicator: React.ReactNode;
+  entity: Pick<MirrorEntity, "title" | "number">;
+  stateLabel: string;
+  subtitle?: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-1.5">
+        {stateIndicator}
+        <div className="flex min-w-0 flex-1 items-center gap-1.5">
+          <span className="font-medium text-sm text-foreground-primary truncate">
+            {entity.title}
+          </span>
+          <span className="text-sm text-foreground-secondary tabular-nums shrink-0">
+            #{entity.number}
+          </span>
+        </div>
+        <span className="text-sm text-foreground-secondary shrink-0">
+          {stateLabel}
+        </span>
+      </div>
+      {subtitle}
+    </div>
+  );
+}
+
+function ExternalEntityMetadataGrid({
+  entity,
+}: {
+  entity: Pick<MirrorEntity, "repoFullName" | "authorLogin">;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <div className="flex flex-col gap-1 min-w-0">
+        <div className="text-xs text-muted-foreground">Repository</div>
+        <span className="text-sm truncate">{entity.repoFullName}</span>
+      </div>
+      <div className="flex flex-col gap-1 min-w-0">
+        <div className="text-xs text-muted-foreground">Author</div>
+        <span className="text-sm truncate">
+          {entity.authorLogin ?? "Unknown"}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function ExternalEntityLabelList({ labels }: { labels: string[] }) {
+  if (labels.length === 0) return null;
 
   return (
     <>
-      <div className="flex flex-col gap-1">
-        <div className="flex items-center gap-1.5">
-          <PrStateIndicator state={prState} />
-          <div className="flex min-w-0 flex-1 items-center gap-1.5">
-            <span className="font-medium text-sm text-foreground-primary truncate">
-              {entity.title}
-            </span>
-            <span className="text-sm text-foreground-secondary tabular-nums shrink-0">
-              #{entity.number}
-            </span>
-          </div>
-          <span className="text-sm text-foreground-secondary shrink-0">
-            {label}
-          </span>
-        </div>
-        {entity.headRef || entity.baseRef ? (
-          <div className="flex min-w-0 items-center gap-1 text-sm text-muted-foreground font-mono">
-            {entity.headRef ? (
-              <span className="truncate">{entity.headRef}</span>
-            ) : null}
-            {entity.headRef && entity.baseRef ? (
-              <ArrowRight
-                className="size-3.5 shrink-0 text-foreground-secondary"
-                aria-hidden="true"
-              />
-            ) : null}
-            {entity.baseRef ? (
-              <span className="truncate">{entity.baseRef}</span>
-            ) : null}
-          </div>
-        ) : null}
-      </div>
       <Separator />
-      <div className="grid grid-cols-2 gap-3">
-        <div className="flex flex-col gap-1 min-w-0">
-          <div className="text-xs text-muted-foreground">Repository</div>
-          <span className="text-sm truncate">{entity.repoFullName}</span>
-        </div>
-        <div className="flex flex-col gap-1 min-w-0">
-          <div className="text-xs text-muted-foreground">Author</div>
-          <span className="text-sm truncate">
-            {entity.authorLogin ?? "Unknown"}
+      <div className="flex flex-wrap gap-1">
+        {labels.map((labelName) => (
+          <span
+            key={labelName}
+            className="rounded-sm bg-foreground-tertiary/15 px-1.5 py-0.5 text-xs text-foreground-secondary"
+          >
+            {labelName}
           </span>
-        </div>
+        ))}
       </div>
-      {entity.labels.length > 0 ? (
-        <>
-          <Separator />
-          <div className="flex flex-wrap gap-1">
-            {entity.labels.map((labelName) => (
-              <span
-                key={labelName}
-                className="rounded-sm bg-foreground-tertiary/15 px-1.5 py-0.5 text-xs text-foreground-secondary"
-              >
-                {labelName}
-              </span>
-            ))}
-          </div>
-        </>
-      ) : null}
     </>
   );
 }
 
-function PrSummaryHoverCard({
+function ExternalEntitySummaryCard({
+  stateIndicator,
   entity,
+  stateLabel,
+  subtitle,
+}: {
+  stateIndicator: React.ReactNode;
+  entity: MirrorEntity;
+  stateLabel: string;
+  subtitle?: React.ReactNode;
+}) {
+  return (
+    <>
+      <ExternalEntitySummaryHeader
+        stateIndicator={stateIndicator}
+        entity={entity}
+        stateLabel={stateLabel}
+        subtitle={subtitle}
+      />
+      <Separator />
+      <ExternalEntityMetadataGrid entity={entity} />
+      <ExternalEntityLabelList labels={entity.labels} />
+    </>
+  );
+}
+
+function ExternalEntitySummaryHoverCard({
   children,
+  summary,
   ...props
 }: Omit<React.ComponentProps<typeof HoverCard>, "children"> & {
-  entity: MirrorEntity;
+  summary: React.ReactNode;
   children: React.ReactElement;
 }) {
   return (
     <HoverCard {...props}>
       <HoverCardTrigger render={children} />
       <HoverCardContent className="max-w-96 w-full flex flex-col gap-3">
-        <PrSummaryCard entity={entity} />
+        {summary}
       </HoverCardContent>
     </HoverCard>
+  );
+}
+
+function PrBranchSubtitle({ entity }: { entity: MirrorEntity }) {
+  if (!entity.headRef && !entity.baseRef) return null;
+
+  return (
+    <div className="flex min-w-0 items-center gap-1 text-sm text-muted-foreground font-mono">
+      {entity.headRef ? (
+        <span className="truncate">{entity.headRef}</span>
+      ) : null}
+      {entity.headRef && entity.baseRef ? (
+        <ArrowRight
+          className="size-3.5 shrink-0 text-foreground-secondary"
+          aria-hidden="true"
+        />
+      ) : null}
+      {entity.baseRef ? (
+        <span className="truncate">{entity.baseRef}</span>
+      ) : null}
+    </div>
+  );
+}
+
+function PrSummaryCard({ entity }: { entity: MirrorEntity }) {
+  const prState = getPullRequestState(entity);
+  const { label } = pullRequestStateConfig[prState];
+
+  return (
+    <ExternalEntitySummaryCard
+      stateIndicator={<PrStateIndicator state={prState} />}
+      entity={entity}
+      stateLabel={label}
+      subtitle={<PrBranchSubtitle entity={entity} />}
+    />
   );
 }
 
@@ -377,70 +441,11 @@ function IssueSummaryCard({ entity }: { entity: MirrorEntity }) {
   const { label } = issueStateConfig[issueState];
 
   return (
-    <>
-      <div className="flex flex-col gap-1">
-        <div className="flex items-center gap-1.5">
-          <IssueStateIndicator state={issueState} />
-          <div className="flex min-w-0 flex-1 items-center gap-1.5">
-            <span className="font-medium text-sm text-foreground-primary truncate">
-              {entity.title}
-            </span>
-            <span className="text-sm text-foreground-secondary tabular-nums shrink-0">
-              #{entity.number}
-            </span>
-          </div>
-          <span className="text-sm text-foreground-secondary shrink-0">
-            {label}
-          </span>
-        </div>
-      </div>
-      <Separator />
-      <div className="grid grid-cols-2 gap-3">
-        <div className="flex flex-col gap-1 min-w-0">
-          <div className="text-xs text-muted-foreground">Repository</div>
-          <span className="text-sm truncate">{entity.repoFullName}</span>
-        </div>
-        <div className="flex flex-col gap-1 min-w-0">
-          <div className="text-xs text-muted-foreground">Author</div>
-          <span className="text-sm truncate">
-            {entity.authorLogin ?? "Unknown"}
-          </span>
-        </div>
-      </div>
-      {entity.labels.length > 0 ? (
-        <>
-          <Separator />
-          <div className="flex flex-wrap gap-1">
-            {entity.labels.map((labelName) => (
-              <span
-                key={labelName}
-                className="rounded-sm bg-foreground-tertiary/15 px-1.5 py-0.5 text-xs text-foreground-secondary"
-              >
-                {labelName}
-              </span>
-            ))}
-          </div>
-        </>
-      ) : null}
-    </>
-  );
-}
-
-function IssueSummaryHoverCard({
-  entity,
-  children,
-  ...props
-}: Omit<React.ComponentProps<typeof HoverCard>, "children"> & {
-  entity: MirrorEntity;
-  children: React.ReactElement;
-}) {
-  return (
-    <HoverCard {...props}>
-      <HoverCardTrigger render={children} />
-      <HoverCardContent className="max-w-96 w-full flex flex-col gap-3">
-        <IssueSummaryCard entity={entity} />
-      </HoverCardContent>
-    </HoverCard>
+    <ExternalEntitySummaryCard
+      stateIndicator={<IssueStateIndicator state={issueState} />}
+      entity={entity}
+      stateLabel={label}
+    />
   );
 }
 
@@ -487,7 +492,11 @@ export function IssueChip({
       </PrChipButton>
     );
 
-    return <IssueSummaryHoverCard entity={entity}>{chip}</IssueSummaryHoverCard>;
+    return (
+      <ExternalEntitySummaryHoverCard summary={<IssueSummaryCard entity={entity} />}>
+        {chip}
+      </ExternalEntitySummaryHoverCard>
+    );
   }
 
   return (
@@ -550,7 +559,11 @@ export function PrChip({
       </PrChipButton>
     );
 
-    return <PrSummaryHoverCard entity={entity}>{chip}</PrSummaryHoverCard>;
+    return (
+      <ExternalEntitySummaryHoverCard summary={<PrSummaryCard entity={entity} />}>
+        {chip}
+      </ExternalEntitySummaryHoverCard>
+    );
   }
 
   return (

--- a/apps/web/src/components/chips.tsx
+++ b/apps/web/src/components/chips.tsx
@@ -20,6 +20,8 @@ import type { schema } from "api/schema";
 import { cva, type VariantProps } from "class-variance-authority";
 import {
   ArrowRight,
+  CircleCheck,
+  CircleDot,
   CircleUser,
   GitMerge,
   GitPullRequest,
@@ -338,6 +340,170 @@ function PrChipButton({
     >
       {children}
     </BaseButton>
+  );
+}
+
+type IssueState = "open" | "closed";
+
+const issueStateConfig: Record<
+  IssueState,
+  { label: string; icon: typeof CircleDot; className: string }
+> = {
+  open: {
+    label: "Open",
+    icon: CircleDot,
+    className: "text-green-600 dark:text-green-500",
+  },
+  closed: {
+    label: "Closed",
+    icon: CircleCheck,
+    className: "text-purple-600 dark:text-purple-500",
+  },
+};
+
+const getIssueState = (
+  entity: Pick<MirrorEntity, "state">,
+): IssueState => (entity.state === "closed" ? "closed" : "open");
+
+function IssueStateIndicator({ state }: { state: IssueState }) {
+  const { label, icon: Icon, className } = issueStateConfig[state];
+  return (
+    <Icon className={cn("size-3.5 shrink-0", className)} aria-label={label} />
+  );
+}
+
+function IssueSummaryCard({ entity }: { entity: MirrorEntity }) {
+  const issueState = getIssueState(entity);
+  const { label } = issueStateConfig[issueState];
+
+  return (
+    <>
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-1.5">
+          <IssueStateIndicator state={issueState} />
+          <div className="flex min-w-0 flex-1 items-center gap-1.5">
+            <span className="font-medium text-sm text-foreground-primary truncate">
+              {entity.title}
+            </span>
+            <span className="text-sm text-foreground-secondary tabular-nums shrink-0">
+              #{entity.number}
+            </span>
+          </div>
+          <span className="text-sm text-foreground-secondary shrink-0">
+            {label}
+          </span>
+        </div>
+      </div>
+      <Separator />
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col gap-1 min-w-0">
+          <div className="text-xs text-muted-foreground">Repository</div>
+          <span className="text-sm truncate">{entity.repoFullName}</span>
+        </div>
+        <div className="flex flex-col gap-1 min-w-0">
+          <div className="text-xs text-muted-foreground">Author</div>
+          <span className="text-sm truncate">
+            {entity.authorLogin ?? "Unknown"}
+          </span>
+        </div>
+      </div>
+      {entity.labels.length > 0 ? (
+        <>
+          <Separator />
+          <div className="flex flex-wrap gap-1">
+            {entity.labels.map((labelName) => (
+              <span
+                key={labelName}
+                className="rounded-sm bg-foreground-tertiary/15 px-1.5 py-0.5 text-xs text-foreground-secondary"
+              >
+                {labelName}
+              </span>
+            ))}
+          </div>
+        </>
+      ) : null}
+    </>
+  );
+}
+
+function IssueSummaryHoverCard({
+  entity,
+  children,
+  ...props
+}: Omit<React.ComponentProps<typeof HoverCard>, "children"> & {
+  entity: MirrorEntity;
+  children: React.ReactElement;
+}) {
+  return (
+    <HoverCard {...props}>
+      <HoverCardTrigger render={children} />
+      <HoverCardContent className="max-w-96 w-full flex flex-col gap-3">
+        <IssueSummaryCard entity={entity} />
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+export function IssueChip({
+  owner,
+  repo,
+  number,
+  url,
+  disabled = false,
+  className,
+  ...props
+}: Omit<React.ComponentProps<typeof BaseButton>, "children" | "render"> &
+  VariantProps<typeof threadChipVariants> & {
+    owner: string;
+    repo: string;
+    number: number;
+    url: string;
+  }) {
+  const entity = useMirrorEntityByRef({
+    type: "issue",
+    repoFullName: `${owner}/${repo}`,
+    number,
+  });
+
+  if (entity) {
+    const issueState = getIssueState(entity);
+    const { label } = issueStateConfig[issueState];
+
+    const chip = (
+      <PrChipButton
+        url={entity.url}
+        ariaLabel={`Issue ${entity.repoFullName}#${entity.number}: ${entity.title} (${label}, opens in new tab)`}
+        disabled={disabled}
+        className={className}
+        {...props}
+      >
+        <IssueStateIndicator state={issueState} />
+        <span className="text-foreground-primary truncate max-w-48">
+          {entity.title}
+        </span>
+        <span className="text-foreground-secondary tabular-nums shrink-0">
+          #{entity.number}
+        </span>
+      </PrChipButton>
+    );
+
+    return <IssueSummaryHoverCard entity={entity}>{chip}</IssueSummaryHoverCard>;
+  }
+
+  return (
+    <PrChipButton
+      url={url}
+      ariaLabel={`Issue ${owner}/${repo}#${number} (opens in new tab)`}
+      disabled={disabled}
+      className={className}
+      {...props}
+    >
+      <CircleDot className="size-3.5 text-foreground-secondary shrink-0" />
+      <span className="text-foreground-primary">
+        {owner}/{repo}
+      </span>
+      <span className="text-foreground-secondary tabular-nums">#{number}</span>
+    </PrChipButton>
   );
 }
 

--- a/apps/web/src/components/markdown/rich-markdown.tsx
+++ b/apps/web/src/components/markdown/rich-markdown.tsx
@@ -5,7 +5,11 @@ import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { type Components, Streamdown } from "streamdown";
 import "streamdown/styles.css";
 import { z } from "zod";
-import { PrChip, ThreadChipWithSummary } from "~/components/chips";
+import {
+  IssueChip,
+  PrChip,
+  ThreadChipWithSummary,
+} from "~/components/chips";
 import { query } from "~/lib/live-state";
 import { buildThreadParam } from "~/utils/thread";
 
@@ -14,7 +18,10 @@ const THREAD_LINK_PROXY_PREFIX = "https://frontdesk-thread.local/";
 const GITHUB_PR_URL_REGEX =
   /^https?:\/\/(?:www\.)?github\.com\/([\w.-]+)\/([\w.-]+)\/pulls?\/(\d+)(?:\/[^?#]*)?(?:[?#].*)?$/;
 
-const GithubPrSchema = z.object({
+const GITHUB_ISSUE_URL_REGEX =
+  /^https?:\/\/(?:www\.)?github\.com\/([\w.-]+)\/([\w.-]+)\/issues?\/(\d+)(?:\/[^?#]*)?(?:[?#].*)?$/;
+
+const GithubEntityUrlSchema = z.object({
   owner: z.string().min(1),
   repo: z.string().min(1),
   number: z.number().int().positive(),
@@ -25,7 +32,21 @@ export function parseGithubPrUrl(href: string | undefined) {
   if (!href) return null;
   const match = href.match(GITHUB_PR_URL_REGEX);
   if (!match) return null;
-  const parseResult = GithubPrSchema.safeParse({
+  const parseResult = GithubEntityUrlSchema.safeParse({
+    owner: match[1],
+    repo: match[2],
+    number: Number(match[3]),
+    url: href,
+  });
+  if (!parseResult.success) return null;
+  return parseResult.data;
+}
+
+export function parseGithubIssueUrl(href: string | undefined) {
+  if (!href) return null;
+  const match = href.match(GITHUB_ISSUE_URL_REGEX);
+  if (!match) return null;
+  const parseResult = GithubEntityUrlSchema.safeParse({
     owner: match[1],
     repo: match[2],
     number: Number(match[3]),
@@ -142,12 +163,14 @@ type RichMarkdownProps = {
   components?: Components;
 };
 
-export function PrChipInline(props: {
+type GithubEntityChipInlineProps = {
   owner: string;
   repo: string;
   number: number;
   url: string;
-}) {
+};
+
+function useInlineChipSpacing() {
   const ref = useRef<HTMLSpanElement>(null);
   const [hasLeadingSpace, setHasLeadingSpace] = useState(false);
   const [hasTrailingSpace, setHasTrailingSpace] = useState(false);
@@ -163,9 +186,32 @@ export function PrChipInline(props: {
     );
   });
 
+  return { ref, hasLeadingSpace, hasTrailingSpace };
+}
+
+export function PrChipInline(props: GithubEntityChipInlineProps) {
+  const { ref, hasLeadingSpace, hasTrailingSpace } = useInlineChipSpacing();
+
   return (
     <span ref={ref} className="contents">
       <PrChip
+        {...props}
+        className={cn(
+          "inline-flex mb-0 translate-y-0.5",
+          hasLeadingSpace && "ml-px",
+          hasTrailingSpace && "mr-px",
+        )}
+      />
+    </span>
+  );
+}
+
+export function IssueChipInline(props: GithubEntityChipInlineProps) {
+  const { ref, hasLeadingSpace, hasTrailingSpace } = useInlineChipSpacing();
+
+  return (
+    <span ref={ref} className="contents">
+      <IssueChip
         {...props}
         className={cn(
           "inline-flex mb-0 translate-y-0.5",
@@ -290,6 +336,10 @@ export const RichMarkdown = ({
         const pr = parseGithubPrUrl(href);
         if (pr) {
           return <PrChipInline {...pr} />;
+        }
+        const issue = parseGithubIssueUrl(href);
+        if (issue) {
+          return <IssueChipInline {...issue} />;
         }
         return (
           <a href={href} target="_blank" rel="noreferrer" {...props}>

--- a/apps/web/src/components/markdown/rich-markdown.tsx
+++ b/apps/web/src/components/markdown/rich-markdown.tsx
@@ -19,7 +19,7 @@ const GITHUB_PR_URL_REGEX =
   /^https?:\/\/(?:www\.)?github\.com\/([\w.-]+)\/([\w.-]+)\/pulls?\/(\d+)(?:\/[^?#]*)?(?:[?#].*)?$/;
 
 const GITHUB_ISSUE_URL_REGEX =
-  /^https?:\/\/(?:www\.)?github\.com\/([\w.-]+)\/([\w.-]+)\/issues?\/(\d+)(?:\/[^?#]*)?(?:[?#].*)?$/;
+  /^https?:\/\/(?:www\.)?github\.com\/([\w.-]+)\/([\w.-]+)\/issues\/(\d+)(?:\/[^?#]*)?(?:[?#].*)?$/;
 
 const GithubEntityUrlSchema = z.object({
   owner: z.string().min(1),

--- a/apps/web/src/components/markdown/tiptap-link-renderer.tsx
+++ b/apps/web/src/components/markdown/tiptap-link-renderer.tsx
@@ -4,7 +4,9 @@ import {
 } from "@workspace/ui/components/blocks/tiptap-link";
 import { useAtomValue } from "jotai";
 import {
+  IssueChipInline,
   PrChipInline,
+  parseGithubIssueUrl,
   parseGithubPrUrl,
   ThreadMention,
 } from "~/components/markdown/rich-markdown";
@@ -74,13 +76,18 @@ const renderLink: TiptapLinkRendererFn = ({ href }) => {
     return <PrChipInline {...pr} />;
   }
 
+  const issue = parseGithubIssueUrl(href);
+  if (issue) {
+    return <IssueChipInline {...issue} />;
+  }
+
   return null;
 };
 
 /**
  * Makes the shared Tiptap editor/renderer render thread references and GitHub
- * PR links as rich chips, mirroring {@link RichMarkdown}. Wrap any subtree that
- * mounts the Tiptap components from `@workspace/ui/components/blocks/tiptap`.
+ * issue/PR links as rich chips, mirroring {@link RichMarkdown}. Wrap any subtree
+ * that mounts the Tiptap components from `@workspace/ui/components/blocks/tiptap`.
  */
 export function TiptapLinkRenderer({
   children,


### PR DESCRIPTION
## Summary
- Add `IssueChip` with reactive lookup against the org-scoped `externalEntity` mirror, showing live title and open/closed state with a hover card
- Parse GitHub issue URLs in `RichMarkdown` and `TiptapLinkRenderer`, mirroring the existing PR chip behavior
- Fall back to a static `owner/repo #number` link when the issue is not mirrored

## Test plan
- [ ] Paste a GitHub issue URL from a mirrored repo into a thread message and confirm it renders as a chip with title and state
- [ ] Hover the chip and verify the summary card shows repo, author, and labels
- [ ] Change the issue title or close it on GitHub (or via devtools sync) and confirm the chip updates without reload
- [ ] Paste an issue URL from an unmirrored repo and confirm the static fallback still renders
- [ ] Confirm PR URLs continue to render as PR chips
- [ ] `bun run --filter web typecheck`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render GitHub issue links as reactive chips in markdown and Tiptap, showing live title and state from the org-scoped `externalEntity` mirror. Falls back to a static `owner/repo #number` link when not mirrored.

- **New Features**
  - Added `IssueChip` with live lookup and a hover card (repo, author, labels).
  - Parse issue URLs in `RichMarkdown` and `TiptapLinkRenderer` (only `/issues/` paths; PR chips unchanged).
  - Improved inline chip spacing for better text flow.

- **Refactors**
  - Extracted a shared external-entity summary layout used by issue and PR hover cards.

<sup>Written for commit 2b1aaaf68856ebb55b3c46075c8ef787810d0fcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub issue links now display as interactive chips with hover card summaries, showing title, number, state, and metadata—matching pull request handling.
  * Issue references in markdown and rich text editors render as styled inline chips with consistent spacing and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->