### PR TITLE
feat(web): restyle signal card inline suggestions as quick suggestions

### DIFF
--- a/apps/web/src/components/signals/action-row/thread-read-card.tsx
+++ b/apps/web/src/components/signals/action-row/thread-read-card.tsx
@@ -424,7 +424,14 @@ function formatErrorMessage(error: unknown): string {
 
 export function ThreadReadCard({ thread, ctx }: Props) {
   const [busyKey, setBusyKey] = useState<string | null>(null);
-  const [replyEditorOpen, setReplyEditorOpen] = useState(false);
+  // Which reply is being previewed/edited: the primary bundle's reply, or a
+  // specific alternative reply. Both open the same inline draft editor.
+  const [replyTarget, setReplyTarget] = useState<
+    { kind: "primary" } | { kind: "alternative"; index: number } | null
+  >(null);
+  const replyEditorOpen = replyTarget !== null;
+  const editingPrimaryReply = replyTarget?.kind === "primary";
+  const editingAlternativeReply = replyTarget?.kind === "alternative";
   const read = thread.agentRead;
   const readFingerprint = fingerprintAgentRead(read);
   const replyIndex = read.primary.findIndex(
@@ -443,7 +450,7 @@ export function ThreadReadCard({ thread, ctx }: Props) {
   );
 
   useEffect(() => {
-    setReplyEditorOpen(false);
+    setReplyTarget(null);
     setSelectedIndices(new Set(read.primary.map((_, index) => index)));
     setReplyDraft(primaryReplyDraftMarkdown(read.primary));
     setReplyEditorRevision((revision) => revision + 1);
@@ -468,7 +475,7 @@ export function ThreadReadCard({ thread, ctx }: Props) {
         ctx,
         replyDraft: replyDraftValue,
       });
-      setReplyEditorOpen(false);
+      setReplyTarget(null);
     } catch (error) {
       toast.error(formatErrorMessage(error));
     } finally {
@@ -478,14 +485,14 @@ export function ThreadReadCard({ thread, ctx }: Props) {
 
   const handlePrimaryClick = () => {
     if (selectionIncludesReply) {
-      setReplyEditorOpen(true);
+      setReplyTarget({ kind: "primary" });
       return;
     }
     void handleAcceptSelected();
   };
 
   const handleCancelReplyEditor = () => {
-    setReplyEditorOpen(false);
+    setReplyTarget(null);
     setReplyDraft(primaryReplyDraftMarkdown(read.primary));
     setReplyEditorRevision((revision) => revision + 1);
   };
@@ -493,12 +500,16 @@ export function ThreadReadCard({ thread, ctx }: Props) {
   const handleSendReply = () => {
     const trimmed = replyDraft.trim();
     if (trimmed.length === 0) return;
+    if (replyTarget?.kind === "alternative") {
+      void handleAcceptAlternative(replyTarget.index, trimmed);
+      return;
+    }
     void handleAcceptSelected(trimmed);
   };
 
   const toggleAction = (index: number) => {
-    // Reply stays locked-in while its editor is expanded.
-    if (replyEditorOpen && index === replyIndex) return;
+    // The primary reply stays locked-in while its editor is expanded.
+    if (editingPrimaryReply && index === replyIndex) return;
     setSelectedIndices((prev) => {
       const next = new Set(prev);
       if (next.has(index)) next.delete(index);
@@ -507,7 +518,10 @@ export function ThreadReadCard({ thread, ctx }: Props) {
     });
   };
 
-  const handleAcceptAlternative = async (alternativeIndex: number) => {
+  const handleAcceptAlternative = async (
+    alternativeIndex: number,
+    replyDraftValue?: string,
+  ) => {
     setBusyKey(`alt:${alternativeIndex}`);
     try {
       await acceptThreadRead({
@@ -515,12 +529,27 @@ export function ThreadReadCard({ thread, ctx }: Props) {
         read,
         selection: { alternativeIndex },
         ctx,
+        replyDraft: replyDraftValue,
       });
+      setReplyTarget(null);
     } catch (error) {
       toast.error(formatErrorMessage(error));
     } finally {
       setBusyKey(null);
     }
+  };
+
+  // A reply alternative opens the same inline preview editor as the primary
+  // reply (seeded with its own draft); any other alternative applies directly.
+  const handleAlternativeClick = (alternativeIndex: number) => {
+    const alternative = read.alternatives?.[alternativeIndex];
+    if (alternative?.kind === "reply") {
+      setReplyTarget({ kind: "alternative", index: alternativeIndex });
+      setReplyDraft(alternative.draftMarkdown ?? "");
+      setReplyEditorRevision((revision) => revision + 1);
+      return;
+    }
+    void handleAcceptAlternative(alternativeIndex);
   };
 
   const handleDismissRead = async () => {
@@ -607,15 +636,13 @@ export function ThreadReadCard({ thread, ctx }: Props) {
         onDraftChange={setReplyDraft}
       />
       <ActionRow.Actions>
-        {(read.alternatives ?? [])
-          .map((alternative, index) => ({ alternative, index }))
-          .filter(({ alternative }) => alternative.kind !== "reply")
-          .map(({ alternative, index }) => (
+        {!editingAlternativeReply &&
+          (read.alternatives ?? []).map((alternative, index) => (
             <ActionButton
               key={`${thread.id}:alternative:${alternative.kind}:${index}`}
               size="sm"
               variant="secondary"
-              onClick={() => handleAcceptAlternative(index)}
+              onClick={() => handleAlternativeClick(index)}
               disabled={busyKey !== null}
             >
               {ACTION_KIND_LABEL[alternative.kind]}
@@ -631,21 +658,32 @@ export function ThreadReadCard({ thread, ctx }: Props) {
             Cancel
           </ActionButton>
         )}
-        {read.primary.length > 0 && (
-          <CompoundActionButton
-            label={compoundButtonLabel(orderedSelected, replyEditorOpen)}
-            disabled={busyKey !== null}
-            executeDisabled={
-              orderedSelected.length === 0 ||
-              (replyEditorOpen && replyDraft.trim().length === 0)
-            }
-            onClick={replyEditorOpen ? handleSendReply : handlePrimaryClick}
-            actions={isCompound ? read.primary : null}
-            selectedIndices={selectedIndices}
-            lockedIndex={replyEditorOpen ? replyIndex : -1}
-            disableToggles={busyKey !== null}
-            onToggle={toggleAction}
-          />
+        {editingAlternativeReply ? (
+          <ActionButton
+            size="sm"
+            variant="primary"
+            onClick={handleSendReply}
+            disabled={busyKey !== null || replyDraft.trim().length === 0}
+          >
+            Send reply
+          </ActionButton>
+        ) : (
+          read.primary.length > 0 && (
+            <CompoundActionButton
+              label={compoundButtonLabel(orderedSelected, replyEditorOpen)}
+              disabled={busyKey !== null}
+              executeDisabled={
+                orderedSelected.length === 0 ||
+                (replyEditorOpen && replyDraft.trim().length === 0)
+              }
+              onClick={replyEditorOpen ? handleSendReply : handlePrimaryClick}
+              actions={isCompound ? read.primary : null}
+              selectedIndices={selectedIndices}
+              lockedIndex={editingPrimaryReply ? replyIndex : -1}
+              disableToggles={busyKey !== null}
+              onToggle={toggleAction}
+            />
+          )
         )}
       </ActionRow.Actions>
     </ActionRow.Root>

--- a/apps/web/src/components/signals/action-row/thread-read-card.tsx
+++ b/apps/web/src/components/signals/action-row/thread-read-card.tsx
@@ -607,17 +607,20 @@ export function ThreadReadCard({ thread, ctx }: Props) {
         onDraftChange={setReplyDraft}
       />
       <ActionRow.Actions>
-        {(read.alternatives ?? []).map((alternative, index) => (
-          <ActionButton
-            key={`${thread.id}:alternative:${alternative.kind}:${index}`}
-            size="sm"
-            variant="secondary"
-            onClick={() => handleAcceptAlternative(index)}
-            disabled={busyKey !== null}
-          >
-            {ACTION_KIND_LABEL[alternative.kind]}
-          </ActionButton>
-        ))}
+        {(read.alternatives ?? [])
+          .map((alternative, index) => ({ alternative, index }))
+          .filter(({ alternative }) => alternative.kind !== "reply")
+          .map(({ alternative, index }) => (
+            <ActionButton
+              key={`${thread.id}:alternative:${alternative.kind}:${index}`}
+              size="sm"
+              variant="secondary"
+              onClick={() => handleAcceptAlternative(index)}
+              disabled={busyKey !== null}
+            >
+              {ACTION_KIND_LABEL[alternative.kind]}
+            </ActionButton>
+          ))}
         {replyEditorOpen && (
           <ActionButton
             size="sm"

--- a/apps/web/src/components/signals/action-row/thread-read-card.tsx
+++ b/apps/web/src/components/signals/action-row/thread-read-card.tsx
@@ -463,6 +463,22 @@ export function ThreadReadCard({ thread, ctx }: Props) {
   const selectionIncludesReply =
     replyIndex >= 0 && selectedIndices.has(replyIndex);
 
+  // When the primary bundle is a lone reply, a reply-only alternative is
+  // redundant — it offers the same "just reply" as the primary — so drop it.
+  // Indices are kept intact so accept/edit handlers still map to read.alternatives.
+  const primaryIsJustReply =
+    read.primary.length === 1 && read.primary[0]?.kind === "reply";
+  const visibleAlternatives = useMemo(
+    () =>
+      (read.alternatives ?? [])
+        .map((alternative, index) => ({ alternative, index }))
+        .filter(
+          ({ alternative }) =>
+            !(primaryIsJustReply && alternative.kind === "reply"),
+        ),
+    [read.alternatives, primaryIsJustReply],
+  );
+
   const handleAcceptSelected = async (replyDraftValue?: string) => {
     const indices = [...selectedIndices].sort((a, b) => a - b);
     if (indices.length === 0) return;
@@ -637,7 +653,7 @@ export function ThreadReadCard({ thread, ctx }: Props) {
       />
       <ActionRow.Actions>
         {!replyEditorOpen &&
-          (read.alternatives ?? []).map((alternative, index) => (
+          visibleAlternatives.map(({ alternative, index }) => (
             <ActionButton
               key={`${thread.id}:alternative:${alternative.kind}:${index}`}
               size="sm"
@@ -665,7 +681,7 @@ export function ThreadReadCard({ thread, ctx }: Props) {
             onClick={handleSendReply}
             disabled={busyKey !== null || replyDraft.trim().length === 0}
           >
-            Send reply
+            Just reply
           </ActionButton>
         ) : (
           read.primary.length > 0 && (

--- a/apps/web/src/components/signals/action-row/thread-read-card.tsx
+++ b/apps/web/src/components/signals/action-row/thread-read-card.tsx
@@ -636,7 +636,7 @@ export function ThreadReadCard({ thread, ctx }: Props) {
         onDraftChange={setReplyDraft}
       />
       <ActionRow.Actions>
-        {!editingAlternativeReply &&
+        {!replyEditorOpen &&
           (read.alternatives ?? []).map((alternative, index) => (
             <ActionButton
               key={`${thread.id}:alternative:${alternative.kind}:${index}`}

--- a/apps/web/src/components/signals/action-row/thread-read-card.tsx
+++ b/apps/web/src/components/signals/action-row/thread-read-card.tsx
@@ -263,12 +263,10 @@ function InlineSuggestionsRow({
   suggestions: InlineSuggestion[];
   organizationId: string;
   busy: boolean;
-  onAccept: (suggestion: InlineSuggestion) => void;
-  onDismiss: (suggestion: InlineSuggestion) => void;
+  onAccept: (suggestion: InlineSuggestion) => void | Promise<void>;
+  onDismiss: (suggestion: InlineSuggestion) => void | Promise<void>;
 }) {
-  const labels = useLiveQuery(
-    query.label.where({ organizationId, enabled: true }),
-  );
+  const labels = useLiveQuery(query.label.where({ organizationId }));
 
   const resolved = useMemo<ResolvedInlineSuggestion[]>(() => {
     const labelById = new Map((labels ?? []).map((label) => [label.id, label]));
@@ -284,7 +282,17 @@ function InlineSuggestionsRow({
         });
       } else {
         const label = labelById.get(suggestion.action.labelId);
-        if (!label) continue;
+        if (!label) {
+          // Keep the suggestion dismissible even when its label was deleted,
+          // disabled, or hasn't loaded yet — otherwise it becomes a stuck row.
+          result.push({
+            suggestion,
+            kind: "label",
+            name: "Unknown label",
+            color: "var(--muted-foreground)",
+          });
+          continue;
+        }
         result.push({
           suggestion,
           kind: "label",
@@ -354,15 +362,19 @@ function InlineSuggestionsRow({
             </HoverCardContent>
           </HoverCard>
         ))}
-        <div className="flex items-center gap-0 opacity-0 transition-opacity pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto">
+        <div className="flex items-center gap-0 opacity-0 transition-opacity pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-within:opacity-100 focus-within:pointer-events-auto">
           <ActionButton
             variant="ghost"
             size="icon-sm"
             tooltip="Apply all"
             className="text-foreground-secondary"
-            onClick={() =>
-              resolved.forEach((item) => onAccept(item.suggestion))
-            }
+            onClick={async () => {
+              // Run sequentially so a single busy state covers the whole batch
+              // instead of concurrent requests racing to clear it.
+              for (const item of resolved) {
+                await onAccept(item.suggestion);
+              }
+            }}
             disabled={busy}
           >
             <Check />
@@ -372,9 +384,11 @@ function InlineSuggestionsRow({
             size="icon-sm"
             tooltip="Ignore all"
             className="text-foreground-secondary"
-            onClick={() =>
-              resolved.forEach((item) => onDismiss(item.suggestion))
-            }
+            onClick={async () => {
+              for (const item of resolved) {
+                await onDismiss(item.suggestion);
+              }
+            }}
             disabled={busy}
           >
             <X />
@@ -501,6 +515,10 @@ export function ThreadReadCard({ thread, ctx }: Props) {
 
   const handlePrimaryClick = () => {
     if (selectionIncludesReply) {
+      // Reseed the shared draft so an earlier alternative-reply flow can't leak
+      // stale text into the primary editor.
+      setReplyDraft(primaryReplyDraftMarkdown(read.primary));
+      setReplyEditorRevision((revision) => revision + 1);
       setReplyTarget({ kind: "primary" });
       return;
     }

--- a/apps/web/src/components/signals/action-row/thread-read-card.tsx
+++ b/apps/web/src/components/signals/action-row/thread-read-card.tsx
@@ -1,4 +1,5 @@
 import type { InferLiveObject } from "@live-state/sync";
+import { useLiveQuery } from "@live-state/sync/client";
 import { Link } from "@tanstack/react-router";
 import {
   ACTION_KIND_LABEL,
@@ -20,13 +21,15 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "@workspace/ui/components/hover-card";
+import { StatusIndicator } from "@workspace/ui/components/indicator";
 import { cn, formatRelativeTime } from "@workspace/ui/lib/utils";
 import type { schema } from "api/schema";
-import { Brain } from "lucide-react";
+import { Brain, Check, X } from "lucide-react";
 import { useEffect, useId, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ThreadSummaryHoverCard } from "~/components/chips";
 import { RichMarkdown } from "~/components/markdown/rich-markdown";
+import { query } from "~/lib/live-state";
 import { buildThreadParam } from "~/utils/thread";
 import { ActionRow } from "./action-row";
 import {
@@ -231,13 +234,155 @@ function CompoundActionButton({
   );
 }
 
-function inlineSuggestionLabel(suggestion: InlineSuggestion): string {
-  if (suggestion.action.kind === "set_status") {
-    const status =
-      STATUS_LABELS[suggestion.action.status] ?? suggestion.action.status;
-    return `Set status: ${status}`;
-  }
-  return `Apply label (${suggestion.action.labelId})`;
+type ResolvedInlineSuggestion =
+  | {
+      suggestion: InlineSuggestion;
+      kind: "status";
+      name: string;
+      status: number;
+    }
+  | {
+      suggestion: InlineSuggestion;
+      kind: "label";
+      name: string;
+      color: string;
+    };
+
+/**
+ * Inline-track suggestions (apply label / set status) rendered as dashed chips,
+ * mirroring the thread toolbar's quick-actions style: click a chip to apply,
+ * hover for detail, and reveal apply-all / ignore-all on row hover.
+ */
+function InlineSuggestionsRow({
+  suggestions,
+  organizationId,
+  busy,
+  onAccept,
+  onDismiss,
+}: {
+  suggestions: InlineSuggestion[];
+  organizationId: string;
+  busy: boolean;
+  onAccept: (suggestion: InlineSuggestion) => void;
+  onDismiss: (suggestion: InlineSuggestion) => void;
+}) {
+  const labels = useLiveQuery(
+    query.label.where({ organizationId, enabled: true }),
+  );
+
+  const resolved = useMemo<ResolvedInlineSuggestion[]>(() => {
+    const labelById = new Map((labels ?? []).map((label) => [label.id, label]));
+    const result: ResolvedInlineSuggestion[] = [];
+    for (const suggestion of suggestions) {
+      if (suggestion.action.kind === "set_status") {
+        const status = suggestion.action.status;
+        result.push({
+          suggestion,
+          kind: "status",
+          name: STATUS_LABELS[status] ?? `Status ${status}`,
+          status,
+        });
+      } else {
+        const label = labelById.get(suggestion.action.labelId);
+        if (!label) continue;
+        result.push({
+          suggestion,
+          kind: "label",
+          name: label.name,
+          color: label.color,
+        });
+      }
+    }
+    return result;
+  }, [labels, suggestions]);
+
+  if (resolved.length === 0) return null;
+
+  const chipContent = (item: ResolvedInlineSuggestion) => (
+    <>
+      {item.kind === "status" ? (
+        <StatusIndicator status={item.status} />
+      ) : (
+        <div
+          className="size-2 rounded-full"
+          style={{ backgroundColor: item.color }}
+        />
+      )}
+      {item.name}
+    </>
+  );
+
+  return (
+    <div className="pl-6 mt-2 grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 items-center text-sm">
+      <div className="text-foreground-secondary">Quick suggestions</div>
+      <div className="flex gap-2 items-center flex-wrap group">
+        {resolved.map((item) => (
+          <HoverCard key={item.suggestion.id}>
+            <HoverCardTrigger
+              render={
+                <ActionButton
+                  variant="ghost"
+                  size="sm"
+                  className="border border-dashed border-input dark:hover:bg-foreground-tertiary/15"
+                  onClick={() => onAccept(item.suggestion)}
+                  disabled={busy}
+                />
+              }
+            >
+              {chipContent(item)}
+            </HoverCardTrigger>
+            <HoverCardContent className="min-w-72 w-full max-w-96 flex flex-col gap-3">
+              <div className="text-xs flex flex-col gap-1">
+                <div className="text-foreground-secondary">
+                  {item.kind === "status"
+                    ? "Suggested status"
+                    : "Suggested label"}
+                </div>
+                <div className="border border-dashed flex items-center w-fit h-6 rounded-sm gap-1.5 px-2 has-[>svg:first-child]:pl-1.5 text-xs bg-foreground-tertiary/15">
+                  {chipContent(item)}
+                </div>
+              </div>
+              <ActionButton
+                variant="outline"
+                size="sm"
+                className="w-full"
+                onClick={() => onAccept(item.suggestion)}
+                disabled={busy}
+              >
+                Apply suggestion
+              </ActionButton>
+            </HoverCardContent>
+          </HoverCard>
+        ))}
+        <div className="flex items-center gap-0 opacity-0 transition-opacity pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto">
+          <ActionButton
+            variant="ghost"
+            size="icon-sm"
+            tooltip="Apply all"
+            className="text-foreground-secondary"
+            onClick={() =>
+              resolved.forEach((item) => onAccept(item.suggestion))
+            }
+            disabled={busy}
+          >
+            <Check />
+          </ActionButton>
+          <ActionButton
+            variant="ghost"
+            size="icon-sm"
+            tooltip="Ignore all"
+            className="text-foreground-secondary"
+            onClick={() =>
+              resolved.forEach((item) => onDismiss(item.suggestion))
+            }
+            disabled={busy}
+          >
+            <X />
+          </ActionButton>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 function AgentReadReasoningTrigger({ reasoning }: { reasoning: string }) {
@@ -442,36 +587,13 @@ export function ThreadReadCard({ thread, ctx }: Props) {
           />
         </ActionRow.Reason>
         {inlineSuggestions.length > 0 && (
-          <div className="pl-6 mt-2 flex flex-col gap-2">
-            {inlineSuggestions.map((suggestion) => (
-              <div
-                key={suggestion.id}
-                className="flex items-center justify-between gap-2 rounded-sm border bg-background-tertiary px-2 py-1"
-              >
-                <span className="text-xs text-foreground-secondary">
-                  {inlineSuggestionLabel(suggestion)}
-                </span>
-                <div className="flex items-center gap-2">
-                  <ActionButton
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => handleInlineDismiss(suggestion)}
-                    disabled={busyKey !== null}
-                  >
-                    Skip
-                  </ActionButton>
-                  <ActionButton
-                    size="sm"
-                    variant="secondary"
-                    onClick={() => handleInlineAccept(suggestion)}
-                    disabled={busyKey !== null}
-                  >
-                    Apply
-                  </ActionButton>
-                </div>
-              </div>
-            ))}
-          </div>
+          <InlineSuggestionsRow
+            suggestions={inlineSuggestions}
+            organizationId={ctx.organizationId}
+            busy={busyKey !== null}
+            onAccept={handleInlineAccept}
+            onDismiss={handleInlineDismiss}
+          />
         )}
         <ActionRow.TopActions>
           <AgentReadReasoningTrigger reasoning={read.reasoning} />

--- a/packages/schemas/src/signals.ts
+++ b/packages/schemas/src/signals.ts
@@ -72,7 +72,7 @@ export const actionKindSchema = z.enum(ACTION_KINDS);
 export type ActionKind = z.infer<typeof actionKindSchema>;
 
 export const ACTION_KIND_LABEL: Record<ActionKind, string> = {
-  reply: "Send reply",
+  reply: "Just reply",
   mark_duplicate: "Mark duplicate",
   link_pr: "Link pull request",
   close: "Close thread",


### PR DESCRIPTION
## Summary

Redo the inline-suggestion rendering on signal cards (`signal/index.tsx` → `ThreadReadCard`) to follow the thread toolbar's quick-actions style.

- Replaces the old stacked list of bordered rows (raw `Apply label (labelId)` text + "Skip"/"Apply" buttons) with a new `InlineSuggestionsRow` component.
- Renders a **"Quick suggestions"** two-column grid row with dashed-border ghost chips, matching `QuickActionsPanel` in the toolbar.
- Resolves suggestions into proper chips: labels show their real name + color dot (via a `query.label` live query), status suggestions render with a `StatusIndicator` and human label.
- Clicking a chip applies the suggestion; each chip has a hover card with the resolved preview and an "Apply suggestion" button.
- Adds group-hover **apply-all** / **ignore-all** icon controls.
- Removes the now-unused `inlineSuggestionLabel` helper.

Existing `handleInlineAccept`/`handleInlineDismiss` handlers and `busyKey` gating are reused as-is.

## Test plan

- [x] `bun run --filter web typecheck`
- [x] `biome check`
- [ ] Visual check of signal cards with pending inline suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restyled inline suggestions into toolbar-style quick suggestion chips with hover previews and bulk apply/ignore. Reply alternatives now open the same inline draft editor as the primary; non-reply alternatives apply directly.

- **New Features**
  - `InlineSuggestionsRow`: Quick suggestions row with dashed chips and hover preview; click to apply or apply all/ignore all (runs sequentially and shows on focus for keyboard use).
  - Chips resolve labels via `useLiveQuery` on `query.label` (with color dot) and statuses via `StatusIndicator`; unknown labels render a safe fallback chip so they remain dismissible.

- **Refactors**
  - Unified reply editing for primary and reply-type alternatives via `replyTarget`; sending accepts that alternative with the edited draft, and the primary draft is re-seeded on open to prevent stale text.
  - Hide alternative actions while the reply editor is open and suppress reply-only alternatives when the primary is reply-only; renamed reply action label to "Just reply".

<sup>Written for commit c97f98a407b8baac92976a29355e2af343a635e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hoverable “Quick suggestions” row on thread read cards with dashed suggestion chips.
  * Users can apply or ignore suggestions individually, plus “Apply all” / “Ignore all” for batch actions.
  * Enabled suggestion labels and statuses are displayed as chips (with clear handling for unknown labels).
* **Improvements**
  * Refined inline reply editing for alternative reads, improving editor routing and cancel/reset behavior.
  * “Just reply” is shown when editing an alternative reply; otherwise the primary action reflects the current locked editing state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->