### PR TITLE
feat(api,integrations): integration procedures and lockdown (LP-006)

### DIFF
--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -23,10 +23,10 @@ import { agentChatMessageRoute, agentChatRoute } from "./router/agent-chat";
 import autonomousActionRoute from "./router/autonomous-action";
 import documentationSourcesRoute from "./router/documentation-sources";
 import externalEntityRoute from "./router/external-entity";
+import integrationRoute from "./router/integration";
 import labelsRoute from "./router/labels";
 import messageRoute from "./router/message";
 import onboardingRoute from "./router/onboarding";
-import { slackChannelsCache } from "./router/slack-channels";
 import threadsRoute from "./router/threads";
 import updateRoute from "./router/update";
 import { schema } from "./schema";
@@ -717,117 +717,7 @@ export const router = createRouter({
           },
         ),
       })),
-    integration: privateRoute
-      .collectionRoute(schema.integration, {
-        read: () => true,
-        insert: ({ ctx }) => {
-          if (ctx?.internalApiKey) return true;
-          if (!ctx?.session) return false;
-
-          return {
-            organization: {
-              organizationUsers: {
-                userId: ctx.session.userId,
-                enabled: true,
-                role: "owner",
-              },
-            },
-          };
-        },
-        update: {
-          preMutation: ({ ctx }) => {
-            if (ctx?.internalApiKey) return true;
-            if (!ctx?.session) return false;
-
-            return {
-              organization: {
-                organizationUsers: {
-                  userId: ctx.session.userId,
-                  enabled: true,
-                  role: "owner",
-                },
-              },
-            };
-          },
-          postMutation: ({ ctx }) => {
-            if (ctx?.internalApiKey) return true;
-            if (!ctx?.session) return false;
-
-            return {
-              organization: {
-                organizationUsers: {
-                  userId: ctx.session.userId,
-                  enabled: true,
-                  role: "owner",
-                },
-              },
-            };
-          },
-        },
-      })
-      .withMutations(({ mutation }) => ({
-        fetchSlackChannels: mutation(
-          z.object({
-            organizationId: z.string(),
-            teamId: z.string().optional(),
-          }),
-        ).handler(async ({ req, db }) => {
-          const { organizationId, teamId: requestedTeamId } = req.input;
-
-          let authorized = !!req.context?.internalApiKey;
-
-          if (!authorized && req.context?.session?.userId) {
-            const selfOrgUser = Object.values(
-              await db.find(schema.organizationUser, {
-                where: {
-                  organizationId,
-                  userId: req.context.session.userId,
-                  enabled: true,
-                },
-              }),
-            )[0];
-
-            authorized = selfOrgUser?.role === "owner";
-          }
-
-          if (!authorized) {
-            throw new Error("UNAUTHORIZED");
-          }
-
-          const integration = Object.values(
-            await db.find(schema.integration, {
-              where: {
-                organizationId,
-                type: "slack",
-                enabled: true,
-              },
-            }),
-          )[0];
-
-          if (!integration || !integration.configStr) {
-            throw new Error("SLACK_INTEGRATION_NOT_CONFIGURED");
-          }
-
-          const config = JSON.parse(integration.configStr);
-          const teamId = config?.teamId;
-
-          if (!teamId) {
-            throw new Error("SLACK_TEAM_ID_NOT_FOUND");
-          }
-
-          if (
-            requestedTeamId !== undefined &&
-            String(teamId) !== String(requestedTeamId)
-          ) {
-            throw new Error("SLACK_TEAM_MISMATCH");
-          }
-
-          return slackChannelsCache.get({
-            organizationId,
-            teamId: String(teamId),
-          });
-        }),
-      })),
+    integration: integrationRoute,
     allowlist: privateRoute.collectionRoute(schema.allowlist, {
       read: ({ ctx }) => {
         if (ctx?.internalApiKey) return true;

--- a/apps/api/src/live-state/router/external-entity.ts
+++ b/apps/api/src/live-state/router/external-entity.ts
@@ -74,7 +74,7 @@ export default privateRoute
       postMutation: () => false,
     },
   })
