### PR TITLE
feat(api): update.recordActivity procedure (LP-004a)

### DIFF
--- a/apps/api/src/lib/signals/activity.ts
+++ b/apps/api/src/lib/signals/activity.ts
@@ -1,6 +1,5 @@
 import { STATUS_LABELS } from "@workspace/schemas/signals";
-import { ulid } from "ulid";
-import { schema } from "../../live-state/schema";
+import { runRecordActivity } from "../update-mutations";
 import type { ExecutionContext } from "./types";
 
 type ActivitySource = "agent_read" | "inline_suggestion" | "autonomous";
@@ -15,20 +14,16 @@ export const insertThreadActivity = async (
 ): Promise<void> => {
   if (ctx.actorUserId === null) return;
 
-  // schema collection is `update`; ServerDB also exposes deprecated `db.update()`
-  // — use db.insert(schema.update, …) so we hit the collection insert path.
-  await ctx.db.insert(schema.update, {
-    id: ulid().toLowerCase(),
+  await runRecordActivity(ctx.db, {
     threadId: ctx.threadId,
+    organizationId: ctx.organizationId,
     userId: ctx.actorUserId,
+    userName: ctx.actorUserName,
     type: args.type,
-    createdAt: new Date(),
-    metadataStr: JSON.stringify({
+    metadata: {
       ...args.metadata,
       source: args.source,
-      userName: ctx.actorUserName,
-    }),
-    replicatedStr: JSON.stringify({}),
+    },
   });
 };
 

--- a/apps/api/src/lib/signals/activity.ts
+++ b/apps/api/src/lib/signals/activity.ts
@@ -23,6 +23,7 @@ export const insertThreadActivity = async (
     metadata: {
       ...args.metadata,
       source: args.source,
+      userName: ctx.actorUserName,
     },
   });
 };

--- a/apps/api/src/lib/thread-mutations.ts
+++ b/apps/api/src/lib/thread-mutations.ts
@@ -2,10 +2,10 @@ import type { InferLiveObject } from "@live-state/sync";
 import type { ServerDB } from "@live-state/sync/server";
 import { PRIORITY_LABELS, threadReadSchema } from "@workspace/schemas/signals";
 import { addDays } from "date-fns";
-import { ulid } from "ulid";
 import { z } from "zod";
 import { schema } from "../live-state/schema";
 import { statusActivityMetadata } from "./signals/activity";
