### PR TITLE
feat(api,worker): close handler convergence and thread.setAgentRead (LP-003f, LP-003g)

### DIFF
--- a/apps/api/src/lib/signals/handlers/close.ts
+++ b/apps/api/src/lib/signals/handlers/close.ts
@@ -1,8 +1,14 @@
 import type { CloseAction } from "@workspace/schemas/signals";
-import { insertThreadActivity, statusActivityMetadata } from "../activity";
+import { runSetThreadStatus } from "../../thread-mutations";
+import {
+  clearCompensateSnapshot,
+  getCompensateSnapshot,
+  setCompensateSnapshot,
+} from "../compensate-snapshots";
 import type { ActionHandler } from "../types";
 
 const STATUS_CLOSED = 3;
+const snapshotKey = () => "close";
 
 export const closeHandler: ActionHandler<CloseAction> = {
   async apply(_action, ctx) {
@@ -14,12 +20,36 @@ export const closeHandler: ActionHandler<CloseAction> = {
     const previousStatus = thread.status ?? 0;
     if (previousStatus === STATUS_CLOSED) return;
 
-    await ctx.db.thread.update(ctx.threadId, { status: STATUS_CLOSED });
+    if (getCompensateSnapshot(ctx, snapshotKey()) === undefined) {
+      setCompensateSnapshot(ctx, snapshotKey(), { previousStatus });
+    }
 
-    await insertThreadActivity(ctx, {
-      type: "status_changed",
-      metadata: statusActivityMetadata(previousStatus, STATUS_CLOSED),
-      source: "agent_read",
+    await runSetThreadStatus(
+      ctx.db,
+      {
+        threadId: ctx.threadId,
+        organizationId: ctx.organizationId,
+        status: STATUS_CLOSED,
+        source: "agent_read",
+      },
+      {
+        userId: ctx.actorUserId,
+        userName: ctx.actorUserName,
+      },
+      { preloadedThread: thread },
+    );
+  },
+
+  async compensate(_action, ctx) {
+    const snapshot = getCompensateSnapshot<{ previousStatus: number }>(
+      ctx,
+      snapshotKey(),
+    );
+    if (!snapshot) return;
+
+    await ctx.db.thread.update(ctx.threadId, {
+      status: snapshot.previousStatus,
     });
+    clearCompensateSnapshot(ctx, snapshotKey());
   },
 };

--- a/apps/api/src/lib/signals/handlers/close.ts
+++ b/apps/api/src/lib/signals/handlers/close.ts
@@ -47,9 +47,16 @@ export const closeHandler: ActionHandler<CloseAction> = {
     );
     if (!snapshot) return;
 
-    await ctx.db.thread.update(ctx.threadId, {
-      status: snapshot.previousStatus,
-    });
+    await runSetThreadStatus(
+      ctx.db,
+      {
+        threadId: ctx.threadId,
+        organizationId: ctx.organizationId,
+        status: snapshot.previousStatus,
+        source: "agent_read",
+      },
+      { userId: null, userName: null },
+    );
     clearCompensateSnapshot(ctx, snapshotKey());
   },
 };

--- a/apps/api/src/lib/thread-mutations.ts
+++ b/apps/api/src/lib/thread-mutations.ts
@@ -1,6 +1,6 @@
 import type { InferLiveObject } from "@live-state/sync";
 import type { ServerDB } from "@live-state/sync/server";
-import { PRIORITY_LABELS } from "@workspace/schemas/signals";
+import { PRIORITY_LABELS, threadReadSchema } from "@workspace/schemas/signals";
 import { addDays } from "date-fns";
 import { ulid } from "ulid";
 import { z } from "zod";
@@ -84,6 +84,12 @@ export const archiveThreadInputSchema = z.object({
 export const restoreThreadInputSchema = z.object({
   threadId: z.string(),
   organizationId: z.string(),
+});
+
+export const setAgentReadInputSchema = z.object({
+  threadId: z.string(),
+  organizationId: z.string(),
+  agentRead: threadReadSchema.nullable(),
 });
 
 type ThreadWriteDb = Pick<ServerDB<typeof schema>, "thread" | "insert">;
@@ -633,5 +639,26 @@ export const runRestoreThread = async (
 
   return {
     thread: { ...thread, deletedAt: null },
+  };
+};
+
+export const runSetAgentRead = async (
+  db: Pick<ServerDB<typeof schema>, "thread">,
+  input: z.infer<typeof setAgentReadInputSchema>,
+  options?: {
+    preloadedThread?: ThreadRow;
+  },
+) => {
+  const thread =
+    options?.preloadedThread ??
+    (await db.thread.one(input.threadId).get());
+  if (!thread || thread.organizationId !== input.organizationId) {
+    throw new Error("THREAD_NOT_FOUND");
+  }
+
+  await db.thread.update(input.threadId, { agentRead: input.agentRead });
+
+  return {
+    thread: { ...thread, agentRead: input.agentRead },
   };
 };

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -16,10 +16,12 @@ import {
   runLinkPullRequest,
   runMarkDuplicate,
   runRestoreThread,
+  runSetAgentRead,
   runSetThreadPriority,
   runSetThreadStatus,
   runUnlinkIssue,
   runUnlinkPullRequest,
+  setAgentReadInputSchema,
   setPriorityInputSchema,
   setStatusInputSchema,
   unlinkIssueInputSchema,
@@ -702,6 +704,15 @@ export default publicRoute
 
       return runRestoreThread(db, req.input);
     }),
+    setAgentRead: mutation(setAgentReadInputSchema).handler(
+      async ({ req, db }) => {
+        if (!req.context?.internalApiKey) {
+          throw new Error("UNAUTHORIZED");
+        }
+
+        return runSetAgentRead(db, req.input);
+      },
+    ),
   }))
   .withHooks({
     // TODO: Migrate this logic into a custom `create` mutation and have the

--- a/apps/worker/src/lib/agent-read.ts
+++ b/apps/worker/src/lib/agent-read.ts
@@ -8,7 +8,12 @@ export { nextAgentReadAfterExecution } from "@workspace/schemas/signals";
 
 export const persistAgentRead = async (
   threadId: string,
+  organizationId: string,
   agentRead: ThreadRead | null,
 ): Promise<void> => {
-  await fetchClient.mutate.thread.update(threadId, { agentRead });
+  await fetchClient.mutate.thread.setAgentRead({
+    threadId,
+    organizationId,
+    agentRead,
+  });
 };

--- a/apps/worker/src/lib/apply-synthesis-autonomy.ts
+++ b/apps/worker/src/lib/apply-synthesis-autonomy.ts
@@ -19,7 +19,7 @@ export const applySynthesisAutonomy = async (
   rawActionSet: ThreadRead | null,
 ): Promise<ThreadRead | null> => {
   if (!rawActionSet) {
-    await persistAgentRead(threadId, null);
+    await persistAgentRead(threadId, organizationId, null);
     return null;
   }
 
@@ -33,7 +33,7 @@ export const applySynthesisAutonomy = async (
   );
 
   if (primary.length === 0) {
-    await persistAgentRead(threadId, null);
+    await persistAgentRead(threadId, organizationId, null);
     return null;
   }
 
@@ -83,7 +83,7 @@ export const applySynthesisAutonomy = async (
   }
 
   if (finalPrimary.length === 0) {
-    await persistAgentRead(threadId, null);
+    await persistAgentRead(threadId, organizationId, null);
     return null;
   }
 
@@ -92,6 +92,6 @@ export const applySynthesisAutonomy = async (
     primary: finalPrimary,
   };
 
-  await persistAgentRead(threadId, agentRead);
+  await persistAgentRead(threadId, organizationId, agentRead);
   return agentRead;
 };

--- a/docs/plans/custom-route-mutations.md
+++ b/docs/plans/custom-route-mutations.md
@@ -22,13 +22,13 @@ All known callers must move to the replacement procedures. When a custom procedu
 ## Current State
 
 - Status: in-progress
-- Active checkpoint: **LP-003f** (next PR slice)
+- Active checkpoint: **LP-003h** (next PR slice)
 - Branch or PR: none
-- Last updated: 2026-06-21
+- Last updated: 2026-06-22
 
 LP-001 inventory is complete below. API routes live in `apps/api/src/live-state/router.ts` and `apps/api/src/live-state/router/*.ts`. Several families already expose custom procedures but still use `withMutations` instead of `withProcedures`; `thread`, `message`, `label`, and `autonomousAction` already use `withProcedures`. Web writes use both `mutate.*` (synced client) and `fetchClient.mutate.*` (HTTP); optimistic handlers are centralized in `apps/web/src/lib/live-state.ts`.
 
-**LP-003 progress:** Shared thread write helpers live in `apps/api/src/lib/thread-mutations.ts`. Implemented `thread.setStatus`, `thread.setPriority`, `thread.assignUser`, `thread.linkIssue`, `thread.unlinkIssue`, `thread.linkPullRequest`, `thread.unlinkPullRequest`, `thread.markDuplicate`, `thread.archive`, `thread.restore` (API procedures + web migration + optimistic handler for archive). `set-status` and `mark-duplicate` signal handlers delegate to shared helpers. Web archive/restore and duplicate accept have zero generic `thread.update` for `deletedAt` or status/activity pairs. Remaining LP-003 work: `setAgentRead`, slack/discord `thread.create` / generic `message.insert`, and integration generic `thread.update` call sites.
+**LP-003 progress:** Shared thread write helpers live in `apps/api/src/lib/thread-mutations.ts`. Implemented `thread.setStatus`, `thread.setPriority`, `thread.assignUser`, `thread.linkIssue`, `thread.unlinkIssue`, `thread.linkPullRequest`, `thread.unlinkPullRequest`, `thread.markDuplicate`, `thread.archive`, `thread.restore`, `thread.setAgentRead` (API procedures + web migration + optimistic handler for archive). `set-status`, `close`, and `mark-duplicate` signal handlers delegate to shared helpers. Worker `persistAgentRead` uses `thread.setAgentRead`. Web archive/restore and duplicate accept have zero generic `thread.update` for `deletedAt` or status/activity pairs. Remaining LP-003 work: slack/discord `thread.create` / generic `message.insert`, and integration generic `thread.update` call sites.
 
 ## Write inventory matrix
 
@@ -209,7 +209,7 @@ Procedures **already implemented** are marked ✓. Others are the LP-003–LP-00
 | `linkPullRequest` / `unlinkPullRequest` ✓ | `thread` | generic `thread.update` externalPrId + paired `update.insert` | **yes** ✓ |
 | `markDuplicate` ✓ | `thread` | generic `thread.update` status duplicate + activity | **yes** ✓ |
 | `archive` / `restore` ✓ | `thread` | generic `thread.update` deletedAt / status | **yes** for archive only ✓ |
-| `setAgentRead` | `thread` | generic `thread.update` agentRead (worker `agent-read.ts`) | **no** — worker-only |
+| `setAgentRead` ✓ | `thread` | generic `thread.update` agentRead (worker `agent-read.ts`) | **no** — worker-only |
 | `create` ✓ | `message` | generic `message.insert` (slack, discord, devtools) | ✓ already |
 | `markAsAnswer` ✓ | `message` | — | ✓ already |
 | — | `author` | generic `author.insert` | **no** — always created inside `thread.create` / `message.create`; block generic insert |
@@ -277,8 +277,8 @@ Parent checklist items (`LP-003`–`LP-009`) complete when all child slices unde
 | [x] **LP-003c** | `thread.linkPullRequest` / `unlinkPullRequest` | `thread-mutations.ts`, `pull-requests.tsx`, optimistic handlers | `pull-requests.tsx` has zero generic thread/update pairs for PR link/unlink |
 | [x] **LP-003d** | `thread.markDuplicate` | `thread-mutations.ts`, `quick-actions.tsx` duplicate accept, `mark-duplicate` handler → shared helper, optimistic | Duplicate accept uses `mutate.thread.markDuplicate` only |
 | [x] **LP-003e** | `thread.archive` / `thread.restore` | `thread-mutations.ts`, `threads/$id/index.tsx` delete, `archive/$id.tsx` restore, optimistic (archive) | Archive/restore use procedures; no generic `thread.update` for `deletedAt` |
-| [ ] **LP-003f** | Signal handler convergence (close) | `close.ts` → `runSetThreadStatus` | Handler calls shared helper, not raw `db.thread.update` + `insertThreadActivity` |
-| [ ] **LP-003g** | `thread.setAgentRead` (worker) | `thread-mutations.ts`, `apps/worker/src/lib/agent-read.ts` | Worker uses `thread.setAgentRead`; no generic `thread.update` for `agentRead` |
+| [x] **LP-003f** | Signal handler convergence (close) | `close.ts` → `runSetThreadStatus` | Handler calls shared helper, not raw `db.thread.update` + `insertThreadActivity` |
+| [x] **LP-003g** | `thread.setAgentRead` (worker) | `thread-mutations.ts`, `apps/worker/src/lib/agent-read.ts` | Worker uses `thread.setAgentRead`; no generic `thread.update` for `agentRead` |
 | [ ] **LP-003h** | Web devtools → `thread.create` / `message.create` | `create-thread-button.tsx`, `duplicate-thread-command.tsx`; remove generic `author.insert` | Devtools use procedures only |
 | [ ] **LP-003i** | `thread.create` optimistic (optional) | `live-state.ts` if product `mutate.thread.create` paths need instant UI | Document yes/no in matrix; implement only if fire-and-forget `mutate` callers exist |
 | [ ] **LP-003j** | Slack → `thread.create` / `message.create` | `apps/slack/src/index.ts` (`store.mutate` / `fetchClient` thread/message/author inserts) | Ripgrep: no `store.mutate.thread.insert` / `message.insert` in slack |
@@ -367,6 +367,8 @@ Parent checklist items (`LP-003`–`LP-009`) complete when all child slices unde
 - 2026-06-21 (LP-003c): PR link procedures mirror issue link (`linkPullRequest` / `unlinkPullRequest`); labels resolve from `externalEntity` mirror (`type: "pull_request"`). Activity type is `pr_changed` with `oldPrId`/`newPrId`/`oldPrLabel`/`newPrLabel` metadata.
 - 2026-06-21 (LP-003d): `runMarkDuplicate` sets status to `STATUS_DUPLICATED` (4) and inserts `marked_duplicate` activity; `mark-duplicate` signal handler delegates to shared helper (compensate snapshot logic retained in handler). Web duplicate accept passes optional `duplicateOfThreadName` for optimistic metadata when target thread is already loaded.
 - 2026-06-21 (LP-003e): `runArchiveThread` / `runRestoreThread` own `deletedAt` semantics server-side (`THREAD_DELETION_GRACE_DAYS = 30`); no timeline activity rows (matches prior generic-update behavior). Optimistic handler for `archive` only; `restore` intentionally omitted (user navigates away immediately).
+- 2026-06-22 (LP-003f): `close` signal handler delegates to `runSetThreadStatus` with `source: "agent_read"`; added compensate snapshot logic (close is reversible per `isReversible`). Activity insertion now flows through shared helper when `actorUserId` is set.
+- 2026-06-22 (LP-003g): `runSetAgentRead` + `thread.setAgentRead` procedure (internal API key only); worker `persistAgentRead` migrated; no web optimistic handler (worker-only).
 
 ## PR Feedback
 
@@ -383,6 +385,8 @@ Parent checklist items (`LP-003`–`LP-009`) complete when all child slices unde
 - 2026-06-21 (LP-003c): `bun run --filter api typecheck` and `bun run --filter web typecheck` pass. Ripgrep: `pull-requests.tsx` has zero `mutate.thread.update` / `mutate.update.insert`. No runtime UI smoke test for PR link/unlink combobox.
 - 2026-06-21 (LP-003d): `bun run --filter api typecheck` and `bun run --filter web typecheck` pass. Ripgrep: `quick-actions.tsx` has zero `mutate.thread.update` / `mutate.update.insert`. No runtime UI smoke test for duplicate accept in Support Intelligence panel.
 - 2026-06-21 (LP-003e): `bun run --filter api typecheck` and `bun run --filter web typecheck` pass. Ripgrep: `threads/$id/index.tsx` and `archive/$id.tsx` have zero `mutate.thread.update`. No runtime UI smoke test for archive/restore flows.
+- 2026-06-22 (LP-003f): `bun run --filter api typecheck` pass. Ripgrep: `close.ts` has no `insertThreadActivity`; apply path uses `runSetThreadStatus`. No runtime test for close action in autonomous bundle rollback.
+- 2026-06-22 (LP-003g): `bun run --filter api typecheck` and `bun run --filter worker typecheck` pass. Ripgrep: `apps/worker/src` has zero `mutate.thread.update` / `thread.update` for agentRead. No runtime synthesis pipeline smoke test.
 
 ## Session Log
 
@@ -397,7 +401,9 @@ Parent checklist items (`LP-003`–`LP-009`) complete when all child slices unde
 - 2026-06-21 (LP-003c): Implemented `thread.linkPullRequest` / `unlinkPullRequest` — `runLinkPullRequest` / `runUnlinkPullRequest` in `thread-mutations.ts`, procedures in `router/threads.ts`, migrated `pull-requests.tsx`, optimistic handlers in `live-state.ts`.
 - 2026-06-21 (LP-003d): Implemented `thread.markDuplicate` — `runMarkDuplicate` in `thread-mutations.ts`, procedure in `router/threads.ts`, migrated `quick-actions.tsx` duplicate accept, refactored `mark-duplicate` signal handler, optimistic handler in `live-state.ts`.
 - 2026-06-21 (LP-003e): Implemented `thread.archive` / `thread.restore` — `runArchiveThread` / `runRestoreThread` in `thread-mutations.ts`, procedures in `router/threads.ts`, migrated `threads/$id/index.tsx` and `archive/$id.tsx`, optimistic `archive` handler in `live-state.ts`.
+- 2026-06-22 (LP-003f): Refactored `close.ts` to delegate apply to `runSetThreadStatus`; added compensate snapshot (first-write-wins) mirroring `set-status.ts`.
+- 2026-06-22 (LP-003g): Added `runSetAgentRead` + `thread.setAgentRead` procedure (internal key); migrated worker `persistAgentRead` and `apply-synthesis-autonomy.ts` call sites.
 
 ## Handoff
 
-Next action: Ship **LP-003f** — refactor `apps/api/src/lib/signals/handlers/close.ts` to delegate to `runSetThreadStatus` (mirror `set-status.ts`); retain compensate snapshot logic in the handler.
+Next action: Ship **LP-003h** — migrate devtools `create-thread-button.tsx` and `duplicate-thread-command.tsx` from generic `thread.insert` / `message.insert` / `author.insert` to `thread.create` / `message.create`; remove standalone `author.insert` calls.


### PR DESCRIPTION
## Summary

- **LP-003f:** Refactor the `close` signal handler to delegate status changes to `runSetThreadStatus` instead of raw `db.thread.update` + `insertThreadActivity`. Adds compensate snapshot logic (first-write-wins) since `close` is a reversible action.
- **LP-003g:** Add `thread.setAgentRead` procedure (internal API key only) with shared `runSetAgentRead` helper. Migrates worker `persistAgentRead` and `apply-synthesis-autonomy.ts` off generic `thread.update`.

## Test plan

- [x] `bun run --filter api typecheck`
- [x] `bun run --filter worker typecheck`
- [x] Ripgrep: `close.ts` uses `runSetThreadStatus`, no `insertThreadActivity` on apply path
- [x] Ripgrep: `apps/worker/src` has no generic `thread.update` for `agentRead`
- [ ] Manual: trigger autonomous bundle with `close` action and verify rollback on paired failure
- [ ] Manual: run synthesis pipeline and confirm `thread.agentRead` persists correctly


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converges the `close` signal handler onto shared status logic with rollback support and adds an internal `thread.setAgentRead` API for the worker, removing the remaining generic `thread.update` for `agentRead`. Completes LP-003f and LP-003g in the LP-003 migration.

- New Features
  - `thread.setAgentRead` mutation (internal-only, requires internal API key) using `runSetAgentRead`.
  - Worker `persistAgentRead` and synthesis autonomy now call `thread.setAgentRead` with `organizationId`.

- Refactors
  - `close` handler delegates apply and compensate to `runSetThreadStatus` with compensate snapshot and tenant-scoped rollback (`organizationId`), activity flowing through the shared helper with `source: "agent_read"`.
  - Removed direct `thread.update` and activity writes from the `close` apply path.
  - Docs updated to mark LP-003f and LP-003g as done and move the checkpoint to LP-003h.

<sup>Written for commit a26b79f9a877d83a3ad4b05e86db7ec1e271f638. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an internal Live-State mutation to set a thread’s agent-read state, intended for internal-key usage.
* **Refactor**
  * Improved thread close handling reliability by using a compensating snapshot to restore prior status on failure.
  * Updated agent-read persistence to always include organizational context for safer, consistent updates.
* **Bug Fixes**
  * Prevented direct status/activity updates during close, relying on the new transactional flow instead.
* **Chores**
  * Advanced and updated the custom route mutations migration plan documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #295
2. **#296** 👈 current
3. #297
4. #298
<!-- stack:links:end -->