-  .withMutations(({ mutation }) => ({
+  .withProcedures(({ mutation }) => ({
     /**
      * Insert or update the mirror row identified by
      * `(organizationId, externalKey)`. Refreshes `lastSyncedAt` and clears any

--- a/apps/api/src/live-state/router/integration.ts
+++ b/apps/api/src/live-state/router/integration.ts
@@ -32,7 +32,19 @@ const updateInstallationInputSchema = z
 
 export default privateRoute
   .collectionRoute(schema.integration, {
-    read: () => true,
+    read: ({ ctx }) => {
+      if (ctx?.internalApiKey) return true;
+      if (!ctx?.session) return false;
+
+      return {
+        organization: {
+          organizationUsers: {
+            userId: ctx.session.userId,
+            enabled: true,
+          },
+        },
+      };
+    },
     insert: () => false,
     update: {
       preMutation: () => false,
@@ -48,17 +60,32 @@ export default privateRoute
         authorize(req, { organizationId, role: "owner" });
 
         const now = new Date();
-        const row = await db.insert(schema.integration, {
-          id: id ?? ulid().toLowerCase(),
-          organizationId,
-          type,
-          enabled: enabled ?? false,
-          configStr: configStr ?? null,
-          createdAt: createdAt ?? now,
-          updatedAt: updatedAt ?? now,
-        });
 
-        return row;
+        return db.transaction(async ({ trx }) => {
+          const existing = Object.values(
+            await trx.find(schema.integration, {
+              where: { organizationId, type },
+            }),
+          )[0];
+
+          if (existing) {
+            return trx.update(schema.integration, existing.id, {
+              ...(enabled !== undefined ? { enabled } : {}),
+              ...(configStr !== undefined ? { configStr } : {}),
+              updatedAt: updatedAt ?? now,
+            });
+          }
+
+          return trx.insert(schema.integration, {
+            id: id ?? ulid().toLowerCase(),
+            organizationId,
+            type,
+            enabled: enabled ?? false,
+            configStr: configStr ?? null,
+            createdAt: createdAt ?? now,
+            updatedAt: updatedAt ?? now,
+          });
+        });
       },
     ),
 
@@ -108,7 +135,12 @@ export default privateRoute
         throw new Error("SLACK_INTEGRATION_NOT_CONFIGURED");
       }
 
-      const config = JSON.parse(integration.configStr);
+      let config: { teamId?: unknown };
+      try {
+        config = JSON.parse(integration.configStr);
+      } catch {
+        throw new Error("SLACK_INTEGRATION_CONFIG_INVALID");
+      }
       const teamId = config?.teamId;
 
       if (!teamId) {

--- a/apps/api/src/live-state/router/integration.ts
+++ b/apps/api/src/live-state/router/integration.ts
@@ -1,0 +1,130 @@
+import { ulid } from "ulid";
+import { z } from "zod";
+import { authorize } from "../../lib/authorize";
+import { privateRoute } from "../factories";
+import { schema } from "../schema";
+import { slackChannelsCache } from "./slack-channels";
+
+const connectInstallationInputSchema = z.object({
+  organizationId: z.string(),
+  type: z.string(),
+  enabled: z.boolean().optional(),
+  configStr: z.string().nullable().optional(),
+  id: z.string().optional(),
+  createdAt: z.coerce.date().optional(),
+  updatedAt: z.coerce.date().optional(),
+});
+
+const updateInstallationInputSchema = z
+  .object({
+    integrationId: z.string(),
+    enabled: z.boolean().optional(),
+    configStr: z.string().nullable().optional(),
+    updatedAt: z.coerce.date().optional(),
+  })
+  .refine(
+    (input) => {
+      const { integrationId: _integrationId, ...fields } = input;
+      return Object.values(fields).some((value) => value !== undefined);
+    },
+    { message: "NO_FIELDS_TO_UPDATE" },
+  );
+
+export default privateRoute
+  .collectionRoute(schema.integration, {
+    read: () => true,
+    insert: () => false,
+    update: {
+      preMutation: () => false,
+      postMutation: () => false,
+    },
+  })
+  .withProcedures(({ mutation }) => ({
+    connectInstallation: mutation(connectInstallationInputSchema).handler(
+      async ({ req, db }) => {
+        const { organizationId, type, enabled, configStr, id, createdAt, updatedAt } =
+          req.input;
+
+        authorize(req, { organizationId, role: "owner" });
+
+        const now = new Date();
+        const row = await db.insert(schema.integration, {
+          id: id ?? ulid().toLowerCase(),
+          organizationId,
+          type,
+          enabled: enabled ?? false,
+          configStr: configStr ?? null,
+          createdAt: createdAt ?? now,
+          updatedAt: updatedAt ?? now,
+        });
+
+        return row;
+      },
+    ),
+
+    updateInstallation: mutation(updateInstallationInputSchema).handler(
+      async ({ req, db }) => {
+        const integration = await db.integration
+          .one(req.input.integrationId)
+          .get();
+        if (!integration) throw new Error("INTEGRATION_NOT_FOUND");
+
+        authorize(req, {
+          organizationId: integration.organizationId,
+          role: "owner",
+        });
+
+        const { integrationId, ...patch } = req.input;
+        const updatedAt = patch.updatedAt ?? new Date();
+
+        return db.update(schema.integration, integrationId, {
+          ...patch,
+          updatedAt,
+        });
+      },
+    ),
+
+    fetchSlackChannels: mutation(
+      z.object({
+        organizationId: z.string(),
+        teamId: z.string().optional(),
+      }),
+    ).handler(async ({ req, db }) => {
+      const { organizationId, teamId: requestedTeamId } = req.input;
+
+      authorize(req, { organizationId, role: "owner" });
+
+      const integration = Object.values(
+        await db.find(schema.integration, {
+          where: {
+            organizationId,
+            type: "slack",
+            enabled: true,
+          },
+        }),
+      )[0];
+
+      if (!integration || !integration.configStr) {
+        throw new Error("SLACK_INTEGRATION_NOT_CONFIGURED");
+      }
+
+      const config = JSON.parse(integration.configStr);
+      const teamId = config?.teamId;
+
+      if (!teamId) {
+        throw new Error("SLACK_TEAM_ID_NOT_FOUND");
+      }
+
+      if (
+        requestedTeamId !== undefined &&
+        String(teamId) !== String(requestedTeamId)
+      ) {
+        throw new Error("SLACK_TEAM_MISMATCH");
+      }
+
+      return slackChannelsCache.get({
+        organizationId,
+        teamId: String(teamId),
+      });
+    }),
+  }));

--- a/apps/discord/src/lib/utils.ts
+++ b/apps/discord/src/lib/utils.ts
@@ -25,7 +25,8 @@ export const updateBackfillStatus = async (
   } | null,
 ) => {
   const current = safeParseIntegrationSettings(configStr) ?? {};
-  await fetchClient.mutate.integration.update(integrationId, {
+  await fetchClient.mutate.integration.updateInstallation({
+    integrationId,
     configStr: JSON.stringify({ ...current, backfill }),
   });
 };
@@ -36,7 +37,8 @@ export const updateSyncedChannels = async (
   syncedChannels: string[],
 ) => {
   const current = safeParseIntegrationSettings(configStr) ?? {};
-  await fetchClient.mutate.integration.update(integrationId, {
+  await fetchClient.mutate.integration.updateInstallation({
+    integrationId,
     configStr: JSON.stringify({ ...current, syncedChannels }),
   });
 };

--- a/apps/github/src/routes/setup.ts
+++ b/apps/github/src/routes/setup.ts
@@ -70,7 +70,8 @@ export const setupRoutes = new Elysia({ prefix: "/api/github" }).get(
         name: repo.name,
       }));
 
-      await fetchClient.mutate.integration.update(integration.id, {
+      await fetchClient.mutate.integration.updateInstallation({
+        integrationId: integration.id,
         enabled: true,
         updatedAt: new Date(),
         configStr: JSON.stringify({

--- a/apps/slack/src/lib/installation-store.ts
+++ b/apps/slack/src/lib/installation-store.ts
@@ -27,7 +27,8 @@ export const installationStore = {
 
     const currentConfig =
       safeParseIntegrationSettings(integration.configStr) ?? {};
-    await fetchClient.mutate.integration.update(integration.id, {
+    await fetchClient.mutate.integration.updateInstallation({
+      integrationId: integration.id,
       updatedAt: new Date(),
       configStr: JSON.stringify({
         ...currentConfig,
@@ -105,7 +106,8 @@ export const installationStore = {
     const { installation: _installation, ...configWithoutInstallation } =
       currentConfig;
 
-    await fetchClient.mutate.integration.update(integration.id, {
+    await fetchClient.mutate.integration.updateInstallation({
+      integrationId: integration.id,
       updatedAt: new Date(),
       configStr: JSON.stringify(configWithoutInstallation),
     });

--- a/apps/slack/src/lib/utils.ts
+++ b/apps/slack/src/lib/utils.ts
@@ -13,7 +13,8 @@ export const updateBackfillStatus = async (
   } | null,
 ) => {
   const current = safeParseIntegrationSettings(configStr) ?? {};
-  await fetchClient.mutate.integration.update(integrationId, {
+  await fetchClient.mutate.integration.updateInstallation({
+    integrationId,
     configStr: JSON.stringify({ ...current, backfill }),
   });
 };
@@ -28,7 +29,8 @@ export const updateSyncedChannels = async (
   const current = safeParseIntegrationSettings(
     latestIntegration?.configStr ?? null,
   ) ?? {};
-  await fetchClient.mutate.integration.update(integrationId, {
+  await fetchClient.mutate.integration.updateInstallation({
+    integrationId,
     configStr: JSON.stringify({ ...current, syncedChannels }),
   });
 };

--- a/apps/web/src/lib/integrations/activate.ts
+++ b/apps/web/src/lib/integrations/activate.ts
@@ -48,7 +48,8 @@ export async function activateDiscord({
   const csrfToken = generateStateToken();
 
   if (existingIntegrationId) {
-    await fetchClient.mutate.integration.update(existingIntegrationId, {
+    await fetchClient.mutate.integration.updateInstallation({
+      integrationId: existingIntegrationId,
       enabled: false,
       updatedAt: new Date(),
       configStr: JSON.stringify({
@@ -57,7 +58,7 @@ export async function activateDiscord({
       }),
     });
   } else {
-    await fetchClient.mutate.integration.insert({
+    await fetchClient.mutate.integration.connectInstallation({
       id: ulid().toLowerCase(),
       organizationId,
       type: "discord",
@@ -114,7 +115,8 @@ export async function activateSlack({
   const csrfToken = generateStateToken();
 
   if (existingIntegrationId) {
-    await fetchClient.mutate.integration.update(existingIntegrationId, {
+    await fetchClient.mutate.integration.updateInstallation({
+      integrationId: existingIntegrationId,
       enabled: false,
       updatedAt: new Date(),
       configStr: JSON.stringify({
@@ -123,7 +125,7 @@ export async function activateSlack({
       }),
     });
   } else {
-    await fetchClient.mutate.integration.insert({
+    await fetchClient.mutate.integration.connectInstallation({
       id: ulid().toLowerCase(),
       organizationId,
       type: "slack",

--- a/apps/web/src/routes/app/_workspace/settings/organization/integration/discord/index.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/integration/discord/index.tsx
@@ -80,7 +80,8 @@ function RouteComponent() {
       enabled: boolean = true,
     ) => {
       if (integration) {
-        mutate.integration.update(integration.id, {
+        mutate.integration.updateInstallation({
+          integrationId: integration.id,
           enabled,
           updatedAt: new Date(),
           configStr: JSON.stringify({
@@ -89,7 +90,7 @@ function RouteComponent() {
           }),
         });
       } else if (activeOrg?.id) {
-        mutate.integration.insert({
+        mutate.integration.connectInstallation({
           id: ulid().toLowerCase(),
           organizationId: activeOrg?.id,
           type: "discord",
@@ -238,7 +239,8 @@ function RouteComponent() {
                     variant="ghost"
                     className="ml-auto text-red-700 dark:hover:text-red-500"
                     onClick={() => {
-                      mutate.integration.update(integration?.id, {
+                      mutate.integration.updateInstallation({
+                        integrationId: integration?.id,
                         enabled: false,
                         updatedAt: new Date(),
                       });

--- a/apps/web/src/routes/app/_workspace/settings/organization/integration/discord/redirect.ts
+++ b/apps/web/src/routes/app/_workspace/settings/organization/integration/discord/redirect.ts
@@ -50,7 +50,8 @@ export const Route = createFileRoute(
               throw new Error("CSRF_TOKEN_MISMATCH");
             }
 
-            await fetchClient.mutate.integration.update(integration.id, {
+            await fetchClient.mutate.integration.updateInstallation({
+              integrationId: integration.id,
               enabled: true,
               updatedAt: new Date(),
               configStr: JSON.stringify({

--- a/apps/web/src/routes/app/_workspace/settings/organization/integration/github/index.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/integration/github/index.tsx
@@ -217,7 +217,7 @@ function RouteComponent() {
                     className="ml-auto text-red-700 dark:hover:text-red-500"
                     onClick={() => {
                       mutate.integration.updateInstallation({
-                        integrationId: integration?.id,
+                        integrationId: integration.id,
                         enabled: false,
                         updatedAt: new Date(),
                       });

--- a/apps/web/src/routes/app/_workspace/settings/organization/integration/github/index.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/integration/github/index.tsx
@@ -89,7 +89,8 @@ function RouteComponent() {
     const csrfToken = generateStateToken();
 
     if (integration) {
-      await fetchClient.mutate.integration.update(integration.id, {
+      await fetchClient.mutate.integration.updateInstallation({
+        integrationId: integration.id,
         enabled: false,
         updatedAt: new Date(),
         configStr: JSON.stringify({
@@ -98,7 +99,7 @@ function RouteComponent() {
         }),
       });
     } else if (activeOrg?.id) {
-      await fetchClient.mutate.integration.insert({
+      await fetchClient.mutate.integration.connectInstallation({
         id: ulid().toLowerCase(),
         organizationId: activeOrg?.id,
         type: "github",
@@ -215,7 +216,8 @@ function RouteComponent() {
                     variant="ghost"
                     className="ml-auto text-red-700 dark:hover:text-red-500"
                     onClick={() => {
-                      mutate.integration.update(integration?.id, {
+                      mutate.integration.updateInstallation({
+                        integrationId: integration?.id,
                         enabled: false,
                         updatedAt: new Date(),
                       });

--- a/apps/web/src/routes/app/_workspace/settings/organization/integration/slack/index.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/integration/slack/index.tsx
@@ -271,7 +271,7 @@ function RouteComponent() {
                     className="ml-auto text-red-700 dark:hover:text-red-500"
                     onClick={() => {
                       mutate.integration.updateInstallation({
-                        integrationId: integration?.id,
+                        integrationId: integration.id,
                         enabled: false,
                         updatedAt: new Date(),
                       });

--- a/apps/web/src/routes/app/_workspace/settings/organization/integration/slack/index.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/integration/slack/index.tsx
@@ -80,7 +80,8 @@ function RouteComponent() {
       enabled: boolean = true,
     ) => {
       if (integration) {
-        mutate.integration.update(integration.id, {
+        mutate.integration.updateInstallation({
+          integrationId: integration.id,
           enabled,
           updatedAt: new Date(),
           configStr: JSON.stringify({
@@ -89,7 +90,7 @@ function RouteComponent() {
           }),
         });
       } else if (activeOrg?.id) {
-        mutate.integration.insert({
+        mutate.integration.connectInstallation({
           id: ulid().toLowerCase(),
           organizationId: activeOrg?.id,
           type: "slack",
@@ -269,7 +270,8 @@ function RouteComponent() {
                     variant="ghost"
                     className="ml-auto text-red-700 dark:hover:text-red-500"
                     onClick={() => {
-                      mutate.integration.update(integration?.id, {
+                      mutate.integration.updateInstallation({
+                        integrationId: integration?.id,
                         enabled: false,
                         updatedAt: new Date(),
                       });

--- a/apps/web/src/routes/app/_workspace/settings/organization/integration/slack/redirect.ts
+++ b/apps/web/src/routes/app/_workspace/settings/organization/integration/slack/redirect.ts
@@ -109,7 +109,8 @@ export const Route = createFileRoute(
             // The installation object contains all the OAuth response data
             const installation = tokenData;
 
-            await fetchClient.mutate.integration.update(integration.id, {
+            await fetchClient.mutate.integration.updateInstallation({
+              integrationId: integration.id,
               enabled: true,
               updatedAt: new Date(),
               configStr: JSON.stringify({

--- a/docs/plans/custom-route-mutations.md
+++ b/docs/plans/custom-route-mutations.md
@@ -24,13 +24,13 @@ All known callers must move to the replacement procedures. When a custom procedu
 ## Current State
 
 - Status: in-progress
-- Active checkpoint: **LP-006a** (next PR slice)
+- Active checkpoint: **LP-007a** (next PR slice)
 - Branch or PR: https://github.com/FrontDeskHQ/front-desk/pull/303
 - Last updated: 2026-06-24
 
 LP-001 inventory is complete below. API routes live in `apps/api/src/live-state/router.ts` and `apps/api/src/live-state/router/*.ts`. Several families already expose custom procedures but still use `withMutations` instead of `withProcedures`; `thread`, `message`, `label`, and `autonomousAction` already use `withProcedures`. Web writes use both `mutate.*` (synced client) and `fetchClient.mutate.*` (HTTP); optimistic handlers are centralized in `apps/web/src/lib/live-state.ts`.
 
-**LP-003 complete** (including **LP-003o** hooks migration). Generic `thread` / `message` / `author` `insert`/`update` denied. Lifecycle hooks live in `live-state/hooks.ts` via `defineHooks` + `server({ hooks })`. **LP-004 complete** — `update.recordActivity` + `runRecordActivity` helper; slack/discord on `update.markReplicated`; generic `update` `insert`/`update` denied. **LP-005 complete** — org-family procedures (`updateSettings`, `updateMember`, `updateProfile`, `revoke`); builders renamed to `withProcedures` where touched; generic `organization` / `organizationUser` / `user` / `invite` `insert`/`update` denied.
+**LP-003 complete** (including **LP-003o** hooks migration). Generic `thread` / `message` / `author` `insert`/`update` denied. Lifecycle hooks live in `live-state/hooks.ts` via `defineHooks` + `server({ hooks })`. **LP-004 complete** — `update.recordActivity` + `runRecordActivity` helper; slack/discord on `update.markReplicated`; generic `update` `insert`/`update` denied. **LP-005 complete** — org-family procedures (`updateSettings`, `updateMember`, `updateProfile`, `revoke`); builders renamed to `withProcedures` where touched; generic `organization` / `organizationUser` / `user` / `invite` `insert`/`update` denied. **LP-006 complete** — `integration.connectInstallation` / `updateInstallation`; builders renamed to `withProcedures` on `integration` and `externalEntity`; generic `integration` `insert`/`update` denied; all web + slack/discord/github callers migrated.
 
 ## Write inventory matrix
 
@@ -55,10 +55,10 @@ Legend:
 | `organizationUser` | disabled | **disabled** | `withProcedures`: `inviteUser`, `updateMember`✓ | Created by `invite.accept`, `organization.create`. | `team.tsx` (`updateMember`, `inviteUser`). | **No** |
 | `user` | disabled | **disabled** | `withProcedures`: `updateProfile`✓ | none | `settings/user/index.tsx` (`updateProfile`). | **No** |
 | `invite` | disabled | **disabled** | `withProcedures`: `accept`, `decline`, `revoke`✓ | `inviteUser` creates rows; `accept` also inserts `organizationUser` + `allowlist`. | `invitation.$id.tsx` (`accept`, `decline`), `onboarding/index.tsx` (`accept`), `team.tsx` (`revoke`). | **No** |
-| `integration` | owner or internal key | owner or internal key | `withMutations`: `fetchSlackChannels`† | `apps/slack` (`installation-store`, `utils`), `apps/discord` (`utils`), `apps/github` (`setup.ts`, settings flows via web). | Settings + redirect routes for slack/discord/github, `lib/integrations/activate.ts`, `organization/index.tsx` (`fetchSlackChannels`). | **No** |
+| `integration` | disabled | disabled | `withProcedures`: `connectInstallation`✓, `updateInstallation`✓, `fetchSlackChannels`† | `apps/slack` (`installation-store`, `utils`), `apps/discord` (`utils`), `apps/github` (`setup.ts`), settings flows via web. | Settings + redirect routes for slack/discord/github, `lib/integrations/activate.ts`, `organization/index.tsx` (`fetchSlackChannels`). | **No** |
 | `onboarding` | org members + internal key | org members + internal key | `withMutations`: `initialize`, `completeStep`, `skip`, `complete` | none | `use-onboarding.ts` (all four procedures; `initialize` via `fetchClient`). | **No** |
 | `documentationSource` | internal key only | internal key only | `withMutations`: `validateDocumentationSource`†, `addDocumentationSource`, `recrawlDocumentationSource`, `deleteDocumentationSource` | `apps/worker` `crawl-documentation.ts` (generic `update` via internal key). | `settings/organization/documentation.tsx` (all custom procedures). | **No** |
-| `externalEntity` | disabled | disabled | `withMutations`: `upsert`, `softDelete`, `syncFromGithub`† | `apps/github` `external-entity.ts` (`upsert`), `jobs/reconcile.ts` + webhooks (`softDelete`). | devtools `github-submenu.tsx` (`syncFromGithub`, dev-only). | **No** |
+| `externalEntity` | disabled | disabled | `withProcedures`: `upsert`, `softDelete`, `syncFromGithub`† | `apps/github` `external-entity.ts` (`upsert`), `jobs/reconcile.ts` + webhooks (`softDelete`). | devtools `github-submenu.tsx` (`syncFromGithub`, dev-only). | **No** |
 | `agentChat` | disabled | disabled | `withMutations`: `create`, `sendMessage`, `acceptDraft`, `dismissDraft`, `updateDraft` | `agentChatMessage` rows written inside `sendMessage` / streaming handlers. | `support-intelligence-chat.tsx`, playground `index.tsx`. | **No** |
 | `agentChatMessage` | disabled | disabled | none (written by `agentChat.sendMessage` / server stream) | same as above | none direct | n/a |
 | `autonomousAction` | disabled | disabled | `withProcedures`: `record`, `undo`, `seedFake`†, `clearFake`† | **API-internal** `db.autonomousAction.insert`: `signals/autonomous-receipts.ts` (bypasses `record` procedure). `apps/worker` uses `thread.executeAutonomousBundle` instead of `record` directly. | devtools `signals-submenu.tsx` (`seedFake`, `clearFake`). **No web caller for `undo` yet** despite optimistic handler. | **Partial** — `undo` handler exists, no UI caller. |
@@ -247,8 +247,8 @@ Procedures **already implemented** are marked ✓. Others are the LP-003–LP-00
 
 | Procedure | Route | Replaces | Web optimistic |
 | --- | --- | --- | --- |
-| `connectInstallation` | `integration` | generic `integration.insert` (slack/discord/github) | **no** — OAuth / `fetchClient` |
-| `updateInstallation` | `integration` | generic `integration.update` | **no** |
+| `connectInstallation` ✓ | `integration` | generic `integration.insert` (slack/discord/github) | **no** — OAuth / `fetchClient` |
+| `updateInstallation` ✓ | `integration` | generic `integration.update` | **no** |
 | `fetchSlackChannels` ✓ (query) | `integration` | — | — |
 | `upsert` / `softDelete` ✓ | `externalEntity` | — | **no** |
 | `syncFromGithub` ✓ (query) | `externalEntity` | — | — |
@@ -319,11 +319,11 @@ Parent checklist items (`LP-003`–`LP-010`) complete when all child slices unde
 
 | Slice | PR title (suggested) | Scope | Completion |
 | --- | --- | --- | --- |
-| [ ] **LP-006a** | `integration.connectInstallation` / `updateInstallation` (web) | `router/integration.ts` `withProcedures`, slack/discord/github settings, `lib/integrations/activate.ts` | No `mutate.integration.insert` / `.update` in web |
-| [ ] **LP-006b** | Slack integration app writes | `apps/slack` `installation-store.ts`, `utils.ts` | Slack app uses integration procedures |
-| [ ] **LP-006c** | Discord integration app writes | `apps/discord/lib/utils.ts` | Discord app uses integration procedures |
-| [ ] **LP-006d** | GitHub integration app writes | `apps/github/routes/setup.ts` | GitHub app uses integration procedures |
-| [ ] **LP-006e-lockdown** | Deny generic integration / externalEntity writes | `router/integration.ts`, `router/external-entity.ts` `withProcedures` rename | Procedures only; externalEntity already procedure-only |
+| [x] **LP-006a** | `integration.connectInstallation` / `updateInstallation` (web) | `router/integration.ts` `withProcedures`, slack/discord/github settings, `lib/integrations/activate.ts` | No `mutate.integration.insert` / `.update` in web |
+| [x] **LP-006b** | Slack integration app writes | `apps/slack` `installation-store.ts`, `utils.ts` | Slack app uses integration procedures |
+| [x] **LP-006c** | Discord integration app writes | `apps/discord/lib/utils.ts` | Discord app uses integration procedures |
+| [x] **LP-006d** | GitHub integration app writes | `apps/github/routes/setup.ts` | GitHub app uses integration procedures |
+| [x] **LP-006e-lockdown** | Deny generic integration / externalEntity writes | `router/integration.ts`, `router/external-entity.ts` `withProcedures` rename | Procedures only; externalEntity already procedure-only |
 
 ### LP-007 — `onboarding`, `documentationSource`, `agentChat`, `autonomousAction`
 
@@ -365,7 +365,7 @@ Cross-cutting cleanup after procedure migration. Can bundle router-file migratio
 - [x] LP-003: Migrate thread and message writes. Completion: all **LP-003a–o** slices done (including lockdown and hooks migration).
 - [x] LP-004: Migrate label, thread-label, and update writes. Completion: all **LP-004\*** slices done (labels already ✓).
 - [x] LP-005: Migrate organization, organization-user, invite, and user writes. Completion: all **LP-005a–e** slices done.
-- [ ] LP-006: Migrate integration and external-entity writes. Completion: all **LP-006a–e** slices done.
+- [x] LP-006: Migrate integration and external-entity writes. Completion: all **LP-006a–e** slices done.
 - [ ] LP-007: Migrate onboarding, documentation-source, agent-chat, and autonomous-action writes. Completion: all **LP-007a–e** slices done.
 - [ ] LP-008: Lock down generic route permissions. Completion: **LP-008** audit slice done.
 - [ ] LP-009: Verify the migration end-to-end. Completion: **LP-009a–b** slices done.
@@ -402,7 +402,7 @@ Cross-cutting cleanup after procedure migration. Can bundle router-file migratio
 - 2026-06-24 (LP-005b): `organizationUser.updateMember` — owner auth via `authorize`; optional `role` / `enabled`; blocks self role change or removal. Renamed builder to `withProcedures`.
 - 2026-06-24 (LP-005c): `user.updateProfile` — self or internal key; optional `name`, `email`, `image`. Added `withProcedures` on user route.
 - 2026-06-24 (LP-005d): `invite.revoke` — owner auth; sets `active: false`. Renamed invite builder to `withProcedures`.
-- 2026-06-24 (LP-005e): Denied generic `insert`/`update` on `organization`, `organizationUser`, `user`, `invite` collection routes. Boot migrations and procedures continue using direct `db.*` writes.
+- 2026-06-24 (LP-006a–e): Added `integration.connectInstallation` / `updateInstallation` procedures in new `router/integration.ts` (owner auth via `authorize`; internal key bypass for slack/discord/github bots). Extracted integration route from `router.ts`; denied generic `insert`/`update`. Renamed `externalEntity` builder to `withProcedures`. Migrated all web integration settings/redirect/activate flows and slack `installation-store`/`utils`, discord `utils`, github `setup.ts` off generic `mutate.integration.insert` / `.update`. Intentional: no optimistic handlers (OAuth / awaited `fetchClient`).
 
 ## PR Feedback
 
@@ -437,6 +437,7 @@ Cross-cutting cleanup after procedure migration. Can bundle router-file migratio
 - 2026-06-24 (LP-004e): `bun run --filter api typecheck` pass. Ripgrep: zero `mutate.update.insert` / `mutate.update.update` under `apps/web`, `apps/slack`, `apps/discord`, `apps/github`; slack/discord use `update.markReplicated` only. No runtime smoke test.
 - 2026-06-24 (LP-005a): `bun run --filter api typecheck` and `bun run --filter web typecheck` pass. Ripgrep: zero `mutate.organization.update(` in `apps/web`. No runtime smoke test for org profile, digest, or custom-instructions settings forms.
 - 2026-06-24 (LP-005b–e): `bun run --filter api typecheck` and `bun run --filter web typecheck` pass. Ripgrep: zero `mutate.(organization|organizationUser|user|invite).(update|insert)(` under `apps/web`, `apps/api`, `apps/slack`, `apps/discord`, `apps/github`. No runtime smoke test for team role/remove/revoke or user profile save.
+- 2026-06-24 (LP-006a–e): `bun run --filter api typecheck`, `bun run --filter web typecheck`, `apps/discord` and `apps/github` `bun run typecheck` pass. `apps/slack` `bunx tsc --noEmit` blocked on missing `@types/node` (pre-existing). Ripgrep: zero `mutate.integration.insert` / `mutate.integration.update` under `apps/`. Generic `integration` `insert`/`update` denied in `router/integration.ts`; `externalEntity` uses `withProcedures`. No runtime smoke test for OAuth connect flows or slack installation-store.
 
 ## Session Log
 
@@ -470,7 +471,8 @@ Cross-cutting cleanup after procedure migration. Can bundle router-file migratio
 - 2026-06-24 (LP-004e): Denied generic `insert`/`update` on `router/update.ts` (`insert: () => false`, `update.preMutation/postMutation: () => false`). Confirmed no remaining product/integration generic callers — GitHub webhooks use `thread.setStatus`; slack/discord use `update.markReplicated`. Files: `router/update.ts`.
 - 2026-06-24 (LP-005a): Added `organization.updateSettings` procedure (owner auth via `authorize`); renamed organization builder to `withProcedures`. Migrated web org profile, digest, and custom-instructions forms. Files: `router.ts`, `settings/organization/index.tsx`, `support-intelligence.tsx`.
 - 2026-06-24 (LP-005b–e): Added `organizationUser.updateMember`, `user.updateProfile`, `invite.revoke`; renamed `organizationUser` and `invite` builders to `withProcedures`; added `withProcedures` on `user`. Migrated `team.tsx` and `settings/user/index.tsx`. Denied generic writes on all four org-family routes. Files: `router.ts`, `team.tsx`, `settings/user/index.tsx`.
+- 2026-06-24 (LP-006a–e): Added `integration.connectInstallation` / `updateInstallation` in `router/integration.ts`; extracted integration route from `router.ts`; denied generic writes; renamed `externalEntity` to `withProcedures`. Migrated web slack/discord/github settings + redirects + `activate.ts`; slack `installation-store.ts`/`utils.ts`; discord `utils.ts`; github `setup.ts`.
 
 ## Handoff
 
-Next action: Ship **LP-006a** — add `integration.connectInstallation` / `updateInstallation` procedures in `apps/api/src/live-state/router.ts` (rename integration builder to `withProcedures`), migrate web integration connect/update flows off generic `mutate.integration.insert` / `.update` (`slack`, `discord`, `github` settings, `lib/integrations/activate.ts`, `organization/index.tsx`). Ripgrep target: zero `mutate.integration.insert` / `mutate.integration.update` in `apps/web`.
+Next action: Ship **LP-007a** — rename onboarding route builder to `withProcedures` in `apps/api/src/live-state/router/onboarding.ts` and deny generic `onboarding.insert` / `update` (web already uses procedures via `fetchClient` / `mutate`). Ripgrep target: zero generic onboarding writes outside procedures.


### PR DESCRIPTION
## Summary

- Add `integration.connectInstallation` and `integration.updateInstallation` procedures in a new `router/integration.ts` module with owner auth via `authorize`.
- Migrate all web integration settings/redirect/activate flows and slack/discord/github integration apps off generic `mutate.integration.insert` / `.update`.
- Deny generic `insert`/`update` on the integration collection route; rename `externalEntity` builder to `withProcedures`.

## Test plan

- [x] `bun run --filter api typecheck`
- [x] `bun run --filter web typecheck`
- [x] `apps/discord` and `apps/github` typecheck
- [x] Ripgrep: zero `mutate.integration.insert` / `.update` under `apps/`
- [ ] Manual smoke: Slack/Discord/GitHub OAuth connect flows in settings


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dedicated integration procedures, scopes integration reads to the caller’s org, and locks down generic writes. Completes LP-006 by migrating Slack/Discord/GitHub to `integration.connectInstallation` and `integration.updateInstallation`.

- New Features
  - Added `integration.connectInstallation` and `integration.updateInstallation` (owner-auth) in a new `integration` router.
  - Scoped integration reads to the caller’s org; moved `fetchSlackChannels` here with Slack config JSON validation.
  - Made `connectInstallation` idempotent (transactional find-or-update); switched builders to `withProcedures` (incl. `externalEntity`).

- Migration
  - Replaced all `mutate.integration.insert`/`.update` calls in web, `apps/slack`, `apps/discord`, and `apps/github` with the new procedures; fixed settings UI to pass `integrationId`.
  - Denied generic `integration` `insert`/`update`; updated docs to mark LP-006 complete and set next checkpoint to LP-007.

<sup>Written for commit fefdafe7a560ff8111b4fa9d0516af2684265195. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #304
2. **#305** 👈 current
3. #306
<!-- stack:links:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new, more consistent way to connect and manage Slack, Discord, and GitHub integrations.
  * Improved integration setup flows so new connections and existing connections use the same experience.

* **Bug Fixes**
  * Fixed integration updates so changes like enabling, disabling, and syncing are saved more reliably.
  * Improved redirect and callback handling for provider setup flows.

* **Documentation**
  * Updated the integration migration plan and completion status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->