### PR TITLE
feat(api,integrations): slack/discord/github thread procedures (LP-003j–m)

### DIFF
--- a/apps/api/src/lib/thread-mutations.ts
+++ b/apps/api/src/lib/thread-mutations.ts
@@ -14,6 +14,10 @@ export const setStatusInputSchema = z.object({
   source: z.string().optional(),
   userId: z.string().optional(),
   userName: z.string().optional(),
+  /** Internal API key only — insert timeline row without a session actor. */
+  recordActivity: z.boolean().optional(),
+  activityMetadata: z.record(z.string(), z.unknown()).optional(),
+  replicatedStr: z.string().optional(),
 });
 
 export const setPriorityInputSchema = z.object({
@@ -173,6 +177,7 @@ export const runSetThreadStatus = async (
   },
   options?: {
     preloadedThread?: ThreadRow;
+    recordActivity?: boolean;
   },
 ) => {
   const thread =
@@ -189,7 +194,10 @@ export const runSetThreadStatus = async (
 
   await db.thread.update(input.threadId, { status: input.status });
 
-  if (actor.userId !== null) {
+  const shouldRecordActivity =
+    actor.userId !== null || options?.recordActivity === true;
+
+  if (shouldRecordActivity) {
     await db.insert(schema.update, {
       id: ulid().toLowerCase(),
       threadId: input.threadId,
@@ -200,8 +208,9 @@ export const runSetThreadStatus = async (
         ...statusActivityMetadata(oldStatus, input.status),
         ...(actor.userName ? { userName: actor.userName } : {}),
         ...(input.source ? { source: input.source } : {}),
+        ...(input.activityMetadata ?? {}),
       }),
-      replicatedStr: JSON.stringify({}),
+      replicatedStr: input.replicatedStr ?? JSON.stringify({}),
     });
   }
 

--- a/apps/api/src/lib/tiptap-content.ts
+++ b/apps/api/src/lib/tiptap-content.ts
@@ -1,8 +1,17 @@
 /** Serialize plain text or TipTap JSON (object or JSON string) for message storage. */
 export const serializeMessageContent = (content: string | unknown): string => {
-  if (typeof content !== "string") {
+  if (content !== null && typeof content === "object") {
     const serialized = JSON.stringify(content);
     return serialized ?? JSON.stringify([{ type: "paragraph" }]);
+  }
+
+  if (typeof content !== "string") {
+    return JSON.stringify([
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: String(content) }],
+      },
+    ]);
   }
 
   const trimmed = content.trim();

--- a/apps/api/src/lib/tiptap-content.ts
+++ b/apps/api/src/lib/tiptap-content.ts
@@ -1,7 +1,8 @@
 /** Serialize plain text or TipTap JSON (object or JSON string) for message storage. */
 export const serializeMessageContent = (content: string | unknown): string => {
   if (typeof content !== "string") {
-    return JSON.stringify(content);
+    const serialized = JSON.stringify(content);
+    return serialized ?? JSON.stringify([{ type: "paragraph" }]);
   }
 
   const trimmed = content.trim();

--- a/apps/api/src/lib/tiptap-content.ts
+++ b/apps/api/src/lib/tiptap-content.ts
@@ -1,0 +1,23 @@
+/** Serialize plain text or TipTap JSON (object or JSON string) for message storage. */
+export const serializeMessageContent = (content: string | unknown): string => {
+  if (typeof content !== "string") {
+    return JSON.stringify(content);
+  }
+
+  const trimmed = content.trim();
+  if (trimmed.startsWith("[") || trimmed.startsWith("{")) {
+    try {
+      JSON.parse(trimmed);
+      return trimmed;
+    } catch {
+      // fall through to plain-text paragraph
+    }
+  }
+
+  return JSON.stringify([
+    {
+      type: "paragraph",
+      content: [{ type: "text", text: content }],
+    },
+  ]);
+};

--- a/apps/api/src/live-state/router/message.ts
+++ b/apps/api/src/live-state/router/message.ts
@@ -4,10 +4,30 @@ import z from "zod";
 import { authorize } from "../../lib/authorize";
 import { enqueueThreadRead } from "../../lib/queue";
 import { searchMessages } from "../../lib/search/qdrant";
+import { serializeMessageContent } from "../../lib/tiptap-content";
 import { publicRoute } from "../factories";
 import { schema } from "../schema";
 
 const STATUS_RESOLVED = 2;
+
+const messageCreateInputSchema = z.object({
+  threadId: z.string(),
+  content: z.union([z.string(), z.any()]),
+  organizationId: z.string(),
+  userId: z.string().optional(),
+  userName: z.string().optional(),
+  author: z
+    .object({
+      id: z.string(),
+      name: z.string(),
+    })
+    .optional(),
+  id: z.string().optional(),
+  createdAt: z.coerce.date().optional(),
+  origin: z.string().nullable().optional(),
+  externalMessageId: z.string().nullable().optional(),
+  isBackfill: z.boolean().optional(),
+});
 
 export default publicRoute
   .collectionRoute(schema.message, {
@@ -44,19 +64,13 @@ export default publicRoute
     },
   })
   .withProcedures(({ mutation }) => ({
-    create: mutation(
-      z.object({
-        threadId: z.string(),
-        content: z.union([z.string(), z.any()]), // Accept string or TipTap JSONContent
-        userId: z.string().optional(),
-        userName: z.string().optional(),
-        organizationId: z.string(),
-      }),
-    ).handler(async ({ req, db }) => {
+    create: mutation(messageCreateInputSchema).handler(async ({ req, db }) => {
       authorize(req, {
         organizationId: req.input.organizationId,
         allowPublicApiKey: true,
       });
+
+      const hasIntegrationAuthor = !!req.input.author;
 
       const actualUserId: string | undefined =
         req.context?.portalSession?.session.userId ??
@@ -68,7 +82,7 @@ export default publicRoute
         req.context?.user?.name ??
         req.input.userName;
 
-      if (!actualUserId || !actualUserName) {
+      if (!hasIntegrationAuthor && (!actualUserId || !actualUserName)) {
         throw new Error("MISSING_USER_ID_OR_NAME");
       }
 
@@ -78,38 +92,56 @@ export default publicRoute
         throw new Error("THREAD_NOT_FOUND");
       }
 
-      const content =
-        typeof req.input.content === "string"
-          ? JSON.stringify([
-              {
-                type: "paragraph",
-                content: [{ type: "text", text: req.input.content }],
-              },
-            ])
-          : JSON.stringify(req.input.content);
-
-      const messageId = ulid().toLowerCase();
+      const content = serializeMessageContent(req.input.content);
+      const messageId = req.input.id ?? ulid().toLowerCase();
 
       await db.transaction(async ({ trx }) => {
-        const existingAuthor = await trx.author
-          .first({
-            userId: actualUserId,
-            organizationId: req.input.organizationId,
-          })
-          .get();
+        let authorId: string | undefined;
 
-        let authorId = existingAuthor?.id;
+        if (hasIntegrationAuthor && req.input.author) {
+          const existingAuthor = await trx.author
+            .first({
+              metaId: req.input.author.id,
+              organizationId: req.input.organizationId,
+            })
+            .get();
 
-        if (!authorId) {
-          authorId = ulid().toLowerCase();
+          authorId = existingAuthor?.id;
 
-          await trx.author.insert({
-            id: authorId,
-            userId: actualUserId,
-            metaId: null,
-            name: actualUserName,
-            organizationId: req.input.organizationId,
-          });
+          if (!authorId) {
+            authorId = ulid().toLowerCase();
+            await trx.author.insert({
+              id: authorId,
+              name: req.input.author.name,
+              organizationId: req.input.organizationId,
+              metaId: req.input.author.id,
+              userId: null,
+            });
+          }
+        } else {
+          if (!actualUserId || !actualUserName) {
+            throw new Error("MISSING_USER_ID_OR_NAME");
+          }
+
+          const existingAuthor = await trx.author
+            .first({
+              userId: actualUserId,
+              organizationId: req.input.organizationId,
+            })
+            .get();
+
+          authorId = existingAuthor?.id;
+
+          if (!authorId) {
+            authorId = ulid().toLowerCase();
+            await trx.author.insert({
+              id: authorId,
+              userId: actualUserId,
+              metaId: null,
+              name: actualUserName,
+              organizationId: req.input.organizationId,
+            });
+          }
         }
 
         await trx.message.insert({
@@ -117,9 +149,10 @@ export default publicRoute
           authorId: authorId,
           content: content,
           threadId: req.input.threadId,
-          createdAt: new Date(),
-          origin: null,
-          externalMessageId: null,
+          createdAt: req.input.createdAt ?? new Date(),
+          origin: req.input.origin ?? null,
+          externalMessageId: req.input.externalMessageId ?? null,
+          isBackfill: req.input.isBackfill ?? false,
         });
       });
 

--- a/apps/api/src/live-state/router/message.ts
+++ b/apps/api/src/live-state/router/message.ts
@@ -71,6 +71,13 @@ export default publicRoute
       });
 
       const hasIntegrationAuthor = !!req.input.author;
+      if (
+        hasIntegrationAuthor &&
+        !req.context?.internalApiKey &&
+        !req.context?.publicApiKey
+      ) {
+        throw new Error("UNAUTHORIZED");
+      }
 
       const actualUserId: string | undefined =
         req.context?.portalSession?.session.userId ??

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -70,7 +70,7 @@ const threadCreateInputSchema = z.object({
   userName: z.string().optional(),
   id: z.string().optional(),
   createdAt: z.coerce.date().optional(),
-  status: z.number().optional(),
+  status: z.number().int().min(0).max(4).optional(),
   discordChannelId: z.string().nullable().optional(),
   externalId: z.string().nullable().optional(),
   externalOrigin: z.string().nullable().optional(),
@@ -600,9 +600,9 @@ export default publicRoute
       }
 
       if (
-        req.input.recordActivity ||
-        req.input.activityMetadata ||
-        req.input.replicatedStr
+        req.input.recordActivity !== undefined ||
+        req.input.activityMetadata !== undefined ||
+        req.input.replicatedStr !== undefined
       ) {
         throw new Error("UNAUTHORIZED");
       }

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -170,6 +170,21 @@ export default publicRoute
         }
       }
 
+      if (
+        !hasInternalKey &&
+        !hasPublicKey &&
+        (req.input.id !== undefined ||
+          req.input.createdAt !== undefined ||
+          req.input.status !== undefined ||
+          req.input.discordChannelId !== undefined ||
+          req.input.externalId !== undefined ||
+          req.input.externalOrigin !== undefined ||
+          req.input.externalMetadataStr !== undefined ||
+          req.input.firstMessage !== undefined)
+      ) {
+        throw new Error("UNAUTHORIZED");
+      }
+
       const content = serializeMessageContent(req.input.message);
 
       const threadId = req.input.id ?? ulid().toLowerCase();

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -43,9 +43,40 @@ import {
   upsertInlineSuggestionInputSchema,
   writeHintSlotInputSchema,
 } from "../../lib/signals/thread-procedures.js";
+import { serializeMessageContent } from "../../lib/tiptap-content";
 import { nextThreadShortId } from "../../lib/thread-short-id";
 import { publicRoute } from "../factories";
 import { schema } from "../schema";
+
+const integrationAuthorSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+const integrationFirstMessageSchema = z.object({
+  id: z.string().optional(),
+  createdAt: z.coerce.date().optional(),
+  origin: z.string().nullable().optional(),
+  externalMessageId: z.string().nullable().optional(),
+  isBackfill: z.boolean().optional(),
+});
+
+const threadCreateInputSchema = z.object({
+  organizationId: z.string().optional(),
+  title: z.string().min(3),
+  message: z.union([z.string(), z.any()]),
+  author: integrationAuthorSchema.optional(),
+  userId: z.string().optional(),
+  userName: z.string().optional(),
+  id: z.string().optional(),
+  createdAt: z.coerce.date().optional(),
+  status: z.number().optional(),
+  discordChannelId: z.string().nullable().optional(),
+  externalId: z.string().nullable().optional(),
+  externalOrigin: z.string().nullable().optional(),
+  externalMetadataStr: z.string().nullable().optional(),
+  firstMessage: integrationFirstMessageSchema.optional(),
+});
 
 const GITHUB_SERVER_URL =
   process.env.BASE_GITHUB_SERVER_URL || "http://localhost:3334";
@@ -96,21 +127,7 @@ export default publicRoute
     },
   })
   .withProcedures(({ mutation, query }) => ({
-    create: mutation(
-      z.object({
-        organizationId: z.string().optional(),
-        title: z.string().min(3),
-        message: z.union([z.string(), z.any()]), // Accept string or TipTap JSONContent
-        author: z
-          .object({
-            id: z.string(),
-            name: z.string(),
-          })
-          .optional(), // Optional - can be inferred from session
-        userId: z.string().optional(), // For portal sessions
-        userName: z.string().optional(), // For portal sessions
-      }),
-    ).handler(async ({ req, db }) => {
+    create: mutation(threadCreateInputSchema).handler(async ({ req, db }) => {
       const hasInternalKey = !!req.context?.internalApiKey;
       const hasPublicKey = !!req.context?.publicApiKey;
       const hasPortalSession = !!req.context?.portalSession?.session;
@@ -153,18 +170,10 @@ export default publicRoute
         }
       }
 
-      // Convert string message to TipTap format if needed
-      const content =
-        typeof req.input.message === "string"
-          ? JSON.stringify([
-              {
-                type: "paragraph",
-                content: [{ type: "text", text: req.input.message }],
-              },
-            ])
-          : JSON.stringify(req.input.message);
+      const content = serializeMessageContent(req.input.message);
 
-      const threadId = ulid().toLowerCase();
+      const threadId = req.input.id ?? ulid().toLowerCase();
+      const firstMessage = req.input.firstMessage;
 
       await db.transaction(async ({ trx }) => {
         let authorId: string | undefined;
@@ -235,29 +244,30 @@ export default publicRoute
           name: req.input.title,
           organizationId: organizationId,
           authorId: authorId,
-          status: 0,
+          status: req.input.status ?? 0,
           priority: 0,
           assignedUserId: null,
-          createdAt: new Date(),
+          createdAt: req.input.createdAt ?? new Date(),
           deletedAt: null,
-          discordChannelId: null,
+          discordChannelId: req.input.discordChannelId ?? null,
           externalIssueId: null,
           externalPrId: null,
-          externalId: null,
-          externalOrigin: null,
-          externalMetadataStr: null,
+          externalId: req.input.externalId ?? null,
+          externalOrigin: req.input.externalOrigin ?? null,
+          externalMetadataStr: req.input.externalMetadataStr ?? null,
           shortId,
         });
 
         // Create first message
         await trx.insert(schema.message, {
-          id: ulid().toLowerCase(),
+          id: firstMessage?.id ?? ulid().toLowerCase(),
           authorId: authorId,
           content: content,
           threadId: threadId,
-          createdAt: new Date(),
-          origin: null,
-          externalMessageId: null,
+          createdAt: firstMessage?.createdAt ?? new Date(),
+          origin: firstMessage?.origin ?? null,
+          externalMessageId: firstMessage?.externalMessageId ?? null,
+          isBackfill: firstMessage?.isBackfill ?? false,
         });
       });
 
@@ -575,6 +585,28 @@ export default publicRoute
       },
     ),
     setStatus: mutation(setStatusInputSchema).handler(async ({ req, db }) => {
+      const hasInternalKey = !!req.context?.internalApiKey;
+
+      if (hasInternalKey) {
+        return runSetThreadStatus(
+          db,
+          req.input,
+          {
+            userId: null,
+            userName: req.input.userName ?? null,
+          },
+          { recordActivity: req.input.recordActivity ?? false },
+        );
+      }
+
+      if (
+        req.input.recordActivity ||
+        req.input.activityMetadata ||
+        req.input.replicatedStr
+      ) {
+        throw new Error("UNAUTHORIZED");
+      }
+
       authorize(req, { organizationId: req.input.organizationId });
 
       const actorUserId = req.context?.session?.userId ?? null;

--- a/apps/discord/src/index.ts
+++ b/apps/discord/src/index.ts
@@ -35,6 +35,9 @@ import { getOrCreateWebhook } from "./utils";
 
 const THREAD_CREATION_THRESHOLD_MS = 1000;
 
+const ensureThreadTitle = (title: string) =>
+  title.length >= 3 ? title : title.padEnd(3, ".");
+
 const token = process.env.DISCORD_TOKEN;
 
 type RelatedThreadLink = {
@@ -111,31 +114,13 @@ const client = new Client({
   ],
 });
 
-/**
- * Helper to get or create an author record for a Discord user
- */
-const getOrCreateAuthor = async (
+const resolveDiscordAuthor = (
   discordUserId: string,
   displayName: string,
-  organizationId: string,
-): Promise<string> => {
-  let authorId = store.query.author
-    .first({ metaId: `discord:${discordUserId}` })
-    .get()?.id;
-
-  if (!authorId) {
-    authorId = ulid().toLowerCase();
-    await fetchClient.mutate.author.insert({
-      id: authorId,
-      name: displayName,
-      userId: null,
-      metaId: `discord:${discordUserId}`,
-      organizationId,
-    });
-  }
-
-  return authorId;
-};
+): { id: string; name: string } => ({
+  id: `discord:${discordUserId}`,
+  name: displayName,
+});
 
 /**
  * Backfill threads from a specific Discord channel (page-based)
@@ -511,40 +496,35 @@ const backfillThread = async (
   // Get the first non-bot message author as the thread author
   const firstMessage =
     sortedMessages.find((m) => !m.author.bot) ?? sortedMessages[0];
-  const authorId = await getOrCreateAuthor(
+  const author = resolveDiscordAuthor(
     firstMessage.author.id,
     firstMessage.author.displayName,
-    organizationId,
   );
 
-  // Create the thread
-  // Status: 0 = Open, 3 = Closed (for archived Discord threads)
   const threadId = ulid().toLowerCase();
-  store.mutate.thread.insert({
+  const firstContent = parseContentAsMarkdown(firstMessage);
+
+  await fetchClient.mutate.thread.create({
     id: threadId,
     organizationId,
-    name: thread.name,
+    title: ensureThreadTitle(thread.name),
+    message: parse(firstContent),
+    author,
     createdAt: thread.createdAt ?? new Date(),
-    deletedAt: null,
-    discordChannelId: thread.id,
-    authorId,
-    assignedUserId: null,
     status: thread.archived ? 3 : 0,
-    externalIssueId: null,
-    externalPrId: null,
+    discordChannelId: thread.id,
     externalId: thread.id,
     externalOrigin: "discord",
     externalMetadataStr: JSON.stringify({ channelId: thread.id }),
+    firstMessage: {
+      createdAt: firstMessage.createdAt,
+      origin: "discord",
+      isBackfill: true,
+      externalMessageId: firstMessage.id,
+    },
   });
 
-  // Wait for the thread to be created
-  await new Promise((resolve) => setTimeout(resolve, 150));
-
-  // Optionally send portal message for new threads
-  // (Skipped during backfill to avoid spamming old threads)
-
-  // Sync all messages
-  for (const message of sortedMessages) {
+  for (const message of sortedMessages.slice(1)) {
     if (message.author.bot) continue;
 
     await backfillMessage(message, threadId, organizationId);
@@ -577,8 +557,11 @@ const backfillMessages = async (
     console.log(
       `      Updating thread status: ${thread.name} (${currentStatus} → ${expectedStatus})`,
     );
-    await fetchClient.mutate.thread.update(existingThread.id, {
+    await fetchClient.mutate.thread.setStatus({
+      threadId: existingThread.id,
+      organizationId,
       status: expectedStatus,
+      source: "discord",
     });
   }
 
@@ -632,19 +615,18 @@ const backfillMessage = async (
   threadId: string,
   organizationId: string,
 ) => {
-  const authorId = await getOrCreateAuthor(
+  const author = resolveDiscordAuthor(
     message.author.id,
     message.author.displayName,
-    organizationId,
   );
-
   const contentWithMentions = parseContentAsMarkdown(message);
 
-  store.mutate.message.insert({
+  await fetchClient.mutate.message.create({
     id: ulid().toLowerCase(),
     threadId,
-    authorId,
-    content: JSON.stringify(parse(contentWithMentions)),
+    organizationId,
+    author,
+    content: parse(contentWithMentions),
     createdAt: message.createdAt,
     origin: "discord",
     isBackfill: true,
@@ -686,30 +668,32 @@ client.on("messageCreate", async (message) => {
 
   // TODO do this in a transaction
 
-  const authorId = await getOrCreateAuthor(
+  const author = resolveDiscordAuthor(
     message.author.id,
     message.author.displayName,
-    integration.organizationId,
   );
 
   if (isFirstMessage) {
     threadId = ulid().toLowerCase();
-    store.mutate.thread.insert({
+    const contentWithMentions = parseContentAsMarkdown(message);
+
+    await fetchClient.mutate.thread.create({
       id: threadId,
       organizationId: integration.organizationId,
-      name: message.channel.name,
+      title: ensureThreadTitle(message.channel.name),
+      message: parse(contentWithMentions),
+      author,
       createdAt: new Date(),
-      deletedAt: null,
       discordChannelId: message.channel.id,
-      authorId: authorId,
-      assignedUserId: null,
-      externalIssueId: null,
-      externalPrId: null,
       externalId: message.channel.id,
       externalOrigin: "discord",
       externalMetadataStr: JSON.stringify({ channelId: message.channel.id }),
+      firstMessage: {
+        createdAt: message.createdAt,
+        origin: "discord",
+        externalMessageId: message.id,
+      },
     });
-    await new Promise((resolve) => setTimeout(resolve, 150)); // TODO remove this once we have a proper transaction
 
     try {
       const organization = await fetchClient.query.organization
@@ -743,17 +727,19 @@ client.on("messageCreate", async (message) => {
 
   if (!threadId) return;
 
-  const contentWithMentions = parseContentAsMarkdown(message);
+  if (!isFirstMessage) {
+    const contentWithMentions = parseContentAsMarkdown(message);
 
-  store.mutate.message.insert({
-    id: ulid().toLowerCase(),
-    threadId,
-    authorId: authorId,
-    content: JSON.stringify(parse(contentWithMentions)),
-    createdAt: message.createdAt,
-    origin: "discord",
-    externalMessageId: message.id,
-  });
+    store.mutate.message.create({
+      threadId,
+      organizationId: integration.organizationId,
+      author,
+      content: parse(contentWithMentions),
+      createdAt: message.createdAt,
+      origin: "discord",
+      externalMessageId: message.id,
+    });
+  }
 
   if (isFirstMessage && portalMessageOrgSlug) {
     const baseUrl = process.env.BASE_URL ?? "https://tryfrontdesk.app";

--- a/apps/discord/src/index.ts
+++ b/apps/discord/src/index.ts
@@ -524,7 +524,8 @@ const backfillThread = async (
     },
   });
 
-  for (const message of sortedMessages.slice(1)) {
+  for (const message of sortedMessages) {
+    if (message.id === firstMessage.id) continue;
     if (message.author.bot) continue;
 
     await backfillMessage(message, threadId, organizationId);

--- a/apps/github/src/webhooks/index.ts
+++ b/apps/github/src/webhooks/index.ts
@@ -1,5 +1,4 @@
 import { statusValues } from "@workspace/ui/components/indicator";
-import { ulid } from "ulid";
 import {
   buildIssueFields,
   buildPullRequestFields,
@@ -85,27 +84,19 @@ const resolveLinkedThreads = (
       `[GitHub] Updating thread ${thread.id} status from ${statusValues[oldStatus]?.label} to ${statusValues[newStatus]?.label}`
     );
 
-    store.mutate.thread.update(thread.id, { status: newStatus });
-
-    store.mutate.update.insert({
-      id: ulid().toLowerCase(),
+    store.mutate.thread.setStatus({
       threadId: thread.id,
-      type: "status_changed",
-      createdAt: new Date(),
-      userId: null,
-      metadataStr: JSON.stringify({
-        oldStatus,
-        newStatus,
-        oldStatusLabel: statusValues[oldStatus]?.label,
-        newStatusLabel: statusValues[newStatus]?.label,
-        source: "github",
+      organizationId: thread.organizationId,
+      status: newStatus,
+      source: "github",
+      userName: "GitHub Integration",
+      recordActivity: true,
+      activityMetadata: {
         repoFullName: fields.repoFullName,
         ...(fields.type === "issue"
           ? { issueNumber: fields.number }
           : { prNumber: fields.number, merged: meta.merged }),
-        userName: "GitHub Integration",
-      }),
-      // Mark as replicated from GitHub so it doesn't sync back
+      },
       replicatedStr: JSON.stringify({ github: true }),
     });
   }

--- a/apps/slack/src/index.ts
+++ b/apps/slack/src/index.ts
@@ -284,44 +284,30 @@ const getClientForTeam = async (teamId: string): Promise<WebClient | null> => {
 };
 
 /**
- * Get or create an author record for a Slack user
+ * Resolve Slack user info for integration author metaId
  */
-const getOrCreateAuthor = async (
+const resolveSlackAuthor = async (
   client: WebClient,
   slackUserId: string,
-  organizationId: string,
-): Promise<string> => {
-  let authorId = store.query.author
-    .first({ metaId: `slack:${slackUserId}`, organizationId })
-    .get()?.id;
-
-  if (!authorId) {
-    // Fetch user info from Slack
-    let userName = "Unknown";
-    try {
-      const userInfo = await client.users.info({ user: slackUserId });
-      if (userInfo.ok && userInfo.user) {
-        userName = userInfo.user.real_name || userInfo.user.name || "Unknown";
-      }
-    } catch (error) {
-      console.error(
-        `[Slack] Error fetching user info for ${slackUserId}:`,
-        error,
-      );
+): Promise<{ id: string; name: string }> => {
+  let userName = "Unknown";
+  try {
+    const userInfo = await client.users.info({ user: slackUserId });
+    if (userInfo.ok && userInfo.user) {
+      userName = userInfo.user.real_name || userInfo.user.name || "Unknown";
     }
-
-    authorId = ulid().toLowerCase();
-    await fetchClient.mutate.author.insert({
-      id: authorId,
-      name: userName,
-      userId: null,
-      metaId: `slack:${slackUserId}`,
-      organizationId,
-    });
+  } catch (error) {
+    console.error(
+      `[Slack] Error fetching user info for ${slackUserId}:`,
+      error,
+    );
   }
 
-  return authorId;
+  return { id: `slack:${slackUserId}`, name: userName };
 };
+
+const ensureThreadTitle = (title: string) =>
+  title.length >= 3 ? title : title.padEnd(3, ".");
 
 /**
  * Backfill a single message into the database
@@ -335,14 +321,15 @@ const backfillMessage = async (
   // Skip bot messages
   if (msg.bot_id || !msg.user || !msg.ts) return;
 
-  const authorId = await getOrCreateAuthor(client, msg.user, organizationId);
+  const author = await resolveSlackAuthor(client, msg.user);
   const messageContent = msg.text || "";
 
-  await store.mutate.message.insert({
+  await fetchClient.mutate.message.create({
     id: ulid().toLowerCase(),
     threadId,
-    authorId,
-    content: JSON.stringify(parse(messageContent)),
+    organizationId,
+    author,
+    content: parse(messageContent),
     createdAt: new Date(Number.parseFloat(msg.ts) * 1000),
     origin: "slack",
     isBackfill: true,
@@ -397,44 +384,42 @@ const createThreadWithMessages = async (
     return;
   }
 
-  // Get or create author for the thread creator
-  const authorId = await getOrCreateAuthor(
+  const author = await resolveSlackAuthor(
     client,
     parentMessage.user,
-    organizationId,
   );
 
-  // Generate thread name from first message
-  const threadName =
+  const threadName = ensureThreadTitle(
     parentMessage.text && parentMessage.text.length > 0
       ? parentMessage.text.substring(0, 100)
-      : "Slack Thread";
+      : "Slack Thread",
+  );
 
-  // Create the thread
   const threadId = ulid().toLowerCase();
-  await store.mutate.thread.insert({
+  const parentTs = parentMessage.ts ?? threadTs;
+  const parentContent = parentMessage.text || "";
+
+  await fetchClient.mutate.thread.create({
     id: threadId,
     organizationId,
-    name: threadName,
+    title: threadName,
+    message: parse(parentContent),
+    author,
     createdAt: new Date(Number.parseFloat(threadTs) * 1000),
-    deletedAt: null,
-    discordChannelId: null,
-    authorId,
-    assignedUserId: null,
     externalId: threadTs,
     externalOrigin: "slack",
     externalMetadataStr: JSON.stringify({ channelId }),
-    externalIssueId: null,
-    externalPrId: null,
+    firstMessage: {
+      createdAt: new Date(Number.parseFloat(parentTs) * 1000),
+      origin: "slack",
+      isBackfill: true,
+      externalMessageId: parentTs,
+    },
   });
-
-  // Wait for the thread to be created
-  await new Promise((resolve) => setTimeout(resolve, 150));
 
   console.log(`    [Slack] Created thread: ${threadName.substring(0, 50)}...`);
 
-  // Insert all messages (including the parent)
-  for (const msg of messages) {
+  for (const msg of messages.slice(1)) {
     await backfillMessage(client, msg, threadId, organizationId);
   }
 
@@ -873,49 +858,36 @@ app.message(
 
     const userName = userInfo.user.real_name || userInfo.user.name || "Unknown";
 
-    let authorId = store.query.author
-      .first({
-        metaId: `slack:${message.user}`,
-        organizationId: integration.organizationId,
-      })
-      .get()?.id;
-
-    if (!authorId) {
-      authorId = ulid().toLowerCase();
-      await fetchClient.mutate.author.insert({
-        id: authorId,
-        name: userName,
-        userId: null,
-        metaId: `slack:${message.user}`,
-        organizationId: integration.organizationId,
-      });
-    }
+    const author = {
+      id: `slack:${message.user}`,
+      name: userName,
+    };
 
     if (isFirstMessage) {
       threadId = ulid().toLowerCase();
       const messageText = "text" in message ? message.text : undefined;
-      const threadName =
+      const threadName = ensureThreadTitle(
         (messageText && messageText.length > 0
           ? messageText.substring(0, 100)
-          : channelName) || channelName;
+          : channelName) || channelName,
+      );
 
-      store.mutate.thread.insert({
+      await fetchClient.mutate.thread.create({
         id: threadId,
         organizationId: integration.organizationId,
-        name: threadName,
+        title: threadName,
+        message: parse(messageText || ""),
+        author,
         createdAt: new Date(parseFloat(message.ts) * 1000),
-        deletedAt: null,
-        discordChannelId: null,
-        authorId: authorId,
-        assignedUserId: null,
         externalId: message.ts,
         externalOrigin: "slack",
         externalMetadataStr: JSON.stringify({ channelId: message.channel }),
-        externalIssueId: null,
-        externalPrId: null,
+        firstMessage: {
+          createdAt: new Date(parseFloat(message.ts) * 1000),
+          origin: "slack",
+          externalMessageId: message.ts,
+        },
       });
-
-      await new Promise((resolve) => setTimeout(resolve, 150)); // TODO remove this once we have a proper transaction
 
       try {
         const organization = await fetchClient.query.organization
@@ -1001,14 +973,14 @@ app.message(
       threadId = thread.id;
     }
 
-    if (!threadId) return;
+    if (!threadId || isFirstMessage) return;
+
     const messageText = "text" in message ? message.text : "";
-    const messageContent = messageText || "";
-    store.mutate.message.insert({
-      id: ulid().toLowerCase(),
+    store.mutate.message.create({
       threadId,
-      authorId: authorId,
-      content: JSON.stringify(parse(messageContent)),
+      organizationId: integration.organizationId,
+      author,
+      content: parse(messageText || ""),
       createdAt: new Date(parseFloat(message.ts) * 1000),
       origin: "slack",
       externalMessageId: message.ts,

--- a/docs/plans/custom-route-mutations.md
+++ b/docs/plans/custom-route-mutations.md
@@ -22,13 +22,13 @@ All known callers must move to the replacement procedures. When a custom procedu
 ## Current State
 
 - Status: in-progress
-- Active checkpoint: **LP-003j** (next PR slice)
+- Active checkpoint: **LP-003n-lockdown** (next PR slice)
 - Branch or PR: none
 - Last updated: 2026-06-22
 
 LP-001 inventory is complete below. API routes live in `apps/api/src/live-state/router.ts` and `apps/api/src/live-state/router/*.ts`. Several families already expose custom procedures but still use `withMutations` instead of `withProcedures`; `thread`, `message`, `label`, and `autonomousAction` already use `withProcedures`. Web writes use both `mutate.*` (synced client) and `fetchClient.mutate.*` (HTTP); optimistic handlers are centralized in `apps/web/src/lib/live-state.ts`.
 
-**LP-003 progress:** Shared thread write helpers live in `apps/api/src/lib/thread-mutations.ts`. Implemented `thread.setStatus`, `thread.setPriority`, `thread.assignUser`, `thread.linkIssue`, `thread.unlinkIssue`, `thread.linkPullRequest`, `thread.unlinkPullRequest`, `thread.markDuplicate`, `thread.archive`, `thread.restore`, `thread.setAgentRead` (API procedures + web migration + optimistic handler for archive). `set-status`, `close`, and `mark-duplicate` signal handlers delegate to shared helpers. Worker `persistAgentRead` uses `thread.setAgentRead`. Web archive/restore and duplicate accept have zero generic `thread.update` for `deletedAt` or status/activity pairs. Devtools (`create-thread-dialog.tsx`, `duplicate-thread-command.tsx`) use `thread.create` only; dead `create-thread-button.tsx` removed. Remaining LP-003 work: slack/discord `thread.create` / generic `message.insert`, and integration generic `thread.update` call sites.
+**LP-003 progress:** … Worker `persistAgentRead` uses `thread.setAgentRead`. Web archive/restore and duplicate accept have zero generic `thread.update` for `deletedAt` or status/activity pairs. Devtools use `thread.create` only. **Slack and Discord** ingest via `thread.create` / `message.create` (no generic `thread.insert` / `message.insert` / `author.insert`). **GitHub** webhooks use `thread.setStatus` for linked-thread resolution. **Discord** channel re-add backfill uses `thread.setStatus` for Open/Closed sync. Remaining LP-003 work: lockdown (`LP-003n`).
 
 ## Write inventory matrix
 
@@ -281,10 +281,10 @@ Parent checklist items (`LP-003`–`LP-009`) complete when all child slices unde
 | [x] **LP-003g** | `thread.setAgentRead` (worker) | `thread-mutations.ts`, `apps/worker/src/lib/agent-read.ts` | Worker uses `thread.setAgentRead`; no generic `thread.update` for `agentRead` |
 | [x] **LP-003h** | Web devtools → `thread.create` / `message.create` | `create-thread-dialog.tsx` (already migrated), `duplicate-thread-command.tsx`; removed dead `create-thread-button.tsx` | Devtools use procedures only |
 | [x] **LP-003i** | `thread.create` optimistic (optional) | Documented intentional omission — no fire-and-forget `mutate.thread.create` callers | Matrix updated; no handler added |
-| [ ] **LP-003j** | Slack → `thread.create` / `message.create` | `apps/slack/src/index.ts` (`store.mutate` / `fetchClient` thread/message/author inserts) | Ripgrep: no `store.mutate.thread.insert` / `message.insert` in slack |
-| [ ] **LP-003k** | Discord → `thread.create` / `message.create` | `apps/discord/src/index.ts` | Same as LP-003j for discord |
-| [ ] **LP-003l** | GitHub webhook thread status | `apps/github/src/webhooks/index.ts` → `thread.setStatus` (or internal helper) | Webhook stops `store.mutate.thread.update` + `update.insert` |
-| [ ] **LP-003m** | Slack/Discord thread field sync | Remaining `thread.update` in slack/discord (e.g. channel metadata sync) | Map each to a named procedure or document exception |
+| [x] **LP-003j** | Slack → `thread.create` / `message.create` | `apps/slack/src/index.ts` (`store.mutate` / `fetchClient` thread/message/author inserts) | Ripgrep: no `store.mutate.thread.insert` / `message.insert` in slack |
+| [x] **LP-003k** | Discord → `thread.create` / `message.create` | `apps/discord/src/index.ts` | Same as LP-003j for discord |
+| [x] **LP-003l** | GitHub webhook thread status | `apps/github/src/webhooks/index.ts` → `thread.setStatus` (or internal helper) | Webhook stops `store.mutate.thread.update` + `update.insert` |
+| [x] **LP-003m** | Slack/Discord thread field sync | Remaining `thread.update` in slack/discord (e.g. channel metadata sync) | Map each to a named procedure or document exception |
 | [ ] **LP-003n-lockdown** | Deny generic `thread` / `message` / `author` writes | `router/threads.ts`, `router/message.ts`, `router/author.ts` — `insert`/`update` → `false` | All LP-003a–m complete; typecheck + ripgrep clean |
 
 ### LP-004 — `update`, `label`, `threadLabel`
@@ -371,6 +371,9 @@ Parent checklist items (`LP-003`–`LP-009`) complete when all child slices unde
 - 2026-06-22 (LP-003g): `runSetAgentRead` + `thread.setAgentRead` procedure (internal API key only); worker `persistAgentRead` migrated; no web optimistic handler (worker-only).
 - 2026-06-22 (LP-003h): Devtools `duplicate-thread-command.tsx` migrated to `thread.create`; dead `create-thread-button.tsx` removed (`create-thread-dialog.tsx` already used procedures). Zero generic `thread`/`message`/`author` inserts in `apps/web`.
 - 2026-06-22 (LP-003i): No `thread.create` optimistic handler — all web callers (`create-thread-dialog`, portal `create-thread-dialog`, devtools duplicate) use awaited `fetchClient.mutate.thread.create`; documented intentional omission in matrix.
+- 2026-06-22 (LP-003j/k): Extended `thread.create` and `message.create` with optional integration fields (`id`, `createdAt`, `externalId`/`externalOrigin`/`externalMetadataStr`, `discordChannelId`, `status`, `firstMessage`, `author` metaId on `message.create`, `origin`/`isBackfill`/`externalMessageId`). Added `serializeMessageContent` helper. Slack/Discord backfill and realtime ingest use procedures; author rows created inside procedures (no `author.insert`). `message.update` for outbound external id sync remains generic until lockdown.
+- 2026-06-22 (LP-003l): Extended `thread.setStatus` for internal API key — optional `recordActivity`, `activityMetadata`, `replicatedStr` on input; GitHub `resolveLinkedThreads` calls `store.mutate.thread.setStatus` with `source: "github"` and `replicatedStr: { github: true }`.
+- 2026-06-22 (LP-003m): Discord `backfillMessages` archived/active sync uses `thread.setStatus` (no activity row). Slack had zero `thread.update` call sites — no code change; `update.update` replication marking deferred to LP-004b.
 
 ## PR Feedback
 
@@ -391,6 +394,10 @@ Parent checklist items (`LP-003`–`LP-009`) complete when all child slices unde
 - 2026-06-22 (LP-003g): `bun run --filter api typecheck` and `bun run --filter worker typecheck` pass. Ripgrep: `apps/worker/src` has zero `mutate.thread.update` / `thread.update` for agentRead. No runtime synthesis pipeline smoke test.
 - 2026-06-22 (LP-003h): `bun run --filter web typecheck` pass. Ripgrep: `apps/web` has zero `mutate.thread.insert` / `mutate.message.insert` / `mutate.author.insert`. No runtime devtools smoke test for create/duplicate flows.
 - 2026-06-22 (LP-003i): Verified no `mutate.thread.create` (synced) callers in `apps/web` — only `fetchClient.mutate.thread.create`. Documentation-only decision; no code change beyond matrix.
+- 2026-06-22 (LP-003j): `bun run --filter api typecheck` pass; `bunx tsc --noEmit` in `apps/slack` blocked on missing `@types/node` (pre-existing). Ripgrep: `apps/slack` has zero `mutate.thread.insert` / `mutate.message.insert` / `mutate.author.insert`. No runtime Slack ingest smoke test.
+- 2026-06-22 (LP-003k): `bun run --filter api typecheck` and `apps/discord` `bun run typecheck` pass. Ripgrep: `apps/discord` has zero generic thread/message/author inserts. `thread.update` for archived status sync remains (LP-003m). No runtime Discord ingest smoke test.
+- 2026-06-22 (LP-003l): `bun run --filter api typecheck` and `apps/github` `bun run typecheck` pass. Ripgrep: `apps/github` has zero `thread.update` / `update.insert`. No runtime GitHub issue/PR close webhook smoke test.
+- 2026-06-22 (LP-003m): `bun run --filter api typecheck` and `apps/discord` `bun run typecheck` pass. Ripgrep: `apps/discord` and `apps/slack` have zero `thread.update`. No runtime Discord channel re-add backfill smoke test.
 
 ## Session Log
 
@@ -409,7 +416,10 @@ Parent checklist items (`LP-003`–`LP-009`) complete when all child slices unde
 - 2026-06-22 (LP-003g): Added `runSetAgentRead` + `thread.setAgentRead` procedure (internal key); migrated worker `persistAgentRead` and `apply-synthesis-autonomy.ts` call sites.
 - 2026-06-22 (LP-003h): Migrated `duplicate-thread-command.tsx` to `thread.create`; deleted unused `create-thread-button.tsx` (superseded by `create-thread-dialog.tsx`).
 - 2026-06-22 (LP-003i): Assessed `thread.create` optimistic need — none; documented intentional omission in matrix.
+- 2026-06-22 (LP-003j/k): Extended `thread.create` / `message.create` for integration ingest; migrated `apps/slack/src/index.ts` and `apps/discord/src/index.ts` to procedures. Removed `getOrCreateAuthor` + `author.insert` paths; first-message realtime uses atomic `thread.create` (drops 150ms sleep).
+- 2026-06-22 (LP-003l): Extended `thread.setStatus` for internal API key + integration activity fields; migrated `apps/github/src/webhooks/index.ts` `resolveLinkedThreads` to `store.mutate.thread.setStatus`.
+- 2026-06-22 (LP-003m): Migrated Discord `backfillMessages` status sync to `fetchClient.mutate.thread.setStatus`; confirmed Slack has no `thread.update` call sites.
 
 ## Handoff
 
-Next action: Ship **LP-003j** — migrate `apps/slack/src/index.ts` from generic `store.mutate.thread.insert` / `message.insert` / `author.insert` to `thread.create` / `message.create` procedures.
+Next action: Ship **LP-003n-lockdown** — deny generic `thread` / `message` / `author` `insert`/`update` in `router/threads.ts`, `router/message.ts`, `router/author.ts` after verifying no remaining product/integration callers (ripgrep under `apps/`).


### PR DESCRIPTION
## Summary

- **LP-003j/k**: Extend `thread.create` and `message.create` with integration ingest fields; migrate Slack and Discord from generic `thread.insert` / `message.insert` / `author.insert` to named procedures. Authors are created inside procedures via `metaId`.
- **LP-003l**: Extend `thread.setStatus` for internal API key with optional `recordActivity`, `activityMetadata`, and `replicatedStr`; migrate GitHub webhook `resolveLinkedThreads` off generic `thread.update` + `update.insert`.
- **LP-003m**: Migrate Discord `backfillMessages` archived/active status sync to `thread.setStatus`; Slack had no remaining `thread.update` call sites.

## Test plan

- [x] `bun run --filter api typecheck`
- [x] `apps/discord` and `apps/github` typecheck
- [x] Ripgrep: zero `thread.insert` / `message.insert` / `author.insert` in slack/discord; zero `thread.update` / `update.insert` in github; zero `thread.update` in slack/discord
- [ ] Manual: Slack thread/message ingest (realtime + backfill)
- [ ] Manual: Discord thread/message ingest and channel re-add backfill status sync
- [ ] Manual: GitHub issue/PR close webhook resolves linked threads with timeline activity


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates Slack/Discord ingest to `thread.create`/`message.create` and routes GitHub/Discord status changes through `thread.setStatus`, with stricter auth for integration-only fields and authors. Completes LP-003j–m and prepares lockdown in LP-003n.

- **New Features**
  - `thread.create` accepts optional `id`, `createdAt`, `status` (0–4), `discordChannelId`, `externalId`, `externalOrigin`, `externalMetadataStr`, and `firstMessage` (`id`, `createdAt`, `origin`, `externalMessageId`, `isBackfill`).
  - `message.create` accepts optional `id`, `createdAt`, `origin`, `externalMessageId`, `isBackfill`, and `author` (`id` metaId + `name`).
  - Added `serializeMessageContent` for plain text or TipTap JSON (string/object), with paragraph wrapping for non-object primitives.
  - Internal key only: `thread.setStatus` supports `recordActivity`, `activityMetadata`, and `replicatedStr`.

- **Bug Fixes**
  - Guarded `thread.create` integration fields behind API/public API keys; user sessions can set only title/message.
  - Restricted integration author usage in `message.create` to API/public key contexts.
  - Discord backfill deduplicates by message ID to avoid duplicate inserts.

<sup>Written for commit 9816bfd8536a2fc6cc72f0f11455e91e8b12d770. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #296
2. #297
3. **#298** 👈 current
<!-- stack:links:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for integration-based message authors, richer message/thread metadata (including backfill fields), and normalized TipTap content serialization.
  * Expanded thread status/activity tracking to accept optional activity metadata and replication info.
* **Improvements**
  * Refactored message and thread sync/backfill flows for Discord and Slack to use consistent create APIs and resolved author objects.
  * Streamlined GitHub webhook thread status updates with combined activity recording.
* **Security**
  * Tightened authorization rules for setting thread/message identity and activity fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->