+import { runRecordActivity } from "./update-mutations";
 
 export const setStatusInputSchema = z.object({
   threadId: z.string(),
@@ -198,18 +198,17 @@ export const runSetThreadStatus = async (
     actor.userId !== null || options?.recordActivity === true;
 
   if (shouldRecordActivity) {
-    await db.insert(schema.update, {
-      id: ulid().toLowerCase(),
+    await runRecordActivity(db, {
       threadId: input.threadId,
+      organizationId: input.organizationId,
       userId: actor.userId,
+      userName: actor.userName,
       type: "status_changed",
-      createdAt: new Date(),
-      metadataStr: JSON.stringify({
+      metadata: {
         ...statusActivityMetadata(oldStatus, input.status),
-        ...(actor.userName ? { userName: actor.userName } : {}),
         ...(input.source ? { source: input.source } : {}),
         ...(input.activityMetadata ?? {}),
-      }),
+      },
       replicatedStr: input.replicatedStr ?? JSON.stringify({}),
     });
   }
@@ -242,17 +241,13 @@ export const runSetThreadPriority = async (
   await db.thread.update(input.threadId, { priority: input.priority });
 
   if (actor.userId !== null) {
-    await db.insert(schema.update, {
-      id: ulid().toLowerCase(),
+    await runRecordActivity(db, {
       threadId: input.threadId,
+      organizationId: input.organizationId,
       userId: actor.userId,
+      userName: actor.userName,
       type: "priority_changed",
-      createdAt: new Date(),
-      metadataStr: JSON.stringify({
-        ...priorityActivityMetadata(oldPriority, input.priority),
-        ...(actor.userName ? { userName: actor.userName } : {}),
-      }),
-      replicatedStr: JSON.stringify({}),
+      metadata: priorityActivityMetadata(oldPriority, input.priority),
     });
   }
 
@@ -302,20 +297,18 @@ export const runAssignThreadUser = async (
   });
 
   if (actor.userId !== null) {
-    await db.insert(schema.update, {
-      id: ulid().toLowerCase(),
+    await runRecordActivity(db, {
       threadId: input.threadId,
+      organizationId: input.organizationId,
       userId: actor.userId,
+      userName: actor.userName,
       type: "assigned_changed",
-      createdAt: new Date(),
-      metadataStr: JSON.stringify({
+      metadata: {
         oldAssignedUserId,
         newAssignedUserId,
         oldAssignedUserName,
         newAssignedUserName,
-        ...(actor.userName ? { userName: actor.userName } : {}),
-      }),
-      replicatedStr: JSON.stringify({}),
+      },
     });
   }
 
@@ -392,20 +385,18 @@ const runLinkExternalEntity = async (
   });
 
   if (actor.userId !== null) {
-    await db.insert(schema.update, {
-      id: ulid().toLowerCase(),
+    await runRecordActivity(db, {
       threadId: input.threadId,
+      organizationId: input.organizationId,
       userId: actor.userId,
+      userName: actor.userName,
       type: config.updateType,
-      createdAt: new Date(),
-      metadataStr: JSON.stringify({
+      metadata: {
         [config.metadataKeys.oldId]: oldId,
         [config.metadataKeys.newId]: input.externalId,
         [config.metadataKeys.oldLabel]: oldLabel,
         [config.metadataKeys.newLabel]: newLabel,
-        ...(actor.userName ? { userName: actor.userName } : {}),
-      }),
-      replicatedStr: JSON.stringify({}),
+      },
     });
   }
 
@@ -450,20 +441,18 @@ const runUnlinkExternalEntity = async (
   await db.thread.update(input.threadId, { [config.threadField]: null });
 
   if (actor.userId !== null) {
-    await db.insert(schema.update, {
-      id: ulid().toLowerCase(),
+    await runRecordActivity(db, {
       threadId: input.threadId,
+      organizationId: input.organizationId,
       userId: actor.userId,
+      userName: actor.userName,
       type: config.updateType,
-      createdAt: new Date(),
-      metadataStr: JSON.stringify({
+      metadata: {
         [config.metadataKeys.oldId]: oldId,
         [config.metadataKeys.newId]: null,
         [config.metadataKeys.oldLabel]: oldLabel,
         [config.metadataKeys.newLabel]: null,
-        ...(actor.userName ? { userName: actor.userName } : {}),
-      }),
-      replicatedStr: JSON.stringify({}),
+      },
     });
   }
 
@@ -572,19 +561,17 @@ export const runMarkDuplicate = async (
 
   const duplicateOfThreadName = input.duplicateOfThreadName ?? target.name;
 
-  await db.insert(schema.update, {
-    id: ulid().toLowerCase(),
+  await runRecordActivity(db, {
     threadId: input.threadId,
+    organizationId: input.organizationId,
     userId: actor.userId,
+    userName: actor.userName,
     type: "marked_duplicate",
-    createdAt: new Date(),
-    metadataStr: JSON.stringify({
+    metadata: {
       duplicateOfThreadId: input.duplicateOfThreadId,
       duplicateOfThreadName,
-      ...(actor.userName ? { userName: actor.userName } : {}),
       ...(input.source ? { source: input.source } : {}),
-    }),
-    replicatedStr: JSON.stringify({}),
+    },
   });
 
   return {

--- a/apps/api/src/lib/update-mutations.ts
+++ b/apps/api/src/lib/update-mutations.ts
@@ -1,0 +1,46 @@
+import type { ServerDB } from "@live-state/sync/server";
+import { ulid } from "ulid";
+import { z } from "zod";
+import { schema } from "../live-state/schema";
+
+export const recordActivityInputSchema = z.object({
+  threadId: z.string(),
+  organizationId: z.string(),
+  type: z.string().min(1),
+  userId: z.string().nullable().optional(),
+  userName: z.string().nullable().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  replicatedStr: z.string().nullable().optional(),
+  id: z.string().optional(),
+  createdAt: z.coerce.date().optional(),
+});
+
+type RecordActivityDb = Pick<ServerDB<typeof schema>, "thread" | "insert">;
+
+export const runRecordActivity = async (
+  db: RecordActivityDb,
+  input: z.infer<typeof recordActivityInputSchema>,
+) => {
+  const thread = await db.thread.one(input.threadId).get();
+  if (!thread || thread.organizationId !== input.organizationId) {
+    throw new Error("THREAD_NOT_FOUND");
+  }
+
+  const metadata: Record<string, unknown> = { ...(input.metadata ?? {}) };
+  if (input.userName) {
+    metadata.userName = input.userName;
+  }
+
+  return db.insert(schema.update, {
+    id: input.id ?? ulid().toLowerCase(),
+    threadId: input.threadId,
+    userId: input.userId ?? null,
+    type: input.type,
+    createdAt: input.createdAt ?? new Date(),
+    metadataStr: JSON.stringify(metadata),
+    replicatedStr:
+      input.replicatedStr === undefined
+        ? JSON.stringify({})
+        : input.replicatedStr,
+  });
+};

--- a/apps/api/src/lib/update-mutations.ts
+++ b/apps/api/src/lib/update-mutations.ts
@@ -10,7 +10,22 @@ export const recordActivityInputSchema = z.object({
   userId: z.string().nullable().optional(),
   userName: z.string().nullable().optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
-  replicatedStr: z.string().nullable().optional(),
+  replicatedStr: z
+    .string()
+    .nullable()
+    .optional()
+    .refine(
+      (value) => {
+        if (value === undefined || value === null) return true;
+        try {
+          JSON.parse(value);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { message: "INVALID_REPLICATED_STR" },
+    ),
   id: z.string().optional(),
   createdAt: z.coerce.date().optional(),
 });
@@ -26,10 +41,15 @@ export const runRecordActivity = async (
     throw new Error("THREAD_NOT_FOUND");
   }
 
-  const metadata: Record<string, unknown> = { ...(input.metadata ?? {}) };
-  if (input.userName) {
-    metadata.userName = input.userName;
-  }
+  const metadata: Record<string, unknown> = {
+    ...(input.metadata ?? {}),
+    userName: input.userName ?? null,
+  };
+
+  const replicatedStr =
+    input.replicatedStr === undefined
+      ? JSON.stringify({})
+      : input.replicatedStr;
 
   return db.insert(schema.update, {
     id: input.id ?? ulid().toLowerCase(),
@@ -38,9 +58,6 @@ export const runRecordActivity = async (
     type: input.type,
     createdAt: input.createdAt ?? new Date(),
     metadataStr: JSON.stringify(metadata),
-    replicatedStr:
-      input.replicatedStr === undefined
-        ? JSON.stringify({})
-        : input.replicatedStr,
+    replicatedStr,
   });
 };

--- a/apps/api/src/live-state/router/autonomous-action.ts
+++ b/apps/api/src/live-state/router/autonomous-action.ts
@@ -9,6 +9,7 @@ import {
 import { ulid } from "ulid";
 import z from "zod";
 import { authorize } from "../../lib/authorize";
+import { runRecordActivity } from "../../lib/update-mutations";
 import { privateRoute } from "../factories";
 import { schema } from "../schema";
 
@@ -146,14 +147,13 @@ export default privateRoute
       }
 
       if (activityType) {
-        await db.insert(schema.update, {
-          id: ulid().toLowerCase(),
+        await runRecordActivity(db, {
           threadId,
+          organizationId: req.input.organizationId,
           userId: req.context?.session?.userId ?? null,
           type: activityType,
+          metadata: activityMetadata,
           createdAt: now,
-          metadataStr: JSON.stringify(activityMetadata),
-          replicatedStr: JSON.stringify({}),
         });
       }
 

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -27,6 +27,7 @@ import {
   unlinkIssueInputSchema,
   unlinkPullRequestInputSchema,
 } from "../../lib/thread-mutations";
+import { runRecordActivity } from "../../lib/update-mutations";
 import {
   acceptInlineSuggestionInputSchema,
   acceptReadInputSchema,
@@ -487,17 +488,16 @@ export default publicRoute
         };
       };
 
-      await db.insert(schema.update, {
-        id: ulid().toLowerCase(),
+      await runRecordActivity(db, {
         threadId: req.input.threadId,
+        organizationId,
         userId: req.context?.session?.userId ?? null,
         type: "github_issue_created",
-        createdAt: new Date(),
-        metadataStr: JSON.stringify({
+        metadata: {
           issueId: data.issue.id,
           issueNumber: data.issue.number,
           issueLabel: `${req.input.owner}/${req.input.repo}#${data.issue.number}`,
-        }),
+        },
         replicatedStr: null,
       });
 

--- a/apps/api/src/live-state/router/update.ts
+++ b/apps/api/src/live-state/router/update.ts
@@ -1,54 +1,93 @@
-// TODO refactor with new live-state mental model
+import { authorize } from "../../lib/authorize";
+import {
+  recordActivityInputSchema,
+  runRecordActivity,
+} from "../../lib/update-mutations";
 import { publicRoute } from "../factories";
 import { schema } from "../schema";
 
-export default publicRoute.collectionRoute(schema.update, {
-  read: () => true,
-  insert: ({ ctx }) => {
-    if (ctx?.internalApiKey) return true;
-    if (!ctx?.session) return false;
+export default publicRoute
+  .collectionRoute(schema.update, {
+    read: () => true,
+    insert: ({ ctx }) => {
+      if (ctx?.internalApiKey) return true;
+      if (!ctx?.session) return false;
 
-    return {
-      thread: {
-        organization: {
-          organizationUsers: {
-            userId: ctx.session.userId,
-            enabled: true,
+      return {
+        thread: {
+          organization: {
+            organizationUsers: {
+              userId: ctx.session.userId,
+              enabled: true,
+            },
           },
         },
+      };
+    },
+    update: {
+      preMutation: ({ ctx }) => {
+        if (ctx?.internalApiKey) return true;
+        if (!ctx?.session) return false;
+
+        return {
+          thread: {
+            organization: {
+              organizationUsers: {
+                userId: ctx.session.userId,
+                enabled: true,
+              },
+            },
+          },
+        };
       },
-    };
-  },
-  update: {
-    preMutation: ({ ctx }) => {
-      if (ctx?.internalApiKey) return true;
-      if (!ctx?.session) return false;
+      postMutation: ({ ctx }) => {
+        if (ctx?.internalApiKey) return true;
+        if (!ctx?.session) return false;
 
-      return {
-        thread: {
-          organization: {
-            organizationUsers: {
-              userId: ctx.session.userId,
-              enabled: true,
+        return {
+          thread: {
+            organization: {
+              organizationUsers: {
+                userId: ctx.session.userId,
+                enabled: true,
+              },
             },
           },
-        },
-      };
+        };
+      },
     },
-    postMutation: ({ ctx }) => {
-      if (ctx?.internalApiKey) return true;
-      if (!ctx?.session) return false;
+  })
+  .withProcedures(({ mutation }) => ({
+    recordActivity: mutation(recordActivityInputSchema).handler(
+      async ({ req, db }) => {
+        authorize(req, { organizationId: req.input.organizationId });
 
-      return {
-        thread: {
-          organization: {
-            organizationUsers: {
-              userId: ctx.session.userId,
-              enabled: true,
-            },
-          },
-        },
-      };
-    },
-  },
-});
+        const isInternal = !!req.context?.internalApiKey;
+        const sessionUserId = req.context?.session?.userId ?? null;
+
+        if (!isInternal && !sessionUserId) {
+          throw new Error("UNAUTHORIZED");
+        }
+
+        const userId = isInternal
+          ? (req.input.userId ?? null)
+          : sessionUserId;
+
+        const userName = isInternal
+          ? (req.input.userName ?? null)
+          : (req.input.userName ?? req.context?.user?.name ?? null);
+
+        return runRecordActivity(db, {
+          threadId: req.input.threadId,
+          organizationId: req.input.organizationId,
+          type: req.input.type,
+          userId,
+          userName,
+          metadata: req.input.metadata,
+          replicatedStr: req.input.replicatedStr,
+          id: req.input.id,
+          createdAt: req.input.createdAt,
+        });
+      },
+    ),
+  }));

--- a/apps/api/src/live-state/router/update.ts
+++ b/apps/api/src/live-state/router/update.ts
@@ -63,26 +63,16 @@ export default publicRoute
         authorize(req, { organizationId: req.input.organizationId });
 
         const isInternal = !!req.context?.internalApiKey;
-        const sessionUserId = req.context?.session?.userId ?? null;
-
-        if (!isInternal && !sessionUserId) {
+        if (!isInternal) {
           throw new Error("UNAUTHORIZED");
         }
-
-        const userId = isInternal
-          ? (req.input.userId ?? null)
-          : sessionUserId;
-
-        const userName = isInternal
-          ? (req.input.userName ?? null)
-          : (req.input.userName ?? req.context?.user?.name ?? null);
 
         return runRecordActivity(db, {
           threadId: req.input.threadId,
           organizationId: req.input.organizationId,
           type: req.input.type,
-          userId,
-          userName,
+          userId: req.input.userId ?? null,
+          userName: req.input.userName ?? null,
           metadata: req.input.metadata,
           replicatedStr: req.input.replicatedStr,
           id: req.input.id,

--- a/docs/plans/custom-route-mutations.md
+++ b/docs/plans/custom-route-mutations.md
@@ -24,13 +24,13 @@ All known callers must move to the replacement procedures. When a custom procedu
 ## Current State
 
 - Status: in-progress
-- Active checkpoint: **LP-004a** (next PR slice)
+- Active checkpoint: **LP-004b** (next PR slice)
 - Branch or PR: none
 - Last updated: 2026-06-23
 
 LP-001 inventory is complete below. API routes live in `apps/api/src/live-state/router.ts` and `apps/api/src/live-state/router/*.ts`. Several families already expose custom procedures but still use `withMutations` instead of `withProcedures`; `thread`, `message`, `label`, and `autonomousAction` already use `withProcedures`. Web writes use both `mutate.*` (synced client) and `fetchClient.mutate.*` (HTTP); optimistic handlers are centralized in `apps/web/src/lib/live-state.ts`.
 
-**LP-003 complete** (including **LP-003o** hooks migration). Generic `thread` / `message` / `author` `insert`/`update` denied. Lifecycle hooks live in `live-state/hooks.ts` via `defineHooks` + `server({ hooks })`. Remaining LP-004 work starts with `update.recordActivity` (`LP-004a`).
+**LP-003 complete** (including **LP-003o** hooks migration). Generic `thread` / `message` / `author` `insert`/`update` denied. Lifecycle hooks live in `live-state/hooks.ts` via `defineHooks` + `server({ hooks })`. **LP-004a** shipped: `update.recordActivity` + `runRecordActivity` helper; all API-internal timeline inserts funnel through the helper.
 
 ## Write inventory matrix
 
@@ -48,7 +48,7 @@ Legend:
 | `thread` | **disabled** | **disabled** | `withProcedures`: `create`, `setStatus`✓, `setPriority`✓, `assignUser`✓, `linkIssue`✓, `unlinkIssue`✓, `linkPullRequest`✓, `unlinkPullRequest`✓, `markDuplicate`✓, `archive`✓, `restore`✓, `setAgentRead`✓, `list`†, … | none (slack/discord/github/worker migrated) | Devtools + web procedures only | **Partial** — optimistic for … `markDuplicate`, `archive`. **Intentional gap:** `create` (all callers use awaited `fetchClient`); `restore` (navigates away immediately). **Missing** for `createGithubIssue`. |
 | `message` | **disabled** | **disabled** | `withProcedures`: `create`, `markAsAnswer`, `setExternalMessageId`✓, `search`† | slack/discord outbound sync via `message.setExternalMessageId`. **API-internal** `db.message.insert`: signal handler `reply.ts`, `agent-chat` `acceptDraft`. | `reply-editor.tsx` (`create`), portal `support/$slug/threads/$id.tsx` (`create`, `markAsAnswer`), `search/index.tsx` (`search`), `thread-reply.tsx` (`markAsAnswer`). Devtools duplicate uses `thread.create` (includes first message). | **Partial** — `create`, `markAsAnswer` yes. |
 | `author` | **disabled** | **disabled** | none | Created inside `thread.create`, `message.create`, `agent-chat` `acceptDraft`, signal `reply.ts`. | none direct (devtools author rows created inside `thread.create`). | **No** (author rows optimistically created only as side effect of `message.create`). |
-| `update` | yes (org member session) | yes (org member + internal key) | none | **Generic** `insert`: `apps/github` webhooks (`store.mutate`). **Generic** `update`: `apps/slack`, `apps/discord` (`fetchClient`). **API-internal** `db.insert(schema.update)`: `threads` `createGithubIssue`, `autonomous-action` `undo`, `signals/activity.ts`, thread inline-suggestion procedures. | Paired with almost every `thread.update` in `actions/threads.ts`, `properties.tsx`, `quick-actions.tsx`, `issues.tsx`, `pull-requests.tsx`. | **No** (except side effects inside `autonomousAction.undo` optimistic). |
+| `update` | yes (org member session) | yes (org member + internal key) | `withProcedures`: `recordActivity`✓ | **Generic** `insert`: `apps/github` webhooks (`store.mutate`). **Generic** `update`: `apps/slack`, `apps/discord` (`fetchClient`). **API-internal** timeline writes use `runRecordActivity` in `update-mutations.ts` (thread procedures, signal handlers, `createGithubIssue`, `autonomousAction.undo`). | Paired with almost every `thread.update` in `actions/threads.ts`, `properties.tsx`, `quick-actions.tsx`, `issues.tsx`, `pull-requests.tsx`. | **No** (except side effects inside `autonomousAction.undo` optimistic). |
 | `label` | disabled | disabled | `withProcedures`: `create`, `update`, `createAndAttachToThread`, `attachToThread`, `detachFromThread` | **API-internal** `db.label` / `db.threadLabel`: signal handler `apply-label.ts`, `autonomous-action` `undo`. | `labels.tsx` (thread UI), `labels.tsx` (settings), `quick-actions.tsx` (`attachToThread`). | **Yes** — all five procedures. |
 | `threadLabel` | disabled | disabled | none (writes only via `label.*` procedures) | **API-internal**: `apply-label.ts`, `autonomous-action` `undo`. | none direct | n/a |
 | `organization` | disabled | owner or internal key | `withMutations`: `create`, `setActionAutonomy`, `createPublicApiKey`, `revokePublicApiKey`, `listApiKeys`† | Boot migration `002_seed_autonomy_settings.ts` (`db.organization.update`). `organization.create` also inserts `subscription` + `organizationUser` server-side. | `onboarding/connect.tsx` (`create`), settings `index.tsx` + `support-intelligence.tsx` (generic `update`, `setActionAutonomy`), `api-keys.tsx` (key procedures). | **No** |
@@ -224,7 +224,7 @@ Procedures **already implemented** are marked ✓. Others are the LP-003–LP-00
 | Procedure | Route | Replaces | Web optimistic |
 | --- | --- | --- | --- |
 | (thread procedures above own timeline inserts) | `update` | generic `update.insert` from web + github webhook | **n/a** — product callers stop inserting directly |
-| `recordActivity` | `update` | any remaining **internal** timeline writes that are not part of a thread procedure | **no** |
+| `recordActivity` ✓ | `update` | any remaining **internal** timeline writes that are not part of a thread procedure | **no** |
 | `create` / `update` / `attachToThread` / … ✓ | `label` | — | ✓ already |
 | — | `threadLabel` | direct writes | remain blocked; only via `label.*` |
 
@@ -298,7 +298,7 @@ Parent checklist items (`LP-003`–`LP-010`) complete when all child slices unde
 | Slice | PR title (suggested) | Scope | Completion |
 | --- | --- | --- | --- |
 | [x] **LP-004-labels** | *(already done)* | `label.*` procedures + web optimistic | Label family complete per matrix |
-| [ ] **LP-004a** | `update.recordActivity` (internal) | `router/update.ts` new procedure; migrate API-internal `db.insert(schema.update)` not owned by `thread.*` | Internal timeline writes use `recordActivity` or thread procedures |
+| [x] **LP-004a** | `update.recordActivity` (internal) | `router/update.ts` new procedure; migrate API-internal `db.insert(schema.update)` not owned by `thread.*` | Internal timeline writes use `recordActivity` or thread procedures |
 | [ ] **LP-004b** | Slack `update.update` | `apps/slack/src/index.ts` `fetchClient.mutate.update.update` | Slack has no generic `update.update` |
 | [ ] **LP-004c** | Discord `update.update` | `apps/discord/src/index.ts` | Discord has no generic `update.update` |
 | [ ] **LP-004d** | `apply-label` handler convergence | `apply-label.ts` → shared label attach helper | Handler reuses `label.attachToThread` logic |
@@ -395,6 +395,7 @@ Cross-cutting cleanup after procedure migration. Can bundle router-file migratio
 - 2026-06-23: **`withHooks` → `defineHooks`** — Live-State deprecates route-level `.withHooks`; hooks move to `defineHooks<typeof schema>(…)` in `live-state/hooks.ts` and `server({ hooks })` in `index.ts`. Shipped as **LP-003o**.
 - 2026-06-23 (LP-003o): Removed `thread.afterInsert` shortId hook (dead after LP-003n — `thread.create` assigns `shortId` atomically and generic `thread.insert` is denied). Kept `message.afterInsert` thread-read enqueue in `defineHooks`.
 - 2026-06-23: **Authorization** — procedures and lib code must use `authorize` / `isAuthorized` from `apps/api/src/lib/authorize.ts`; extend that module for new patterns instead of ad-hoc `req.context` checks. Tracked as **LP-010** (scan + migrate).
+- 2026-06-23 (LP-004a): Added `runRecordActivity` in `apps/api/src/lib/update-mutations.ts` and `update.recordActivity` procedure (`withProcedures`). Migrated `insertThreadActivity`, `thread-mutations` activity rows, `createGithubIssue`, and `autonomousAction.undo` to the shared helper. Single `db.insert(schema.update)` site remains in `update-mutations.ts`.
 
 ## PR Feedback
 
@@ -422,6 +423,7 @@ Cross-cutting cleanup after procedure migration. Can bundle router-file migratio
 - 2026-06-22 (LP-003m): `bun run --filter api typecheck` and `apps/discord` `bun run typecheck` pass. Ripgrep: `apps/discord` and `apps/slack` have zero `thread.update`. No runtime Discord channel re-add backfill smoke test.
 - 2026-06-23 (LP-003n): `bun run --filter api typecheck` and `apps/discord` `bun run typecheck` pass. `apps/slack` `bunx tsc --noEmit` blocked on missing `@types/node` (pre-existing). Ripgrep: zero `mutate.(thread|message|author).(insert|update)` under `apps/` (comment-only match in `threads.ts`). No runtime outbound Slack/Discord message sync smoke test.
 - 2026-06-23 (LP-003o): `bun run --filter api typecheck` pass. Ripgrep: zero `.withHooks(` under `apps/api`. No runtime message-ingest / thread-read enqueue smoke test.
+- 2026-06-23 (LP-004a): `bun run --filter api typecheck` pass. Ripgrep: single `db.insert(schema.update)` in `update-mutations.ts`; `insertThreadActivity` delegates to `runRecordActivity`. No runtime smoke test for GitHub issue creation timeline or autonomous undo activity rows.
 
 ## Session Log
 
@@ -447,7 +449,8 @@ Cross-cutting cleanup after procedure migration. Can bundle router-file migratio
 - 2026-06-23: Recorded operating instruction to migrate deprecated `withHooks` → `defineHooks` + `server({ hooks })` (documentation only; no code change this session).
 - 2026-06-23 (LP-003o): Migrated `message.afterInsert` to `live-state/hooks.ts` (`defineHooks`); wired `server({ hooks })` in `index.ts`; removed `.withHooks` from `router/message.ts` and `router/threads.ts` (dropped dead `thread.afterInsert` shortId hook). Files: `hooks.ts`, `index.ts`, `router/message.ts`, `router/threads.ts`.
 - 2026-06-23: Added **LP-010** (authorization scan + migrate) and operating instruction to centralize on `authorize.ts` (ledger only).
+- 2026-06-23 (LP-004a): Added `update.recordActivity` procedure and `runRecordActivity` helper; migrated all API-internal timeline inserts. Files: `update-mutations.ts`, `router/update.ts`, `signals/activity.ts`, `thread-mutations.ts`, `router/threads.ts`, `router/autonomous-action.ts`.
 
 ## Handoff
 
-Next action: Ship **LP-004a** — add `update.recordActivity` procedure in `router/update.ts` and migrate API-internal `db.insert(schema.update)` call sites that are not already owned by `thread.*` procedures. Start by ripgrep for `db.insert(schema.update)` and `insertThreadActivity` under `apps/api/src`.
+Next action: Ship **LP-004b** — migrate Slack `fetchClient.mutate.update.update` in `apps/slack/src/index.ts` to a named procedure (likely `update.markReplicated` or fold into an existing path). Start by reading the slack call site around line 1168 and the `replicatedStr` semantics on timeline rows.


### PR DESCRIPTION
## Summary
- Adds `update.recordActivity` Live-State procedure and shared `runRecordActivity` helper in `apps/api/src/lib/update-mutations.ts`.
- Migrates all API-internal timeline inserts (thread mutations, signal handlers, `createGithubIssue`, `autonomousAction.undo`) to the shared helper — single `db.insert(schema.update)` site remains.
- Updates the custom-route-mutations ledger to mark LP-004a complete.

## Test plan
- [x] `bun run --filter api typecheck`
- [ ] Ripgrep confirms only `update-mutations.ts` calls `db.insert(schema.update)`
- [ ] Smoke: thread status/priority/assign changes still show timeline activity
- [ ] Smoke: GitHub issue creation from thread records `github_issue_created` activity
- [ ] Smoke: autonomous action undo still inserts undo activity rows


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `update.recordActivity` and a shared `runRecordActivity` helper to centralize timeline activity writes with org checks and internal-only access. Migrates internal inserts to this path and ships LP-004a.

- **New Features**
  - Added `update.recordActivity` procedure with validated input (thread, organization, type, optional user, metadata, JSON `replicatedStr`, id, createdAt).
  - Authorization: restricted to internal API key callers; verifies the thread belongs to the org.
  - Introduced `runRecordActivity` to compose metadata (always includes `userName`), default `replicatedStr`/`id`/`createdAt`, and perform the single `db.insert(schema.update)`.

- **Refactors**
  - Replaced direct `db.insert(schema.update)` with `runRecordActivity` across thread mutations (status, priority, assign, link/unlink issue/PR, mark duplicate), `insertThreadActivity`, `createGithubIssue`, and `autonomousAction.undo`. Only raw insert remains inside the helper.
  - Updated docs: LP-004a shipped; next checkpoint is LP-004b.

<sup>Written for commit dde302548b5135de7a69bc45c85ad330cec5d9ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Standardized how thread update activities are recorded by routing all activity writes through a shared helper, improving consistency across status, priority, assignments, duplicates, and autonomous undo receipts.
  * Added a dedicated `update.recordActivity` endpoint to record activities with validated inputs and internal-only authorization.
* **Documentation**
  * Updated the Live-State migration plan to reflect the new activity recording procedure and remaining migration steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#300** 👈 current
2. #301
3. #302
<!-- stack:links:end -->