### PR TITLE
feat(api): extract runAttachLabelToThread shared helper (LP-004d)

### DIFF
--- a/apps/api/src/lib/label-mutations.ts
+++ b/apps/api/src/lib/label-mutations.ts
@@ -29,14 +29,33 @@ export const runAttachLabelToThread = async (
 ) => {
   const thread =
     options?.preloadedThread ??
-    (await db.thread.one(input.threadId).get());
-  if (!thread || thread.organizationId !== input.organizationId) {
+    (await db.thread
+      .first({
+        id: input.threadId,
+        organizationId: input.organizationId,
+      })
+      .get());
+  if (
+    !thread ||
+    thread.id !== input.threadId ||
+    thread.organizationId !== input.organizationId
+  ) {
     throw new Error("THREAD_NOT_FOUND");
   }
 
   const label =
-    options?.preloadedLabel ?? (await db.label.one(input.labelId).get());
-  if (!label || label.organizationId !== input.organizationId) {
+    options?.preloadedLabel ??
+    (await db.label
+      .first({
+        id: input.labelId,
+        organizationId: input.organizationId,
+      })
+      .get());
+  if (
+    !label ||
+    label.id !== input.labelId ||
+    label.organizationId !== input.organizationId
+  ) {
     throw new Error("LABEL_NOT_FOUND");
   }
 

--- a/apps/api/src/lib/label-mutations.ts
+++ b/apps/api/src/lib/label-mutations.ts
@@ -1,0 +1,112 @@
+import type { InferLiveObject } from "@live-state/sync";
+import type { ServerDB } from "@live-state/sync/server";
+import { ulid } from "ulid";
+import { z } from "zod";
+import { schema } from "../live-state/schema";
+
+export const attachLabelToThreadInputSchema = z.object({
+  threadId: z.string(),
+  labelId: z.string(),
+  organizationId: z.string(),
+  threadLabelId: z.string().optional(),
+});
+
+type LabelAttachDb = Pick<
+  ServerDB<typeof schema>,
+  "thread" | "label" | "threadLabel" | "transaction"
+>;
+
+type ThreadRow = InferLiveObject<typeof schema.thread>;
+type LabelRow = InferLiveObject<typeof schema.label>;
+
+export const runAttachLabelToThread = async (
+  db: LabelAttachDb,
+  input: z.infer<typeof attachLabelToThreadInputSchema>,
+  options?: {
+    preloadedThread?: ThreadRow;
+    preloadedLabel?: LabelRow;
+  },
+) => {
+  const thread =
+    options?.preloadedThread ??
+    (await db.thread.one(input.threadId).get());
+  if (!thread || thread.organizationId !== input.organizationId) {
+    throw new Error("THREAD_NOT_FOUND");
+  }
+
+  const label =
+    options?.preloadedLabel ?? (await db.label.one(input.labelId).get());
+  if (!label || label.organizationId !== input.organizationId) {
+    throw new Error("LABEL_NOT_FOUND");
+  }
+
+  if (label.organizationId !== thread.organizationId) {
+    throw new Error("LABEL_THREAD_ORGANIZATION_MISMATCH");
+  }
+
+  const threadLabelId = input.threadLabelId ?? ulid().toLowerCase();
+
+  const attachResult = await db.transaction(async ({ trx }) => {
+    const existing = await trx.threadLabel
+      .first({
+        threadId: input.threadId,
+        labelId: input.labelId,
+      })
+      .get();
+
+    if (existing?.enabled) {
+      return {
+        threadLabelId: existing.id,
+        noOp: true as const,
+      };
+    }
+
+    if (existing) {
+      await trx.threadLabel.update(existing.id, { enabled: true });
+      return {
+        threadLabelId: existing.id,
+        noOp: false as const,
+      };
+    }
+
+    try {
+      const created = await trx.threadLabel.insert({
+        id: threadLabelId,
+        threadId: input.threadId,
+        labelId: input.labelId,
+        enabled: true,
+      });
+
+      return {
+        threadLabelId: created.id,
+        noOp: false as const,
+      };
+    } catch {
+      const concurrent = await trx.threadLabel
+        .first({
+          threadId: input.threadId,
+          labelId: input.labelId,
+        })
+        .get();
+
+      if (concurrent) {
+        if (!concurrent.enabled) {
+          await trx.threadLabel.update(concurrent.id, { enabled: true });
+        }
+
+        return {
+          threadLabelId: concurrent.id,
+          noOp: concurrent.enabled,
+        };
+      }
+
+      throw new Error("THREAD_LABEL_ATTACH_FAILED");
+    }
+  });
+
+  return {
+    ...attachResult,
+    label,
+    thread,
+  };
+};

--- a/apps/api/src/lib/signals/handlers/apply-label.ts
+++ b/apps/api/src/lib/signals/handlers/apply-label.ts
@@ -1,11 +1,11 @@
 import type { ApplyLabelAction } from "@workspace/schemas/signals";
-import { ulid } from "ulid";
+import { runAttachLabelToThread } from "../../label-mutations";
+import { insertThreadActivity } from "../activity";
 import {
   clearCompensateSnapshot,
   getCompensateSnapshot,
   setCompensateSnapshot,
 } from "../compensate-snapshots";
-import { insertThreadActivity } from "../activity";
 import type { ActionHandler } from "../types";
 
 const snapshotKey = (action: ApplyLabelAction) =>
@@ -13,44 +13,19 @@ const snapshotKey = (action: ApplyLabelAction) =>
 
 export const applyLabelHandler: ActionHandler<ApplyLabelAction> = {
   async apply(action, ctx) {
-    const thread = await ctx.db.thread.one(ctx.threadId).get();
-    if (!thread || thread.organizationId !== ctx.organizationId) {
-      throw new Error("THREAD_NOT_FOUND");
-    }
+    const result = await runAttachLabelToThread(ctx.db, {
+      threadId: ctx.threadId,
+      labelId: action.labelId,
+      organizationId: ctx.organizationId,
+    });
 
-    const label = await ctx.db.label.one(action.labelId).get();
-    if (!label || label.organizationId !== ctx.organizationId) {
-      throw new Error("LABEL_NOT_FOUND");
-    }
-
-    const existing = await ctx.db.threadLabel
-      .first({
-        threadId: ctx.threadId,
-        labelId: action.labelId,
-      })
-      .get();
-
-    if (existing?.enabled) {
+    if (result.noOp) {
       return;
     }
 
-    let threadLabelId = existing?.id;
-
-    if (existing) {
-      await ctx.db.threadLabel.update(existing.id, { enabled: true });
-    } else {
-      threadLabelId = ulid().toLowerCase();
-      await ctx.db.threadLabel.insert({
-        id: threadLabelId,
-        threadId: ctx.threadId,
-        labelId: action.labelId,
-        enabled: true,
-      });
-    }
-
     setCompensateSnapshot(ctx, snapshotKey(action), {
-      threadLabelId: threadLabelId!,
-      hadEnabled: existing?.enabled ?? false,
+      threadLabelId: result.threadLabelId,
+      hadEnabled: false,
     });
 
     await insertThreadActivity(ctx, {
@@ -58,7 +33,7 @@ export const applyLabelHandler: ActionHandler<ApplyLabelAction> = {
       metadata: {
         action: "added",
         labelId: action.labelId,
-        labelName: label.name,
+        labelName: result.label.name,
       },
       source: "inline_suggestion",
     });

--- a/apps/api/src/lib/signals/types.ts
+++ b/apps/api/src/lib/signals/types.ts
@@ -11,6 +11,7 @@ export type SignalExecutionDb = Pick<
   | "label"
   | "autonomousAction"
   | "insert"
+  | "transaction"
 >;
 
 export type ExecutionContext = {

--- a/apps/api/src/live-state/router/labels.ts
+++ b/apps/api/src/live-state/router/labels.ts
@@ -3,6 +3,7 @@ import { ulid } from "ulid";
 import type { ServerDB } from "@live-state/sync/server";
 import type { AuthorizationContext } from "../../lib/authorize";
 import { authorize } from "../../lib/authorize";
+import { runAttachLabelToThread } from "../../lib/label-mutations";
 import { publicRoute } from "../factories";
 import { schema } from "../schema";
 
@@ -253,54 +254,19 @@ export default {
         organizationId: thread.organizationId,
       });
 
-      const id = req.input.id ?? ulid().toLowerCase();
-      const threadLabelId = await db.transaction(async ({ trx }) => {
-        const existing = await trx.threadLabel
-          .first({
-            threadId: req.input.threadId,
-            labelId: req.input.labelId,
-          })
-          .get();
-
-        if (existing) {
-          if (!existing.enabled) {
-            await trx.threadLabel.update(existing.id, { enabled: true });
-          }
-
-          return existing.id;
-        }
-
-        try {
-          const created = await trx.threadLabel.insert({
-            id,
-            threadId: req.input.threadId,
-            labelId: req.input.labelId,
-            enabled: true,
-          });
-
-          return created.id;
-        } catch {
-          const concurrent = await trx.threadLabel
-            .first({
-              threadId: req.input.threadId,
-              labelId: req.input.labelId,
-            })
-            .get();
-
-          if (concurrent) {
-            if (!concurrent.enabled) {
-              await trx.threadLabel.update(concurrent.id, { enabled: true });
-            }
-
-            return concurrent.id;
-          }
-
-          throw new Error("THREAD_LABEL_ATTACH_FAILED");
-        }
-      });
+      const attachResult = await runAttachLabelToThread(
+        db,
+        {
+          threadId: req.input.threadId,
+          labelId: req.input.labelId,
+          organizationId: thread.organizationId,
+          threadLabelId: req.input.id,
+        },
+        { preloadedThread: thread, preloadedLabel: label },
+      );
 
       const created = await db.threadLabel
-        .one(threadLabelId)
+        .one(attachResult.threadLabelId)
         .include({ label: true })
         .get();
 

--- a/docs/plans/custom-route-mutations.md
+++ b/docs/plans/custom-route-mutations.md
@@ -461,4 +461,4 @@ Cross-cutting cleanup after procedure migration. Can bundle router-file migratio
 
 ## Handoff
 
-Next action: Ship **LP-004e-lockdown** — deny generic `insert`/`update` on `router/update.ts` collection route (`insert`/`update` pre/post → `false` or deny-by-default). Before locking: ripgrep repo for remaining `mutate.update.insert` / `mutate.update.update` product callers (github webhook `store.mutate` timeline inserts may still need `recordActivity` or thread procedures — see matrix). Confirm slack/discord replication already on `markReplicated`; web `update.insert` pairs should already be gone via thread procedures.
+Next action: Ship **LP-004e-lockdown** — deny generic `insert`/`update` on `router/update.ts` collection route (`insert`/`update` pre/post → `false` or deny-by-default). Before locking: ripgrep repo for remaining `mutate.update.insert` / `mutate.update.update` product callers (GitHub webhook `store.mutate` timeline inserts may still need `recordActivity` or thread procedures — see matrix). Confirm slack/discord replication already on `markReplicated`; web `update.insert` pairs should already be gone via thread procedures.

--- a/docs/plans/custom-route-mutations.md
+++ b/docs/plans/custom-route-mutations.md
@@ -24,7 +24,7 @@ All known callers must move to the replacement procedures. When a custom procedu
 ## Current State
 
 - Status: in-progress
-- Active checkpoint: **LP-004d** (next PR slice)
+- Active checkpoint: **LP-004e-lockdown** (next PR slice)
 - Branch or PR: https://github.com/FrontDeskHQ/front-desk/pull/300
 - Last updated: 2026-06-23
 
@@ -302,7 +302,7 @@ Parent checklist items (`LP-003`–`LP-010`) complete when all child slices unde
 | [x] **LP-004a** | `update.recordActivity` (internal) | `router/update.ts` new procedure; migrate API-internal `db.insert(schema.update)` not owned by `thread.*` | Internal timeline writes use `recordActivity` or thread procedures |
 | [x] **LP-004b** | Slack `update.update` | `apps/slack/src/index.ts` `fetchClient.mutate.update.update` → `update.markReplicated` | Slack has no generic `update.update` |
 | [x] **LP-004c** | Discord `update.update` | `apps/discord/src/index.ts` | Discord has no generic `update.update` |
-| [ ] **LP-004d** | `apply-label` handler convergence | `apply-label.ts` → shared label attach helper | Handler reuses `label.attachToThread` logic |
+| [x] **LP-004d** | `apply-label` handler convergence | `apply-label.ts` → shared label attach helper | Handler reuses `label.attachToThread` logic |
 | [ ] **LP-004e-lockdown** | Deny generic `update` writes | `router/update.ts` | Product + integration callers migrated; github webhook timeline covered |
 
 ### LP-005 — `organization`, `organizationUser`, `user`, `invite`
@@ -428,6 +428,7 @@ Cross-cutting cleanup after procedure migration. Can bundle router-file migratio
 - 2026-06-23 (LP-004a): `bun run --filter api typecheck` pass. Ripgrep: single `db.insert(schema.update)` in `update-mutations.ts`; `insertThreadActivity` delegates to `runRecordActivity`. No runtime smoke test for GitHub issue creation timeline or autonomous undo activity rows.
 - 2026-06-23 (LP-004b): `bun run --filter api typecheck` pass. Ripgrep: `apps/slack` has zero `mutate.update.update` / `mutate.update.insert`. No runtime Slack timeline replication smoke test.
 - 2026-06-23 (LP-004c): `bun run --filter api typecheck` and `bun run --filter discord typecheck` pass. Ripgrep: `apps/discord` has zero `mutate.update.update` / `mutate.update.insert`. No runtime Discord timeline replication smoke test.
+- 2026-06-23 (LP-004d): `bun run --filter api typecheck` pass. Ripgrep: `apply-label.ts` has no `threadLabel.insert` / direct label lookup — only `runAttachLabelToThread` + compensate `threadLabel.update`. No runtime inline-suggestion label apply smoke test.
 
 ## Session Log
 
@@ -456,7 +457,8 @@ Cross-cutting cleanup after procedure migration. Can bundle router-file migratio
 - 2026-06-23 (LP-004a): Added `update.recordActivity` procedure and `runRecordActivity` helper; migrated all API-internal timeline inserts. Files: `update-mutations.ts`, `router/update.ts`, `signals/activity.ts`, `thread-mutations.ts`, `router/threads.ts`, `router/autonomous-action.ts`.
 - 2026-06-23 (LP-004b): Added `update.markReplicated` procedure; migrated Slack `handleUpdates` off generic `update.update`. Files: `update-mutations.ts`, `router/update.ts`, `apps/slack/src/index.ts`.
 - 2026-06-23 (LP-004c): Migrated Discord `handleUpdates` off generic `update.update` to `update.markReplicated`. Files: `apps/discord/src/index.ts`.
+- 2026-06-23 (LP-004d): Extracted `runAttachLabelToThread` in `label-mutations.ts`; `label.attachToThread` procedure and `apply-label` signal handler delegate to shared helper (transaction + race handling). Added `transaction` to `SignalExecutionDb`.
 
 ## Handoff
 
-Next action: Ship **LP-004d** — refactor `apps/api/src/lib/signals/handlers/apply-label.ts` to reuse the shared label attach helper (same logic as `label.attachToThread` procedure). Read `router/label.ts` and any existing label mutation helpers before editing; goal is one implementation path for attach + threadLabel rows. Ripgrep `apply-label.ts` for zero direct `db.label` / `db.threadLabel` writes that duplicate procedure logic when done.
+Next action: Ship **LP-004e-lockdown** — deny generic `insert`/`update` on `router/update.ts` collection route (`insert`/`update` pre/post → `false` or deny-by-default). Before locking: ripgrep repo for remaining `mutate.update.insert` / `mutate.update.update` product callers (github webhook `store.mutate` timeline inserts may still need `recordActivity` or thread procedures — see matrix). Confirm slack/discord replication already on `markReplicated`; web `update.insert` pairs should already be gone via thread procedures.


### PR DESCRIPTION
## Summary

- Extract `runAttachLabelToThread` into `apps/api/src/lib/label-mutations.ts` with transactional attach logic and concurrent-insert race handling.
- Refactor `label.attachToThread` and the `apply-label` signal handler to delegate to the shared helper instead of duplicating `threadLabel` writes.
- Add `transaction` to `SignalExecutionDb` so signal handlers can use the transactional path.

Part of the custom route procedures migration ([ledger](docs/plans/custom-route-mutations.md)). Stacks on #301 (`feat/lp-004b-slack-mark-replicated`).

## Test plan

- [x] `bun run --filter api typecheck`
- [ ] Smoke: accept an inline-suggestion label apply on a thread
- [ ] Smoke: attach an existing label to a thread from thread UI / quick actions


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized label-to-thread attach logic in a shared helper with transactions, org-scoped lookups, and race handling. Refactored the labels route and apply-label signal to use it, completing LP-004d and standardizing behavior across the API.

- **Refactors**
  - Added `runAttachLabelToThread` with input schema, organization-scoped thread/label queries, preloaded row ID/org validation, transactional attach, and concurrent-insert handling.
  - Updated `labels.attachToThread` and the `apply-label` handler to delegate to the helper; preserve client `threadLabelId`, pass preloaded `thread`/`label`, short-circuit on no-op, and use returned `label` for activity.
  - Extended `SignalExecutionDb` with `transaction`. Updated docs to mark LP-004d complete and advance the checkpoint to LP-004e-lockdown.

<sup>Written for commit 55765b315a4625d9b3e187fb30375a9d8f7cafb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #300
2. #301
3. **#302** 👈 current
<!-- stack:links:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Labels can now be attached to threads more reliably, with support for re-enabling an existing label link instead of creating duplicates.

* **Bug Fixes**
  * Improved consistency when applying labels so repeated or concurrent actions no longer create conflicting results.
  * Label actions now return the correct thread and label details more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->