### PR TITLE
feat(web): render inline suggestions on the thread toolbar

### DIFF
--- a/apps/api/src/lib/signals/thread-procedures.ts
+++ b/apps/api/src/lib/signals/thread-procedures.ts
@@ -109,6 +109,32 @@ const removeInlineSuggestion = (
 ): InlineSuggestion[] =>
   suggestions.filter((suggestion) => suggestion.id !== suggestionId);
 
+// Atomically drops a suggestion from thread.inlineSuggestions. The read-filter-
+// write runs inside a single transaction so concurrent accepts/dismisses (a
+// batch loop, or another tab) can't each read the same array and clobber one
+// another's removals — the client-side serialization is only a courtesy on top
+// of this. Returns whether the suggestion was present.
+const removeInlineSuggestionAtomically = async (
+  db: TransactionalDb,
+  args: { threadId: string; organizationId: string; suggestionId: string },
+): Promise<boolean> => {
+  let existed = false;
+  await db.transaction(async ({ trx }) => {
+    const thread = await trx.findOne(schema.thread, args.threadId);
+    if (!thread || thread.organizationId !== args.organizationId) {
+      throw new Error("THREAD_NOT_FOUND");
+    }
+    const current = thread.inlineSuggestions ?? [];
+    existed = current.some((s) => s.id === args.suggestionId);
+    if (existed) {
+      await trx.update(schema.thread, args.threadId, {
+        inlineSuggestions: removeInlineSuggestion(current, args.suggestionId),
+      });
+    }
+  });
+  return existed;
+};
+
 export const runExecuteAutonomousBundle = async (
   db: SignalExecutionDb,
   input: z.infer<typeof executeAutonomousBundleInputSchema>,
@@ -135,7 +161,8 @@ export const runAcceptRead = async (
 ): Promise<ExecutionResult> => {
   authorize(req, { organizationId: input.organizationId });
 
-  const { userId: actorUserId, userName: actorUserName } = getWorkspaceActor(req);
+  const { userId: actorUserId, userName: actorUserName } =
+    getWorkspaceActor(req);
 
   const thread = await loadThread(db, input.threadId, input.organizationId);
   if (!thread.agentRead) {
@@ -209,7 +236,8 @@ export const runAcceptInlineSuggestion = async (
 ): Promise<ExecutionResult> => {
   authorize(req, { organizationId: input.organizationId });
 
-  const { userId: actorUserId, userName: actorUserName } = getWorkspaceActor(req);
+  const { userId: actorUserId, userName: actorUserName } =
+    getWorkspaceActor(req);
 
   const thread = await loadThread(db, input.threadId, input.organizationId);
   const suggestions = thread.inlineSuggestions ?? [];
@@ -229,8 +257,10 @@ export const runAcceptInlineSuggestion = async (
   const result = await executeBundle([suggestion.action], registry, ctx);
 
   if (!result.failed) {
-    await db.thread.update(input.threadId, {
-      inlineSuggestions: removeInlineSuggestion(suggestions, suggestion.id),
+    await removeInlineSuggestionAtomically(db, {
+      threadId: input.threadId,
+      organizationId: input.organizationId,
+      suggestionId: suggestion.id,
     });
   }
 
@@ -244,16 +274,14 @@ export const runDismissInlineSuggestion = async (
 ): Promise<{ dismissed: true }> => {
   authorize(req, { organizationId: input.organizationId });
 
-  const thread = await loadThread(db, input.threadId, input.organizationId);
-  const suggestions = thread.inlineSuggestions ?? [];
-  const suggestion = suggestions.find((s) => s.id === input.suggestionId);
-  if (!suggestion) {
+  const existed = await removeInlineSuggestionAtomically(db, {
+    threadId: input.threadId,
+    organizationId: input.organizationId,
+    suggestionId: input.suggestionId,
+  });
+  if (!existed) {
     throw new Error("INLINE_SUGGESTION_NOT_FOUND");
   }
-
-  await db.thread.update(input.threadId, {
-    inlineSuggestions: removeInlineSuggestion(suggestions, suggestion.id),
-  });
 
   return { dismissed: true };
 };

--- a/apps/web/src/components/threads/thread-toolbar/quick-actions.tsx
+++ b/apps/web/src/components/threads/thread-toolbar/quick-actions.tsx
@@ -202,9 +202,10 @@ export const QuickActionsPanel = ({
     });
   };
 
-  // Accept/dismiss the batch serially: each mutation read-modify-writes the same
-  // thread.inlineSuggestions JSON array server-side, so firing them concurrently
-  // would let writes clobber each other and leave suggestions behind.
+  // Accept/dismiss the batch serially so this loop doesn't pile redundant
+  // requests against the same thread. The server-side removal is transactional,
+  // so cross-tab concurrency is already safe; awaiting here just avoids
+  // self-inflicted contention.
   const handleAcceptAllLabels = async () => {
     const labels = suggestedLabels ?? [];
 

--- a/apps/web/src/components/threads/thread-toolbar/quick-actions.tsx
+++ b/apps/web/src/components/threads/thread-toolbar/quick-actions.tsx
@@ -25,7 +25,7 @@ import {
   usePendingLabelSuggestions,
   usePendingStatusSuggestions,
 } from "~/components/threads/thread-toolbar/support-intelligence";
-import { mutate, query } from "~/lib/live-state";
+import { mutate } from "~/lib/live-state";
 import { buildThreadParam } from "~/utils/thread";
 
 type UseQuickActionsSuggestionsProps = {
@@ -172,18 +172,18 @@ export const QuickActionsPanel = ({
   // Accepting an inline suggestion executes its action (attach label / set
   // status) and removes it from thread.inlineSuggestions server-side; dismissing
   // just removes it. Both are no-ops without an organization scope.
-  const acceptSuggestion = (suggestionId: string) => {
+  const acceptSuggestion = async (suggestionId: string) => {
     if (!organizationId) return;
-    mutate.thread.acceptInlineSuggestion({
+    await mutate.thread.acceptInlineSuggestion({
       threadId,
       organizationId,
       suggestionId,
     });
   };
 
-  const dismissSuggestion = (suggestionId: string) => {
+  const dismissSuggestion = async (suggestionId: string) => {
     if (!organizationId) return;
-    mutate.thread.dismissInlineSuggestion({
+    await mutate.thread.dismissInlineSuggestion({
       threadId,
       organizationId,
       suggestionId,
@@ -202,11 +202,14 @@ export const QuickActionsPanel = ({
     });
   };
 
-  const handleAcceptAllLabels = () => {
+  // Accept/dismiss the batch serially: each mutation read-modify-writes the same
+  // thread.inlineSuggestions JSON array server-side, so firing them concurrently
+  // would let writes clobber each other and leave suggestions behind.
+  const handleAcceptAllLabels = async () => {
     const labels = suggestedLabels ?? [];
 
     for (const label of labels) {
-      acceptSuggestion(label.suggestionId);
+      await acceptSuggestion(label.suggestionId);
     }
 
     captureThreadEvent("support_intelligence:all_labels_accepted", {
@@ -214,11 +217,11 @@ export const QuickActionsPanel = ({
     });
   };
 
-  const handleDismissAllLabels = () => {
+  const handleDismissAllLabels = async () => {
     const labels = suggestedLabels ?? [];
 
     for (const label of labels) {
-      dismissSuggestion(label.suggestionId);
+      await dismissSuggestion(label.suggestionId);
     }
 
     captureThreadEvent("support_intelligence:all_labels_dismissed", {
@@ -226,7 +229,7 @@ export const QuickActionsPanel = ({
     });
   };
 
-  const handleAcceptStatus = () => {
+  const handleAcceptStatus = async () => {
     if (!statusSuggestion) return;
 
     const oldStatus = currentStatus;
@@ -234,7 +237,7 @@ export const QuickActionsPanel = ({
     const oldStatusLabel = statusValues[oldStatus]?.label ?? "Unknown";
     const newStatusLabel = statusSuggestion.label;
 
-    acceptSuggestion(statusSuggestion.suggestionId);
+    await acceptSuggestion(statusSuggestion.suggestionId);
 
     captureThreadEvent("support_intelligence:status_accepted", {
       old_status: oldStatus,
@@ -244,10 +247,10 @@ export const QuickActionsPanel = ({
     });
   };
 
-  const handleDismissStatus = () => {
+  const handleDismissStatus = async () => {
     if (!statusSuggestion) return;
 
-    dismissSuggestion(statusSuggestion.suggestionId);
+    await dismissSuggestion(statusSuggestion.suggestionId);
 
     captureThreadEvent("support_intelligence:status_dismissed", {
       suggested_status: statusSuggestion.suggestedStatus,
@@ -286,15 +289,15 @@ export const QuickActionsPanel = ({
     });
   };
 
-  const handleAcceptAll = () => {
-    if (hasStatusSuggestion) handleAcceptStatus();
-    if (hasLabelSuggestions) handleAcceptAllLabels();
+  const handleAcceptAll = async () => {
+    if (hasStatusSuggestion) await handleAcceptStatus();
+    if (hasLabelSuggestions) await handleAcceptAllLabels();
     if (hasDuplicateSuggestion) handleAcceptDuplicate();
   };
 
-  const handleDismissAll = () => {
-    if (hasStatusSuggestion) handleDismissStatus();
-    if (hasLabelSuggestions) handleDismissAllLabels();
+  const handleDismissAll = async () => {
+    if (hasStatusSuggestion) await handleDismissStatus();
+    if (hasLabelSuggestions) await handleDismissAllLabels();
     if (hasDuplicateSuggestion) handleDismissDuplicate();
   };
 

--- a/apps/web/src/components/threads/thread-toolbar/quick-actions.tsx
+++ b/apps/web/src/components/threads/thread-toolbar/quick-actions.tsx
@@ -19,7 +19,6 @@ import { formatRelativeTime } from "@workspace/ui/lib/utils";
 import { Check, ChevronDown, CircleUser, X, Zap } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ulid } from "ulid";
 import { ThreadChip } from "~/components/chips";
 import {
   usePendingDuplicateSuggestions,
@@ -42,7 +41,7 @@ export const useQuickActionsSuggestions = ({
   threadLabels,
   currentStatus,
 }: UseQuickActionsSuggestionsProps) => {
-  const { suggestedLabels, suggestions } = usePendingLabelSuggestions({
+  const { suggestedLabels } = usePendingLabelSuggestions({
     threadId,
     organizationId,
     threadLabels,
@@ -68,7 +67,6 @@ export const useQuickActionsSuggestions = ({
 
   return {
     suggestedLabels,
-    suggestions,
     statusSuggestion,
     duplicateSuggestion,
     hasLabelSuggestions,
@@ -97,16 +95,6 @@ type QuickActionsPanelProps = {
   suggestionsData: QuickActionsSuggestionsData;
 };
 
-const getSuggestionReasoning = (metadataStr: string | null): string | null => {
-  if (!metadataStr) return null;
-  try {
-    const metadata = JSON.parse(metadataStr) as { reasoning?: string };
-    return metadata.reasoning ?? null;
-  } catch {
-    return null;
-  }
-};
-
 type HoverCardPayload = {
   element: React.ReactNode;
   subtitle: string;
@@ -129,7 +117,6 @@ export const QuickActionsPanel = ({
 }: QuickActionsPanelProps) => {
   const {
     suggestedLabels,
-    suggestions,
     statusSuggestion,
     duplicateSuggestion,
     hasLabelSuggestions,
@@ -182,78 +169,73 @@ export const QuickActionsPanel = ({
     setIsCollapsed(newState);
   };
 
-  // TODO(signals-overhaul issue 10): rewrite against thread.inlineSuggestions.
-  // The suggestion table was dropped in issue 02; this is a no-op until the
-  // inline-suggestion mutations land.
-  const updateSuggestionForLabel = (_labelId: string, _accepted: boolean) => {};
+  // Accepting an inline suggestion executes its action (attach label / set
+  // status) and removes it from thread.inlineSuggestions server-side; dismissing
+  // just removes it. Both are no-ops without an organization scope.
+  const acceptSuggestion = (suggestionId: string) => {
+    if (!organizationId) return;
+    mutate.thread.acceptInlineSuggestion({
+      threadId,
+      organizationId,
+      suggestionId,
+    });
+  };
+
+  const dismissSuggestion = (suggestionId: string) => {
+    if (!organizationId) return;
+    mutate.thread.dismissInlineSuggestion({
+      threadId,
+      organizationId,
+      suggestionId,
+    });
+  };
 
   const handleAcceptLabel = (labelId: string) => {
     const label = suggestedLabels?.find((l) => l.id === labelId);
+    if (!label) return;
 
-    mutate.label.attachToThread({
-      threadId,
-      labelId,
-      id: ulid().toLowerCase(),
-    });
-
-    updateSuggestionForLabel(labelId, true);
+    acceptSuggestion(label.suggestionId);
 
     captureThreadEvent("support_intelligence:label_accepted", {
       label_id: labelId,
-      label_name: label?.name,
+      label_name: label.name,
     });
   };
 
   const handleAcceptAllLabels = () => {
-    const labelIds = suggestedLabels?.map((l) => l.id) ?? [];
+    const labels = suggestedLabels ?? [];
 
-    for (const label of suggestedLabels ?? []) {
-      const labelId = label.id;
-
-      mutate.label.attachToThread({
-        threadId,
-        labelId: label.id,
-        id: ulid().toLowerCase(),
-      });
-
-      updateSuggestionForLabel(labelId, true);
+    for (const label of labels) {
+      acceptSuggestion(label.suggestionId);
     }
 
     captureThreadEvent("support_intelligence:all_labels_accepted", {
-      label_count: labelIds.length,
+      label_count: labels.length,
     });
   };
 
   const handleDismissAllLabels = () => {
-    const labelIds = suggestedLabels?.map((l) => l.id) ?? [];
+    const labels = suggestedLabels ?? [];
 
-    for (const labelId of labelIds) {
-      updateSuggestionForLabel(labelId, false);
+    for (const label of labels) {
+      dismissSuggestion(label.suggestionId);
     }
 
     captureThreadEvent("support_intelligence:all_labels_dismissed", {
-      label_count: labelIds.length,
+      label_count: labels.length,
     });
   };
 
   const handleAcceptStatus = () => {
-    if (!statusSuggestion || !organizationId) return;
+    if (!statusSuggestion) return;
 
     const oldStatus = currentStatus;
     const newStatus = statusSuggestion.suggestedStatus;
     const oldStatusLabel = statusValues[oldStatus]?.label ?? "Unknown";
     const newStatusLabel = statusSuggestion.label;
 
-    mutate.thread.setStatus({
-      threadId,
-      organizationId,
-      status: newStatus,
-      userId: user.id,
-      userName: user.name,
-      source: "support_intelligence",
-    });
+    acceptSuggestion(statusSuggestion.suggestionId);
 
-    // TODO(signals-overhaul issue 10): record acceptance on inlineSuggestions.
     captureThreadEvent("support_intelligence:status_accepted", {
       old_status: oldStatus,
       new_status: newStatus,
@@ -265,7 +247,8 @@ export const QuickActionsPanel = ({
   const handleDismissStatus = () => {
     if (!statusSuggestion) return;
 
-    // TODO(signals-overhaul issue 10): record dismissal on inlineSuggestions.
+    dismissSuggestion(statusSuggestion.suggestionId);
+
     captureThreadEvent("support_intelligence:status_dismissed", {
       suggested_status: statusSuggestion.suggestedStatus,
       suggested_status_label: statusSuggestion.label,
@@ -376,43 +359,37 @@ export const QuickActionsPanel = ({
                 <>
                   <div className="text-foreground-secondary">Suggestions</div>
                   <div className="flex gap-2 items-center flex-wrap group">
-                    {statusSuggestion &&
-                      (() => {
-                        const reasoning = getSuggestionReasoning(
-                          statusSuggestion.suggestion.metadataStr,
-                        );
-                        return (
-                          <HoverCardTrigger
-                            render={
-                              <ActionButton
-                                variant="ghost"
-                                size="sm"
-                                className="border border-dashed border-input dark:hover:bg-foreground-tertiary/15"
-                                onClick={handleAcceptStatus}
+                    {statusSuggestion && (
+                      <HoverCardTrigger
+                        render={
+                          <ActionButton
+                            variant="ghost"
+                            size="sm"
+                            className="border border-dashed border-input dark:hover:bg-foreground-tertiary/15"
+                            onClick={handleAcceptStatus}
+                          />
+                        }
+                        handle={hoverCardHandle}
+                        payload={{
+                          subtitle: "Suggested status",
+                          element: (
+                            <div className="border border-dashed flex items-center w-fit h-6 rounded-sm gap-1.5 px-2 has-[>svg:first-child]:pl-1.5 has-[>svg:last-child]:pr-1.5 text-xs bg-foreground-tertiary/15">
+                              <StatusIndicator
+                                status={statusSuggestion.suggestedStatus}
                               />
-                            }
-                            handle={hoverCardHandle}
-                            payload={{
-                              subtitle: "Suggested status",
-                              element: (
-                                <div className="border border-dashed flex items-center w-fit h-6 rounded-sm gap-1.5 px-2 has-[>svg:first-child]:pl-1.5 has-[>svg:last-child]:pr-1.5 text-xs bg-foreground-tertiary/15">
-                                  <StatusIndicator
-                                    status={statusSuggestion.suggestedStatus}
-                                  />
-                                  {statusSuggestion.label}
-                                </div>
-                              ),
-                              reasoning: reasoning,
-                              handleAccept: handleAcceptStatus,
-                            }}
-                          >
-                            <StatusIndicator
-                              status={statusSuggestion.suggestedStatus}
-                            />
-                            {statusSuggestion.label}
-                          </HoverCardTrigger>
-                        );
-                      })()}
+                              {statusSuggestion.label}
+                            </div>
+                          ),
+                          reasoning: null,
+                          handleAccept: handleAcceptStatus,
+                        }}
+                      >
+                        <StatusIndicator
+                          status={statusSuggestion.suggestedStatus}
+                        />
+                        {statusSuggestion.label}
+                      </HoverCardTrigger>
+                    )}
                     {suggestedLabels?.map((label) => {
                       return (
                         <HoverCardTrigger
@@ -496,7 +473,9 @@ export const QuickActionsPanel = ({
                               <Link
                                 to="/app/threads/$id"
                                 params={{
-                                  id: buildThreadParam(duplicateSuggestion.thread),
+                                  id: buildThreadParam(
+                                    duplicateSuggestion.thread,
+                                  ),
                                 }}
                                 className="text-sm font-medium text-foreground hover:underline"
                               >

--- a/apps/web/src/components/threads/thread-toolbar/support-intelligence.tsx
+++ b/apps/web/src/components/threads/thread-toolbar/support-intelligence.tsx
@@ -62,12 +62,15 @@ export const usePendingLabelSuggestions = ({
     );
 
     const result: LabelSuggestion[] = [];
+    const seenLabelIds = new Set<string>();
     for (const suggestion of suggestions) {
       if (suggestion.action.kind !== "apply_label") continue;
       const labelId = suggestion.action.labelId;
       if (attachedLabelIds.has(labelId)) continue;
+      if (seenLabelIds.has(labelId)) continue;
       const label = labelById.get(labelId);
       if (!label) continue;
+      seenLabelIds.add(labelId);
       result.push({
         suggestionId: suggestion.id,
         id: label.id,

--- a/apps/web/src/components/threads/thread-toolbar/support-intelligence.tsx
+++ b/apps/web/src/components/threads/thread-toolbar/support-intelligence.tsx
@@ -1,17 +1,40 @@
-// TODO(signals-overhaul issue 10): rewrite against thread.agentRead /
-// thread.inlineSuggestions. The suggestion table was dropped in issue 02;
-// these hooks return empty data and Suggestions renders null until then.
+// Reads the inline-track suggestions off `thread.inlineSuggestions` (the
+// suggestion table was dropped in the signals overhaul) and shapes them for the
+// quick-actions toolbar. Only the inline-track kinds surface here — `apply_label`
+// and `set_status`; synthesis-track reads (reply / duplicate / close) render in
+// the signals feed via ThreadReadCard.
 
 import type { InferLiveObject } from "@live-state/sync";
+import { useLiveQuery } from "@live-state/sync/client";
+import { STATUS_LABELS } from "@workspace/schemas/signals";
+import { statusValues } from "@workspace/ui/components/indicator";
 import type { schema } from "api/schema";
+import { useMemo } from "react";
+import { query } from "~/lib/live-state";
 
-type SuggestionRow = {
+export type LabelSuggestion = {
+  suggestionId: string;
   id: string;
-  relatedEntityId: string | null;
-  active: boolean;
-  accepted: boolean;
-  resultsStr: string | null;
-  metadataStr: string | null;
+  name: string;
+  color: string;
+};
+
+export type StatusSuggestionData = {
+  suggestionId: string;
+  suggestedStatus: number;
+  label: string;
+} | null;
+
+const useInlineSuggestions = (threadId: string) => {
+  const threads = useLiveQuery(query.thread.where({ id: threadId }));
+  const thread = threads?.[0];
+  return useMemo(
+    () =>
+      (thread?.inlineSuggestions ?? []).filter(
+        (suggestion) => !suggestion.dismissedAt,
+      ),
+    [thread?.inlineSuggestions],
+  );
 };
 
 type UsePendingLabelSuggestionsProps = {
@@ -20,15 +43,42 @@ type UsePendingLabelSuggestionsProps = {
   threadLabels: Array<{ id: string; label: { id: string } }> | undefined;
 };
 
-export const usePendingLabelSuggestions = (
-  _props: UsePendingLabelSuggestionsProps,
-) => {
-  return {
-    suggestedLabels: undefined as
-      | Array<{ id: string; name: string; color: string }>
-      | undefined,
-    suggestions: undefined as SuggestionRow[] | undefined,
-  };
+export const usePendingLabelSuggestions = ({
+  threadId,
+  organizationId,
+  threadLabels,
+}: UsePendingLabelSuggestionsProps) => {
+  const suggestions = useInlineSuggestions(threadId);
+  const labels = useLiveQuery(
+    query.label.where({ organizationId, enabled: true }),
+  );
+
+  const suggestedLabels = useMemo<LabelSuggestion[] | undefined>(() => {
+    if (!labels) return undefined;
+
+    const labelById = new Map(labels.map((label) => [label.id, label]));
+    const attachedLabelIds = new Set(
+      (threadLabels ?? []).map((threadLabel) => threadLabel.label.id),
+    );
+
+    const result: LabelSuggestion[] = [];
+    for (const suggestion of suggestions) {
+      if (suggestion.action.kind !== "apply_label") continue;
+      const labelId = suggestion.action.labelId;
+      if (attachedLabelIds.has(labelId)) continue;
+      const label = labelById.get(labelId);
+      if (!label) continue;
+      result.push({
+        suggestionId: suggestion.id,
+        id: label.id,
+        name: label.name,
+        color: label.color,
+      });
+    }
+    return result;
+  }, [labels, suggestions, threadLabels]);
+
+  return { suggestedLabels };
 };
 
 type UsePendingStatusSuggestionsProps = {
@@ -37,19 +87,30 @@ type UsePendingStatusSuggestionsProps = {
   currentStatus: number;
 };
 
-type StatusSuggestionData = {
-  suggestion: SuggestionRow;
-  suggestedStatus: number;
-  label: string;
-} | null;
+const statusLabel = (status: number): string =>
+  statusValues[status]?.label ?? STATUS_LABELS[status] ?? `Status ${status}`;
 
-export const usePendingStatusSuggestions = (
-  _props: UsePendingStatusSuggestionsProps,
-) => {
-  return {
-    statusSuggestion: null as StatusSuggestionData,
-    suggestion: undefined as SuggestionRow | undefined,
-  };
+export const usePendingStatusSuggestions = ({
+  threadId,
+  currentStatus,
+}: UsePendingStatusSuggestionsProps) => {
+  const suggestions = useInlineSuggestions(threadId);
+
+  const statusSuggestion = useMemo<StatusSuggestionData>(() => {
+    for (const suggestion of suggestions) {
+      if (suggestion.action.kind !== "set_status") continue;
+      const suggestedStatus = suggestion.action.status;
+      if (suggestedStatus === currentStatus) continue;
+      return {
+        suggestionId: suggestion.id,
+        suggestedStatus,
+        label: statusLabel(suggestedStatus),
+      };
+    }
+    return null;
+  }, [suggestions, currentStatus]);
+
+  return { statusSuggestion };
 };
 
 type UsePendingDuplicateSuggestionsProps = {
@@ -62,41 +123,19 @@ type DuplicateThread = InferLiveObject<
   { author: { include: { user: true } }; assignedUser: true }
 >;
 
-type DuplicateSuggestionData = {
-  suggestion: SuggestionRow;
+export type DuplicateSuggestionData = {
+  suggestionId: string;
   duplicateThreadId: string;
   confidence: string | null;
   reason: string | null;
   thread: DuplicateThread | null;
 } | null;
 
+// Duplicate detection moved to the synthesis track (rendered in the signals
+// feed as a `mark_duplicate` agent read), so no duplicate surfaces on the
+// inline toolbar. Kept as a no-op hook so the quick-actions layout stays intact.
 export const usePendingDuplicateSuggestions = (
   _props: UsePendingDuplicateSuggestionsProps,
 ) => {
-  return {
-    duplicateSuggestion: null as DuplicateSuggestionData,
-    suggestion: undefined as SuggestionRow | undefined,
-  };
-};
-
-type SuggestionsProps = {
-  threadId: string;
-  organizationId: string | undefined;
-  suggestedLabels:
-    | Array<{ id: string; name: string; color: string }>
-    | undefined;
-  threadLabels: Array<{ id: string; label: { id: string } }> | undefined;
-  suggestions: SuggestionRow[] | undefined;
-  statusSuggestion: StatusSuggestionData;
-  duplicateSuggestion: DuplicateSuggestionData;
-  currentStatus: number;
-  user: { id: string; name: string };
-  captureThreadEvent: (
-    eventName: string,
-    properties?: Record<string, unknown>,
-  ) => void;
-};
-
-export const Suggestions = (_props: SuggestionsProps) => {
-  return null;
+  return { duplicateSuggestion: null as DuplicateSuggestionData };
 };


### PR DESCRIPTION
## What

Wires the thread toolbar's quick-actions suggestions against `thread.inlineSuggestions`. Previously these hooks were inert stubs returning empty data (the old `suggestion` table was dropped in the signals overhaul), so nothing rendered on the toolbar.

## Changes

**`support-intelligence.tsx`** — replaced the stubs with real hooks:
- `usePendingLabelSuggestions` reads `thread.inlineSuggestions` via `useLiveQuery`, keeps non-dismissed `apply_label` suggestions, drops labels already attached to the thread, and joins `query.label` to resolve name/color. Each carries its `suggestionId`.
- `usePendingStatusSuggestions` picks the first non-dismissed `set_status` suggestion whose status differs from the current one.
- `usePendingDuplicateSuggestions` returns `null` — `mark_duplicate` moved to the synthesis track (signals feed), so nothing surfaces on the toolbar. Kept as a typed no-op so the existing duplicate JSX still typechecks.

**`quick-actions.tsx`** — handlers now call the existing API mutations:
- Accept → `mutate.thread.acceptInlineSuggestion`, which executes the action (attach label / set status) **and** prunes the suggestion server-side.
- Dismiss → `mutate.thread.dismissInlineSuggestion`.
- Removed the old `attachToThread` / `setStatus` paths, the no-op `updateSuggestionForLabel`, the `getSuggestionReasoning` helper, and the unused `ulid` import. Analytics events are preserved.

This completes the "issue 10" TODO left across `quick-actions.tsx` / `support-intelligence.tsx`.

## Testing

- `bun run --filter web typecheck` passes.
- Biome passes (one pre-existing unused-param warning on `QuickActionsPanel`, untouched).
- Not yet verified end-to-end in the running app against a thread with populated `inlineSuggestions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders inline quick-action suggestions on the thread toolbar by wiring to `thread.inlineSuggestions`. Accepting or dismissing runs the action and removes the suggestion server-side.

- **New Features**
  - Read `apply_label` and `set_status` from `thread.inlineSuggestions` via `useLiveQuery`, ignoring dismissed entries and labels already attached; resolve label name/color via `query.label`; deduplicate label suggestions by label id.
  - Accept with `mutate.thread.acceptInlineSuggestion` and dismiss with `mutate.thread.dismissInlineSuggestion`; “accept all”/“dismiss all” run sequentially.
  - Duplicate suggestions no longer surface on the toolbar (moved to the synthesis track); kept a typed no-op to preserve layout.
  - Replaced stub hooks with real ones and removed old label/status mutation paths; analytics events are unchanged.

- **Bug Fixes**
  - Inline-suggestion removal is now atomic in the API, preventing concurrent accept/dismiss calls from clobbering each other.

<sup>Written for commit c1fccd32535e284b265c65abe86b5ea0cd24b58b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quick actions now apply label and status changes using live inline suggestions from the thread toolbar.
  * Suggested labels/status are surfaced only when they still match the current thread state.

* **Bug Fixes**
  * Accepting/dismissing suggestions from the toolbar now updates more consistently, including bulk accept/dismiss flows.

* **UX Improvements**
  * Status suggestion hover cards no longer show supplemental reasoning.
  * Duplicate-thread suggestions are no longer shown in the quick-actions panel to reduce clutter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->