### PR TITLE
feat(api,web): org-family custom procedures and lockdown (LP-005)

### DIFF
--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -31,6 +31,31 @@ import threadsRoute from "./router/threads";
 import updateRoute from "./router/update";
 import { schema } from "./schema";
 
+const RESERVED_ORG_SLUGS: readonly string[] = [
+  "support",
+  "help",
+  "status",
+  "api",
+  "admin",
+  "www",
+  "app",
+  "dashboard",
+  "login",
+  "signup",
+  "register",
+  "account",
+  "settings",
+  "billing",
+  "docs",
+  "documentation",
+  "blog",
+  "about",
+  "contact",
+  "privacy",
+  "terms",
+  "legal",
+];
+
 export const router = createRouter({
   schema,
   routes: {
@@ -51,34 +76,7 @@ export const router = createRouter({
               .string()
               .min(4)
               .refine(
-                (slug) => {
-                  // TODO: Unify reserved slugs list - extract to shared constant
-                  const reservedSlugs = [
-                    "support",
-                    "help",
-                    "status",
-                    "api",
-                    "admin",
-                    "www",
-                    "app",
-                    "dashboard",
-                    "login",
-                    "signup",
-                    "register",
-                    "account",
-                    "settings",
-                    "billing",
-                    "docs",
-                    "documentation",
-                    "blog",
-                    "about",
-                    "contact",
-                    "privacy",
-                    "terms",
-                    "legal",
-                  ];
-                  return !reservedSlugs.includes(slug.toLowerCase());
-                },
+                (slug) => !RESERVED_ORG_SLUGS.includes(slug.toLowerCase()),
                 {
                   message: "This slug is reserved and cannot be used",
                 },
@@ -220,33 +218,7 @@ export const router = createRouter({
                 .string()
                 .min(4)
                 .refine(
-                  (slug) => {
-                    const reservedSlugs = [
-                      "support",
-                      "help",
-                      "status",
-                      "api",
-                      "admin",
-                      "www",
-                      "app",
-                      "dashboard",
-                      "login",
-                      "signup",
-                      "register",
-                      "account",
-                      "settings",
-                      "billing",
-                      "docs",
-                      "documentation",
-                      "blog",
-                      "about",
-                      "contact",
-                      "privacy",
-                      "terms",
-                      "legal",
-                    ];
-                    return !reservedSlugs.includes(slug.toLowerCase());
-                  },
+                  (slug) => !RESERVED_ORG_SLUGS.includes(slug.toLowerCase()),
                   {
                     message: "This slug is reserved and cannot be used",
                   },
@@ -285,13 +257,28 @@ export const router = createRouter({
             settings,
           } = req.input;
 
+          const rawSettings =
+            org.settings &&
+            typeof org.settings === "object" &&
+            !Array.isArray(org.settings)
+              ? (org.settings as Record<string, unknown>)
+              : {};
+
           return db.organization.update(org.id, {
             ...(name !== undefined ? { name } : {}),
             ...(slug !== undefined ? { slug } : {}),
             ...(logoUrl !== undefined ? { logoUrl } : {}),
             ...(socials !== undefined ? { socials } : {}),
             ...(customInstructions !== undefined ? { customInstructions } : {}),
-            ...(settings !== undefined ? { settings } : {}),
+            ...(settings !== undefined
+              ? {
+                  settings: {
+                    ...rawSettings,
+                    ...settings,
+                    // biome-ignore lint/suspicious/noExplicitAny: settings JSON shape is open
+                  } as any,
+                }
+              : {}),
           });
         }),
         createPublicApiKey: mutation(

--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -1,6 +1,7 @@
 // TODO refactor with new live-state mental model
 import { router as createRouter } from "@live-state/sync/server";
 import { InviteUserEmail } from "@workspace/emails/transactional/org-invitation";
+import { organizationSettingsSchema } from "@workspace/schemas/organization";
 import {
   type ActionAutonomyMap,
   actionAutonomyMapSchema,
@@ -38,33 +39,11 @@ export const router = createRouter({
         read: () => true,
         insert: () => false,
         update: {
-          preMutation: ({ ctx }) => {
-            if (ctx?.internalApiKey) return true;
-            if (!ctx?.session) return false;
-
-            return {
-              organizationUsers: {
-                userId: ctx.session.userId,
-                role: "owner",
-                enabled: true,
-              },
-            };
-          },
-          postMutation: ({ ctx }) => {
-            if (ctx?.internalApiKey) return true;
-            if (!ctx?.session) return false;
-
-            return {
-              organizationUsers: {
-                userId: ctx.session.userId,
-                role: "owner",
-                enabled: true,
-              },
-            };
-          },
+          preMutation: () => false,
+          postMutation: () => false,
         },
       })
-      .withMutations(({ mutation }) => ({
+      .withProcedures(({ mutation }) => ({
         create: mutation(
           z.object({
             name: z.string(),
@@ -232,6 +211,89 @@ export const router = createRouter({
             } as any,
           });
         }),
+        updateSettings: mutation(
+          z
+            .object({
+              organizationId: z.string(),
+              name: z.string().optional(),
+              slug: z
+                .string()
+                .min(4)
+                .refine(
+                  (slug) => {
+                    const reservedSlugs = [
+                      "support",
+                      "help",
+                      "status",
+                      "api",
+                      "admin",
+                      "www",
+                      "app",
+                      "dashboard",
+                      "login",
+                      "signup",
+                      "register",
+                      "account",
+                      "settings",
+                      "billing",
+                      "docs",
+                      "documentation",
+                      "blog",
+                      "about",
+                      "contact",
+                      "privacy",
+                      "terms",
+                      "legal",
+                    ];
+                    return !reservedSlugs.includes(slug.toLowerCase());
+                  },
+                  {
+                    message: "This slug is reserved and cannot be used",
+                  },
+                )
+                .optional(),
+              logoUrl: z.string().nullable().optional(),
+              socials: z.string().nullable().optional(),
+              customInstructions: z.string().nullable().optional(),
+              settings: organizationSettingsSchema.optional(),
+            })
+            .refine(
+              (input) => {
+                const { organizationId: _organizationId, ...fields } = input;
+                return Object.values(fields).some(
+                  (value) => value !== undefined,
+                );
+              },
+              { message: "NO_FIELDS_TO_UPDATE" },
+            ),
+        ).handler(async ({ req, db }) => {
+          authorize(req, {
+            organizationId: req.input.organizationId,
+            role: "owner",
+          });
+
+          const org = await db.organization.one(req.input.organizationId).get();
+          if (!org) throw new Error("ORGANIZATION_NOT_FOUND");
+
+          const {
+            organizationId: _organizationId,
+            name,
+            slug,
+            logoUrl,
+            socials,
+            customInstructions,
+            settings,
+          } = req.input;
+
+          return db.organization.update(org.id, {
+            ...(name !== undefined ? { name } : {}),
+            ...(slug !== undefined ? { slug } : {}),
+            ...(logoUrl !== undefined ? { logoUrl } : {}),
+            ...(socials !== undefined ? { socials } : {}),
+            ...(customInstructions !== undefined ? { customInstructions } : {}),
+            ...(settings !== undefined ? { settings } : {}),
+          });
+        }),
         createPublicApiKey: mutation(
           z.object({
             organizationId: z.string(),
@@ -360,37 +422,11 @@ export const router = createRouter({
         read: () => true,
         insert: () => false,
         update: {
-          preMutation: ({ ctx }) => {
-            if (ctx?.internalApiKey) return true;
-            if (!ctx?.session) return false;
-
-            return {
-              organization: {
-                organizationUsers: {
-                  userId: ctx.session.userId,
-                  enabled: true,
-                  role: "owner",
-                },
-              },
-            };
-          },
-          postMutation: ({ ctx }) => {
-            if (ctx?.internalApiKey) return true;
-            if (!ctx?.session) return false;
-
-            return {
-              organization: {
-                organizationUsers: {
-                  userId: ctx.session.userId,
-                  enabled: true,
-                  role: "owner",
-                },
-              },
-            };
-          },
+          preMutation: () => false,
+          postMutation: () => false,
         },
       })
-      .withMutations(({ mutation }) => ({
+      .withProcedures(({ mutation }) => ({
         inviteUser: mutation(
           z.object({
             organizationId: z.string(),
@@ -488,29 +524,98 @@ export const router = createRouter({
             success: true,
           };
         }),
+        updateMember: mutation(
+          z
+            .object({
+              organizationUserId: z.string(),
+              role: z.enum(["owner", "user"]).optional(),
+              enabled: z.boolean().optional(),
+            })
+            .refine(
+              (input) => {
+                const { organizationUserId: _organizationUserId, ...fields } =
+                  input;
+                return Object.values(fields).some(
+                  (value) => value !== undefined,
+                );
+              },
+              { message: "NO_FIELDS_TO_UPDATE" },
+            ),
+        ).handler(async ({ req, db }) => {
+          const member = await db.organizationUser
+            .one(req.input.organizationUserId)
+            .get();
+          if (!member) throw new Error("ORGANIZATION_USER_NOT_FOUND");
+
+          authorize(req, {
+            organizationId: member.organizationId,
+            role: "owner",
+          });
+
+          if (
+            member.userId === req.context?.session?.userId &&
+            (req.input.enabled === false ||
+              (req.input.role !== undefined && req.input.role !== member.role))
+          ) {
+            throw new Error("CANNOT_UPDATE_SELF");
+          }
+
+          const { organizationUserId: _organizationUserId, role, enabled } =
+            req.input;
+
+          return db.organizationUser.update(member.id, {
+            ...(role !== undefined ? { role } : {}),
+            ...(enabled !== undefined ? { enabled } : {}),
+          });
+        }),
       })),
-    user: publicRoute.collectionRoute(schema.user, {
-      read: () => true,
-      insert: () => false,
-      update: {
-        preMutation: ({ ctx }) => {
-          if (ctx?.internalApiKey) return true;
-          if (!ctx?.session) return false;
-
-          return {
-            id: ctx.session.userId,
-          };
+    user: publicRoute
+      .collectionRoute(schema.user, {
+        read: () => true,
+        insert: () => false,
+        update: {
+          preMutation: () => false,
+          postMutation: () => false,
         },
-        postMutation: ({ ctx }) => {
-          if (ctx?.internalApiKey) return true;
-          if (!ctx?.session) return false;
+      })
+      .withProcedures(({ mutation }) => ({
+        updateProfile: mutation(
+          z
+            .object({
+              userId: z.string(),
+              name: z.string().optional(),
+              email: z.string().optional(),
+              image: z.string().nullable().optional(),
+            })
+            .refine(
+              (input) => {
+                const { userId: _userId, ...fields } = input;
+                return Object.values(fields).some(
+                  (value) => value !== undefined,
+                );
+              },
+              { message: "NO_FIELDS_TO_UPDATE" },
+            ),
+        ).handler(async ({ req, db }) => {
+          const isSelf = req.context?.session?.userId === req.input.userId;
+          const isInternal = !!req.context?.internalApiKey;
 
-          return {
-            id: ctx.session.userId,
-          };
-        },
-      },
-    }),
+          if (!isSelf && !isInternal) {
+            throw new Error("UNAUTHORIZED");
+          }
+
+          const existing = await db.user.one(req.input.userId).get();
+          if (!existing) throw new Error("USER_NOT_FOUND");
+
+          const { userId: _userId, name, email, image } = req.input;
+
+          return db.user.update(existing.id, {
+            ...(name !== undefined ? { name } : {}),
+            ...(email !== undefined ? { email } : {}),
+            ...(image !== undefined ? { image } : {}),
+          });
+        }),
+      })),
     author: publicRoute.collectionRoute(schema.author, {
       read: () => true,
       insert: () => false,
@@ -543,35 +648,11 @@ export const router = createRouter({
         },
         insert: () => false,
         update: {
-          preMutation: ({ ctx }) => {
-            if (ctx?.internalApiKey) return true;
-            if (!ctx?.session) return false;
-
-            return {
-              organization: {
-                organizationUsers: {
-                  userId: ctx.session.userId,
-                  enabled: true,
-                },
-              },
-            };
-          },
-          postMutation: ({ ctx }) => {
-            if (ctx?.internalApiKey) return true;
-            if (!ctx?.session) return false;
-
-            return {
-              organization: {
-                organizationUsers: {
-                  userId: ctx.session.userId,
-                  enabled: true,
-                },
-              },
-            };
-          },
+          preMutation: () => false,
+          postMutation: () => false,
         },
       })
-      .withMutations(({ mutation }) => ({
+      .withProcedures(({ mutation }) => ({
         accept: mutation(z.object({ id: z.string() })).handler(
           async ({ req, db }) => {
             await db.transaction(async ({ trx }) => {
@@ -633,6 +714,19 @@ export const router = createRouter({
             return {
               success: true,
             };
+          },
+        ),
+        revoke: mutation(z.object({ inviteId: z.string() })).handler(
+          async ({ req, db }) => {
+            const invite = await db.invite.one(req.input.inviteId).get();
+            if (!invite) throw new Error("INVITATION_NOT_FOUND");
+
+            authorize(req, {
+              organizationId: invite.organizationId,
+              role: "owner",
+            });
+
+            return db.invite.update(invite.id, { active: false });
           },
         ),
       })),

--- a/apps/web/src/routes/app/_workspace/settings/organization/index.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/index.tsx
@@ -249,7 +249,8 @@ function OrgProfileForm({ org, currentOrg, isUserOwner }: OrgFormProps) {
         timezone: value.orgTimezone,
       });
 
-      mutate.organization.update(currentOrg.id, {
+      mutate.organization.updateSettings({
+        organizationId: currentOrg.id,
         name: value.orgName,
         slug: value.orgSlug,
         logoUrl,
@@ -484,7 +485,8 @@ function DigestSettingsForm({ org, currentOrg, isUserOwner }: OrgFormProps) {
         },
       });
 
-      mutate.organization.update(currentOrg.id, {
+      mutate.organization.updateSettings({
+        organizationId: currentOrg.id,
         settings: nextSettings,
       });
     },

--- a/apps/web/src/routes/app/_workspace/settings/organization/support-intelligence.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/support-intelligence.tsx
@@ -77,7 +77,8 @@ function RouteComponent() {
     onSubmit: async ({ value }) => {
       if (!currentOrg?.id) return;
 
-      mutate.organization.update(currentOrg.id, {
+      mutate.organization.updateSettings({
+        organizationId: currentOrg.id,
         customInstructions: value.customInstructions || null,
       });
     },

--- a/apps/web/src/routes/app/_workspace/settings/organization/team.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/team.tsx
@@ -105,8 +105,9 @@ function RouteComponent() {
                   value={orgUser.role}
                   items={roleOptions}
                   onValueChange={(value) => {
-                    mutate.organizationUser.update(orgUser.id, {
-                      role: value as string,
+                    mutate.organizationUser.updateMember({
+                      organizationUserId: orgUser.id,
+                      role: value as "owner" | "user",
                     });
                   }}
                 >
@@ -157,7 +158,8 @@ function RouteComponent() {
                         <AlertDialogAction
                           variant="destructive"
                           onClick={() => {
-                            mutate.organizationUser.update(orgUser.id, {
+                            mutate.organizationUser.updateMember({
+                              organizationUserId: orgUser.id,
                               enabled: false,
                             });
                           }}
@@ -209,9 +211,7 @@ function RouteComponent() {
                         <AlertDialogAction
                           variant="destructive"
                           onClick={() => {
-                            mutate.invite.update(invite.id, {
-                              active: false,
-                            });
+                            mutate.invite.revoke({ inviteId: invite.id });
                           }}
                         >
                           Revoke

--- a/apps/web/src/routes/app/_workspace/settings/user/index.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/user/index.tsx
@@ -63,7 +63,8 @@ function RouteComponent() {
         imageUrl = await uploadFile({ data: formData });
       }
 
-      mutate.user.update(user.id, {
+      mutate.user.updateProfile({
+        userId: user.id,
         name: value.userName,
         email: value.userEmail,
         image: imageUrl,

--- a/docs/plans/custom-route-mutations.md
+++ b/docs/plans/custom-route-mutations.md
@@ -24,13 +24,13 @@ All known callers must move to the replacement procedures. When a custom procedu
 ## Current State
 
 - Status: in-progress
-- Active checkpoint: **LP-005a** (next PR slice)
+- Active checkpoint: **LP-006a** (next PR slice)
 - Branch or PR: https://github.com/FrontDeskHQ/front-desk/pull/303
 - Last updated: 2026-06-24
 
 LP-001 inventory is complete below. API routes live in `apps/api/src/live-state/router.ts` and `apps/api/src/live-state/router/*.ts`. Several families already expose custom procedures but still use `withMutations` instead of `withProcedures`; `thread`, `message`, `label`, and `autonomousAction` already use `withProcedures`. Web writes use both `mutate.*` (synced client) and `fetchClient.mutate.*` (HTTP); optimistic handlers are centralized in `apps/web/src/lib/live-state.ts`.
 
-**LP-003 complete** (including **LP-003o** hooks migration). Generic `thread` / `message` / `author` `insert`/`update` denied. Lifecycle hooks live in `live-state/hooks.ts` via `defineHooks` + `server({ hooks })`. **LP-004 complete** — `update.recordActivity` + `runRecordActivity` helper; slack/discord on `update.markReplicated`; generic `update` `insert`/`update` denied.
+**LP-003 complete** (including **LP-003o** hooks migration). Generic `thread` / `message` / `author` `insert`/`update` denied. Lifecycle hooks live in `live-state/hooks.ts` via `defineHooks` + `server({ hooks })`. **LP-004 complete** — `update.recordActivity` + `runRecordActivity` helper; slack/discord on `update.markReplicated`; generic `update` `insert`/`update` denied. **LP-005 complete** — org-family procedures (`updateSettings`, `updateMember`, `updateProfile`, `revoke`); builders renamed to `withProcedures` where touched; generic `organization` / `organizationUser` / `user` / `invite` `insert`/`update` denied.
 
 ## Write inventory matrix
 
@@ -51,10 +51,10 @@ Legend:
 | `update` | **disabled** | **disabled** | `withProcedures`: `recordActivity`✓, `markReplicated`✓ | **API-internal** timeline writes use `runRecordActivity` in `update-mutations.ts` (thread procedures, signal handlers, `createGithubIssue`, `autonomousAction.undo`). Slack/Discord replication via `update.markReplicated`. | No direct web callers — timeline rows created inside thread procedures' optimistic handlers. | **No** (except side effects inside `autonomousAction.undo` optimistic). |
 | `label` | disabled | disabled | `withProcedures`: `create`, `update`, `createAndAttachToThread`, `attachToThread`, `detachFromThread` | **API-internal** `db.label` / `db.threadLabel`: signal handler `apply-label.ts`, `autonomous-action` `undo`. | `labels.tsx` (thread UI), `labels.tsx` (settings), `quick-actions.tsx` (`attachToThread`). | **Yes** — all five procedures. |
 | `threadLabel` | disabled | disabled | none (writes only via `label.*` procedures) | **API-internal**: `apply-label.ts`, `autonomous-action` `undo`. | none direct | n/a |
-| `organization` | disabled | owner or internal key | `withMutations`: `create`, `setActionAutonomy`, `createPublicApiKey`, `revokePublicApiKey`, `listApiKeys`† | Boot migration `002_seed_autonomy_settings.ts` (`db.organization.update`). `organization.create` also inserts `subscription` + `organizationUser` server-side. | `onboarding/connect.tsx` (`create`), settings `index.tsx` + `support-intelligence.tsx` (generic `update`, `setActionAutonomy`), `api-keys.tsx` (key procedures). | **No** |
-| `organizationUser` | disabled | owner or internal key | `withMutations`: `inviteUser` | Created by `invite.accept`, `organization.create`. | `team.tsx` (generic `update`, `inviteUser`). | **No** |
-| `user` | disabled | self or internal key | none | none | `settings/user/index.tsx` (generic `update`). | **No** |
-| `invite` | disabled | org members | `withMutations`: `accept`, `decline` | `inviteUser` creates rows; `accept` also inserts `organizationUser` + `allowlist`. | `invitation.$id.tsx` (`accept`, `decline`), `onboarding/index.tsx` (`accept`), `team.tsx` (generic `update` revoke). | **No** |
+| `organization` | disabled | **disabled** | `withProcedures`: `create`, `updateSettings`✓, `setActionAutonomy`, `createPublicApiKey`, `revokePublicApiKey`, `listApiKeys`† | Boot migration `002_seed_autonomy_settings.ts` (`db.organization.update`). `organization.create` also inserts `subscription` + `organizationUser` server-side. | `onboarding/connect.tsx` (`create`), settings `index.tsx` + `support-intelligence.tsx` (`updateSettings`, `setActionAutonomy`), `api-keys.tsx` (key procedures). | **No** |
+| `organizationUser` | disabled | **disabled** | `withProcedures`: `inviteUser`, `updateMember`✓ | Created by `invite.accept`, `organization.create`. | `team.tsx` (`updateMember`, `inviteUser`). | **No** |
+| `user` | disabled | **disabled** | `withProcedures`: `updateProfile`✓ | none | `settings/user/index.tsx` (`updateProfile`). | **No** |
+| `invite` | disabled | **disabled** | `withProcedures`: `accept`, `decline`, `revoke`✓ | `inviteUser` creates rows; `accept` also inserts `organizationUser` + `allowlist`. | `invitation.$id.tsx` (`accept`, `decline`), `onboarding/index.tsx` (`accept`), `team.tsx` (`revoke`). | **No** |
 | `integration` | owner or internal key | owner or internal key | `withMutations`: `fetchSlackChannels`† | `apps/slack` (`installation-store`, `utils`), `apps/discord` (`utils`), `apps/github` (`setup.ts`, settings flows via web). | Settings + redirect routes for slack/discord/github, `lib/integrations/activate.ts`, `organization/index.tsx` (`fetchSlackChannels`). | **No** |
 | `onboarding` | org members + internal key | org members + internal key | `withMutations`: `initialize`, `completeStep`, `skip`, `complete` | none | `use-onboarding.ts` (all four procedures; `initialize` via `fetchClient`). | **No** |
 | `documentationSource` | internal key only | internal key only | `withMutations`: `validateDocumentationSource`†, `addDocumentationSource`, `recrawlDocumentationSource`, `deleteDocumentationSource` | `apps/worker` `crawl-documentation.ts` (generic `update` via internal key). | `settings/organization/documentation.tsx` (all custom procedures). | **No** |
@@ -234,14 +234,14 @@ Procedures **already implemented** are marked ✓. Others are the LP-003–LP-00
 | Procedure | Route | Replaces | Web optimistic |
 | --- | --- | --- | --- |
 | `create` ✓ | `organization` | — | **no** — onboarding uses `fetchClient`, awaited |
-| `updateSettings` | `organization` | generic `organization.update` (support URL, name, …) | **no** |
+| `updateSettings` ✓ | `organization` | generic `organization.update` (support URL, name, …) | **no** |
 | `setActionAutonomy` ✓ | `organization` | — | **no** |
 | `createPublicApiKey` / `revokePublicApiKey` ✓ | `organization` | — | **no** |
 | `inviteUser` ✓ | `organizationUser` | — | **no** |
-| `updateMember` | `organizationUser` | generic `organizationUser.update` (role, enabled) | **no** |
-| `updateProfile` | `user` | generic `user.update` | **no** |
+| `updateMember` ✓ | `organizationUser` | generic `organizationUser.update` (role, enabled) | **no** |
+| `updateProfile` ✓ | `user` | generic `user.update` | **no** |
 | `accept` / `decline` ✓ | `invite` | — | **no** |
-| `revoke` | `invite` | generic `invite.update` revoke | **no** |
+| `revoke` ✓ | `invite` | generic `invite.update` revoke | **no** |
 
 #### LP-006: `integration`, `externalEntity`
 
@@ -309,11 +309,11 @@ Parent checklist items (`LP-003`–`LP-010`) complete when all child slices unde
 
 | Slice | PR title (suggested) | Scope | Completion |
 | --- | --- | --- | --- |
-| [ ] **LP-005a** | `organization.updateSettings` + builder rename | `router/organization.ts` `withProcedures`, `settings/organization/index.tsx`, `support-intelligence.tsx` | No `mutate.organization.update` in web |
-| [ ] **LP-005b** | `organizationUser.updateMember` | `router/organization-user.ts`, `team.tsx` role/enabled toggles | No `mutate.organizationUser.update` in web |
-| [ ] **LP-005c** | `user.updateProfile` | `router/user.ts` new procedure, `settings/user/index.tsx` | No `mutate.user.update` in web |
-| [ ] **LP-005d** | `invite.revoke` | `router/invite.ts`, `team.tsx` invite revoke | No `mutate.invite.update` in web |
-| [ ] **LP-005e-lockdown** | Deny generic org-family writes | `organization`, `organizationUser`, `user`, `invite` routes | All LP-005a–d complete |
+| [x] **LP-005a** | `organization.updateSettings` + builder rename | `router.ts` organization `withProcedures`, `settings/organization/index.tsx`, `support-intelligence.tsx` | No `mutate.organization.update` in web |
+| [x] **LP-005b** | `organizationUser.updateMember` | `router.ts` organizationUser `withProcedures`, `team.tsx` role/enabled toggles | No `mutate.organizationUser.update` in web |
+| [x] **LP-005c** | `user.updateProfile` | `router.ts` user `withProcedures`, `settings/user/index.tsx` | No `mutate.user.update` in web |
+| [x] **LP-005d** | `invite.revoke` | `router.ts` invite `withProcedures`, `team.tsx` invite revoke | No `mutate.invite.update` in web |
+| [x] **LP-005e-lockdown** | Deny generic org-family writes | `organization`, `organizationUser`, `user`, `invite` routes | All LP-005a–d complete |
 
 ### LP-006 — `integration`, `externalEntity`
 
@@ -364,7 +364,7 @@ Cross-cutting cleanup after procedure migration. Can bundle router-file migratio
 - [x] LP-002: Define the target procedure contract. Completion: documented conventions for naming, input schemas, authorization, return values, optimistic handlers, and whether generic writes stay available for internal-only routes.
 - [x] LP-003: Migrate thread and message writes. Completion: all **LP-003a–o** slices done (including lockdown and hooks migration).
 - [x] LP-004: Migrate label, thread-label, and update writes. Completion: all **LP-004\*** slices done (labels already ✓).
-- [ ] LP-005: Migrate organization, organization-user, invite, and user writes. Completion: all **LP-005a–e** slices done.
+- [x] LP-005: Migrate organization, organization-user, invite, and user writes. Completion: all **LP-005a–e** slices done.
 - [ ] LP-006: Migrate integration and external-entity writes. Completion: all **LP-006a–e** slices done.
 - [ ] LP-007: Migrate onboarding, documentation-source, agent-chat, and autonomous-action writes. Completion: all **LP-007a–e** slices done.
 - [ ] LP-008: Lock down generic route permissions. Completion: **LP-008** audit slice done.
@@ -398,6 +398,11 @@ Cross-cutting cleanup after procedure migration. Can bundle router-file migratio
 - 2026-06-23: **Authorization** — procedures and lib code must use `authorize` / `isAuthorized` from `apps/api/src/lib/authorize.ts`; extend that module for new patterns instead of ad-hoc `req.context` checks. Tracked as **LP-010** (scan + migrate).
 - 2026-06-23 (LP-004a): Added `runRecordActivity` in `apps/api/src/lib/update-mutations.ts` and `update.recordActivity` procedure (`withProcedures`). Migrated `insertThreadActivity`, `thread-mutations` activity rows, `createGithubIssue`, and `autonomousAction.undo` to the shared helper. Single `db.insert(schema.update)` site remains in `update-mutations.ts`.
 - 2026-06-23 (LP-004b): Added `update.markReplicated` procedure + `runMarkReplicated` helper (internal API key only). Migrated Slack `handleUpdates` replication marking off generic `update.update`. Discord migrated in **LP-004c**.
+- 2026-06-24 (LP-005a): Added `organization.updateSettings` — owner-only procedure accepting optional `name`, `slug`, `logoUrl`, `socials`, `customInstructions`, `settings`; validates slug + settings via shared schemas. Renamed organization route builder to `withProcedures`. Web settings forms use `mutate.organization.updateSettings({ organizationId, … })`. Intentional: no optimistic handler (settings use fire-and-forget `mutate` but infrequent; same as prior generic update behavior).
+- 2026-06-24 (LP-005b): `organizationUser.updateMember` — owner auth via `authorize`; optional `role` / `enabled`; blocks self role change or removal. Renamed builder to `withProcedures`.
+- 2026-06-24 (LP-005c): `user.updateProfile` — self or internal key; optional `name`, `email`, `image`. Added `withProcedures` on user route.
+- 2026-06-24 (LP-005d): `invite.revoke` — owner auth; sets `active: false`. Renamed invite builder to `withProcedures`.
+- 2026-06-24 (LP-005e): Denied generic `insert`/`update` on `organization`, `organizationUser`, `user`, `invite` collection routes. Boot migrations and procedures continue using direct `db.*` writes.
 
 ## PR Feedback
 
@@ -430,6 +435,8 @@ Cross-cutting cleanup after procedure migration. Can bundle router-file migratio
 - 2026-06-23 (LP-004c): `bun run --filter api typecheck` and `bun run --filter discord typecheck` pass. Ripgrep: `apps/discord` has zero `mutate.update.update` / `mutate.update.insert`. No runtime Discord timeline replication smoke test.
 - 2026-06-23 (LP-004d): `bun run --filter api typecheck` pass. Ripgrep: `apply-label.ts` has no `threadLabel.insert` / direct label lookup — only `runAttachLabelToThread` + compensate `threadLabel.update`. No runtime inline-suggestion label apply smoke test.
 - 2026-06-24 (LP-004e): `bun run --filter api typecheck` pass. Ripgrep: zero `mutate.update.insert` / `mutate.update.update` under `apps/web`, `apps/slack`, `apps/discord`, `apps/github`; slack/discord use `update.markReplicated` only. No runtime smoke test.
+- 2026-06-24 (LP-005a): `bun run --filter api typecheck` and `bun run --filter web typecheck` pass. Ripgrep: zero `mutate.organization.update(` in `apps/web`. No runtime smoke test for org profile, digest, or custom-instructions settings forms.
+- 2026-06-24 (LP-005b–e): `bun run --filter api typecheck` and `bun run --filter web typecheck` pass. Ripgrep: zero `mutate.(organization|organizationUser|user|invite).(update|insert)(` under `apps/web`, `apps/api`, `apps/slack`, `apps/discord`, `apps/github`. No runtime smoke test for team role/remove/revoke or user profile save.
 
 ## Session Log
 
@@ -461,7 +468,9 @@ Cross-cutting cleanup after procedure migration. Can bundle router-file migratio
 - 2026-06-24 (LP-004e): Denied generic `insert`/`update` on `update` collection route; product callers already on thread procedures or `markReplicated`; internal timeline writes use `runRecordActivity` only.
 - 2026-06-23 (LP-004d): Extracted `runAttachLabelToThread` in `label-mutations.ts`; `label.attachToThread` procedure and `apply-label` signal handler delegate to shared helper (transaction + race handling). Added `transaction` to `SignalExecutionDb`.
 - 2026-06-24 (LP-004e): Denied generic `insert`/`update` on `router/update.ts` (`insert: () => false`, `update.preMutation/postMutation: () => false`). Confirmed no remaining product/integration generic callers — GitHub webhooks use `thread.setStatus`; slack/discord use `update.markReplicated`. Files: `router/update.ts`.
+- 2026-06-24 (LP-005a): Added `organization.updateSettings` procedure (owner auth via `authorize`); renamed organization builder to `withProcedures`. Migrated web org profile, digest, and custom-instructions forms. Files: `router.ts`, `settings/organization/index.tsx`, `support-intelligence.tsx`.
+- 2026-06-24 (LP-005b–e): Added `organizationUser.updateMember`, `user.updateProfile`, `invite.revoke`; renamed `organizationUser` and `invite` builders to `withProcedures`; added `withProcedures` on `user`. Migrated `team.tsx` and `settings/user/index.tsx`. Denied generic writes on all four org-family routes. Files: `router.ts`, `team.tsx`, `settings/user/index.tsx`.
 
 ## Handoff
 
-Next action: Ship **LP-005a** — add `organization.updateSettings` procedure in `apps/api/src/live-state/router/organization.ts` (rename builder to `withProcedures` in same PR), migrate `apps/web` settings pages off generic `mutate.organization.update` (`settings/organization/index.tsx`, `support-intelligence.tsx`). Ripgrep target: zero `mutate.organization.update` in `apps/web`.
+Next action: Ship **LP-006a** — add `integration.connectInstallation` / `updateInstallation` procedures in `apps/api/src/live-state/router.ts` (rename integration builder to `withProcedures`), migrate web integration connect/update flows off generic `mutate.integration.insert` / `.update` (`slack`, `discord`, `github` settings, `lib/integrations/activate.ts`, `organization/index.tsx`). Ripgrep target: zero `mutate.integration.insert` / `mutate.integration.update` in `apps/web`.


### PR DESCRIPTION
## Summary

- Adds explicit Live-State procedures for org-family writes: `organization.updateSettings`, `organizationUser.updateMember`, `user.updateProfile`, and `invite.revoke`
- Renames affected route builders from `withMutations` to `withProcedures` and denies generic `insert`/`update` on `organization`, `organizationUser`, `user`, and `invite`
- Migrates web settings and team pages off generic `mutate.*.update` call sites

## Test plan

- [x] `bun run --filter api typecheck`
- [x] `bun run --filter web typecheck`
- [x] Ripgrep: zero `mutate.(organization|organizationUser|user|invite).(update|insert)(` under `apps/web`
- [ ] Manual: org profile + digest + custom instructions save (`settings/organization/*`)
- [ ] Manual: team role change, member remove, invite revoke (`settings/organization/team`)
- [ ] Manual: user profile save (`settings/user`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced generic writes for `organization`, `organizationUser`, `user`, and `invite` with named procedures and locked down direct mutations. Finalizes LP-005 by migrating web settings and team pages, renaming builders to `withProcedures`, and tightening slug/settings handling.

- New Features
  - `organization.updateSettings` (owner-only; validates slug against reserved list; validates `settings`; merges with existing settings to preserve unknown keys).
  - `organizationUser.updateMember` (owner-only; blocks self demote/disable).
  - `user.updateProfile` (self or internal key).
  - `invite.revoke` (owner-only).

- Refactors
  - Deny generic `insert`/`update` on `organization`, `organizationUser`, `user`, `invite`.
  - Rename builders from `withMutations` to `withProcedures` where touched.
  - Migrate web callers:
    - Org profile/digest/custom instructions → `mutate.organization.updateSettings`.
    - Team role/disable → `mutate.organizationUser.updateMember`.
    - Invite revoke → `mutate.invite.revoke`.
    - User profile → `mutate.user.updateProfile`.
  - Update docs to mark LP-005 complete and reflect new procedures.

<sup>Written for commit 3637e84ef3a484ac90dafe1a315fa906f789eb19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#304** 👈 current
2. #305
3. #306
<!-- stack:links:end -->