### PR TITLE
feat(worker,web): separate summary and recommendation in thread reads

### DIFF
--- a/apps/web/src/components/signals/action-row/thread-read-card.tsx
+++ b/apps/web/src/components/signals/action-row/thread-read-card.tsx
@@ -5,12 +5,12 @@ import {
   ACTION_KIND_LABEL,
   ACTION_KIND_VERB,
   type Action,
-  fingerprintAgentRead,
   type InlineSuggestion,
   type ReplyAction,
   STATUS_LABELS,
-  sanitizeAgentReadReasoning,
   type ThreadRead,
+  fingerprintAgentRead,
+  sanitizeAgentReadReasoning,
   urgencyTierFromScore,
 } from "@workspace/schemas/signals";
 import { Avatar } from "@workspace/ui/components/avatar";
@@ -643,11 +643,24 @@ export function ThreadReadCard({ thread, ctx }: Props) {
           ) : null}
         </ActionRow.Title>
         <ActionRow.Reason>
-          <RichMarkdown
-            content={read.summary}
-            preset="inline"
-            className="text-foreground-primary"
-          />
+          <div className="flex min-w-0 flex-col gap-1">
+            <RichMarkdown
+              content={read.summary}
+              preset="inline"
+              className={
+                read.recommendation
+                  ? "text-foreground-secondary"
+                  : "text-foreground-primary"
+              }
+            />
+            {read.recommendation ? (
+              <RichMarkdown
+                content={read.recommendation}
+                preset="inline"
+                className="text-foreground-primary"
+              />
+            ) : null}
+          </div>
         </ActionRow.Reason>
         {inlineSuggestions.length > 0 && (
           <InlineSuggestionsRow

--- a/apps/web/src/components/signals/action-row/thread-read-card.tsx
+++ b/apps/web/src/components/signals/action-row/thread-read-card.tsx
@@ -647,19 +647,13 @@ export function ThreadReadCard({ thread, ctx }: Props) {
             <RichMarkdown
               content={read.summary}
               preset="inline"
-              className={
-                read.recommendation
-                  ? "text-foreground-secondary"
-                  : "text-foreground-primary"
-              }
+              className="text-foreground-secondary"
             />
-            {read.recommendation ? (
-              <RichMarkdown
-                content={read.recommendation}
-                preset="inline"
-                className="text-foreground-primary"
-              />
-            ) : null}
+            <RichMarkdown
+              content={read.recommendation}
+              preset="inline"
+              className="text-foreground-primary"
+            />
           </div>
         </ActionRow.Reason>
         {inlineSuggestions.length > 0 && (

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/dataset.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/dataset.ts
@@ -22,6 +22,7 @@ export const synthesisDataset: SynthesisEvalCase[] = [
     input: {
       output: {
         summary: "No action needed",
+        recommendation: "No reply, duplicate link, or close is justified yet.",
         reasoning: "No substantive move is justified.",
         primary: [],
         alternatives: [],
@@ -44,6 +45,7 @@ export const synthesisDataset: SynthesisEvalCase[] = [
     input: {
       output: {
         summary: "Customer reports invoice amount mismatch ",
+        recommendation: "Reply with an explanation of the invoice difference.",
         reasoning:
           " Latest inbound asks why the invoice total differs from the expected plan price. ",
         primary: [
@@ -73,6 +75,7 @@ export const synthesisDataset: SynthesisEvalCase[] = [
     input: {
       output: {
         summary: "Likely duplicate report",
+        recommendation: "This is a duplicate of an existing thread.",
         reasoning: "Hint points strongly to an existing thread.",
         primary: [{ kind: "mark_duplicate", targetThreadId: "t-123" }],
         alternatives: [{ kind: "close" }],
@@ -95,6 +98,7 @@ export const synthesisDataset: SynthesisEvalCase[] = [
     input: {
       output: {
         summary: "No useful reply content",
+        recommendation: "Reply to acknowledge the customer.",
         reasoning: "Model proposed an empty draft.",
         primary: [{ kind: "reply", draftMarkdown: "   " }],
         alternatives: [],
@@ -117,6 +121,7 @@ export const synthesisDataset: SynthesisEvalCase[] = [
     input: {
       output: {
         summary: "Duplicate target is missing",
+        recommendation: "This is a duplicate of an existing thread.",
         reasoning: "Model attempted mark_duplicate without a real target id.",
         primary: [{ kind: "mark_duplicate", targetThreadId: "   " }],
         alternatives: [{ kind: "close" }],
@@ -139,6 +144,7 @@ export const synthesisDataset: SynthesisEvalCase[] = [
     input: {
       output: {
         summary: "Duplicate without acknowledgment",
+        recommendation: "This is a duplicate of an existing thread.",
         reasoning: "Should be rejected by normalize.",
         primary: [{ kind: "mark_duplicate", targetThreadId: "t-123" }],
         alternatives: [{ kind: "close" }],
@@ -161,6 +167,8 @@ export const synthesisDataset: SynthesisEvalCase[] = [
     input: {
       output: {
         summary: "Link duplicate and acknowledge customer",
+        recommendation:
+          "This is a duplicate of an existing thread; reply to acknowledge the customer.",
         reasoning: "Bundled reply is valid.",
         primary: [
           { kind: "mark_duplicate", targetThreadId: "t-123" },
@@ -189,6 +197,8 @@ export const synthesisDataset: SynthesisEvalCase[] = [
     input: {
       output: {
         summary: "Customer confirmed issue resolved",
+        recommendation:
+          "Close the thread — the customer confirmed the issue is resolved.",
         reasoning: "Latest message says we can close the thread.",
         primary: [{ kind: "close" }],
         alternatives: [

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/normalize.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/normalize.ts
@@ -64,6 +64,7 @@ export const normalizeSynthesisRawActionSet = ({
 
   const rawActionSet: ThreadRead = {
     summary: output.summary.trim(),
+    recommendation: output.recommendation.trim(),
     reasoning: sanitizeAgentReadReasoning(output.reasoning),
     urgencyScore: output.urgencyScore,
     sourceInputMessageId: messageIds.has(output.sourceInputMessageId)

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
@@ -18,6 +18,7 @@ const synthesisActionSchema = z.discriminatedUnion("kind", [
 
 const synthesisRawActionSetSchema = z.object({
   summary: z.string(),
+  recommendation: z.string(),
   reasoning: z.string(),
   primary: z.array(synthesisActionSchema),
   alternatives: z.array(synthesisActionSchema).default([]),
@@ -112,34 +113,37 @@ When hasTeamReply is false, the customer has written but no teammate has replied
 
 When hasTeamReply is true, alternatives may be any allowed action kind (including standalone close or mark_duplicate).
 
-## summary vs reasoning (critical)
+## summary, recommendation, and reasoning (critical)
 
-\`summary\` is the **inbox headline** (1–2 sentences). It must match \`primary\` and always pair (1) what the customer needs with (2) the next move in direct, imperative language.
+\`summary\` and \`recommendation\` together are the **inbox headline**. They must match \`primary\`: the summary states what the customer needs, the recommendation states the next move in direct, imperative language.
 
-**Format:** Sentence 1 = concise customer situation (what they want or reported). Sentence 2 = imperative instruction tied to \`primary\` (what the human should do). Never prefix with "Recommend" or "We recommend".
+\`summary\` = **one concise sentence** describing the customer situation (what they want or reported). No action, no imperative — just the situation.
 
-- mark_duplicate: end with "This is a duplicate of [target thread name](thread:targetThreadId)." Use the exact \`targetThreadId\` from primary and the name from read_thread when available.
-- reply: end with a reply imperative, e.g. "Reply to acknowledge …" or "Reply with an explanation of …"
-- close: end with a close imperative, e.g. "Close the thread — the customer confirmed the issue is resolved."
-- empty primary: both sentences; second states no substantive move, e.g. "No reply, duplicate link, or close is justified yet."
+\`recommendation\` = **one imperative sentence** tied to \`primary\` (what the human should do). Never prefix with "Recommend" or "We recommend".
 
-Thread mentions in summary must use markdown link syntax only: [Display name](thread:threadId). Never put raw thread ids as plain text.
+- mark_duplicate: "This is a duplicate of [target thread name](thread:targetThreadId)." Use the exact \`targetThreadId\` from primary and the name from read_thread when available.
+- reply: a reply imperative, e.g. "Reply to acknowledge …" or "Reply with an explanation of …"
+- close: a close imperative, e.g. "Close the thread — the customer confirmed the issue is resolved."
+- empty primary: state that no substantive move is justified, e.g. "No reply, duplicate link, or close is justified yet."
+
+Thread mentions in \`recommendation\` must use markdown link syntax only: [Display name](thread:threadId). Never put raw thread ids as plain text.
 
 Example (reply):
-"Customer is interested in upgrading to the enterprise plan and is asking for pricing details for 50+ users and additional features. Reply to acknowledge the request and inform them that a specialist will provide the details."
+- summary: "Customer is interested in upgrading to the enterprise plan and is asking for pricing details for 50+ users and additional features."
+- recommendation: "Reply to acknowledge the request and inform them that a specialist will provide the details."
 
 Example (mark_duplicate):
-"Customer is requesting an increase in API rate limits due to their application constantly hitting the current limits. This is a duplicate of [API rate limit increase](thread:abc123)."
+- summary: "Customer is requesting an increase in API rate limits due to their application constantly hitting the current limits."
+- recommendation: "This is a duplicate of [API rate limit increase](thread:abc123)."
 
-Incomplete (missing the actionable second sentence — never do this):
-"Customer is requesting an increase in API rate limits due to their application constantly hitting the current limits."
+Never leave \`recommendation\` empty when \`primary\` is non-empty.
 
 \`reasoning\` is **why** in plain language for a human agent reviewing the inbox. Use 2–4 short sentences grounded in the conversation and what you verified. Do not repeat the full summary.
 
 **Never put in \`reasoning\` (user-facing copy):**
 - Internal pipeline terms (hint bag, hints JSON, tool names, tool calls, messageId, preprocessor/thread digest, synthesis agent)
 - Confidence or similarity numbers (percentages, 0–1 scores, "confidence: …", urgency scores)
-- Raw identifiers (thread ids, message ids, UUIDs, doc ids) — refer to other threads by **name** only. Thread markdown links belong in \`summary\` only, not in \`reasoning\`.
+- Raw identifiers (thread ids, message ids, UUIDs, doc ids) — refer to other threads by **name** only. Thread markdown links belong in \`recommendation\` only, not in \`reasoning\`.
 
 Thread id: ${input.threadId}
 Thread name: ${input.threadName ?? "(none)"}
@@ -148,13 +152,14 @@ Default sourceInputMessageId: ${input.sourceInputMessageId}
 Thread messages (oldest -> newest):
 ${transcript}
 
-${summaryJson ? `Thread digest (preprocessor context only — do not copy into summary):\n${summaryJson}\n` : ""}
+${summaryJson ? `Thread digest (preprocessor context only — do not copy into summary or recommendation):\n${summaryJson}\n` : ""}
 Hint bag:
 ${hintsJson}
 
 Return a single valid JSON object with exactly this shape:
 {
-  "summary": string (customer situation + imperative next move; use [name](thread:id) for duplicate targets),
+  "summary": string (one sentence: customer situation only, no imperative),
+  "recommendation": string (one imperative sentence tied to primary; use [name](thread:id) for duplicate targets),
   "reasoning": string (user-facing evidence; no internal terms, scores, or raw ids),
   "primary": Array<{ "kind": "reply", "draftMarkdown": string } | { "kind": "mark_duplicate", "targetThreadId": string } | { "kind": "close" }>,
   "alternatives": Array<{ "kind": "reply", "draftMarkdown": string } | { "kind": "mark_duplicate", "targetThreadId": string } | { "kind": "close" }>,

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
@@ -18,7 +18,7 @@ const synthesisActionSchema = z.discriminatedUnion("kind", [
 
 const synthesisRawActionSetSchema = z.object({
   summary: z.string(),
-  recommendation: z.string(),
+  recommendation: z.string().trim().min(1),
   reasoning: z.string(),
   primary: z.array(synthesisActionSchema),
   alternatives: z.array(synthesisActionSchema).default([]),

--- a/packages/schemas/src/signals.ts
+++ b/packages/schemas/src/signals.ts
@@ -125,7 +125,7 @@ export const threadReadSchema = z.object({
   /** Thread summary: the customer situation (what they want or reported). */
   summary: z.string(),
   /** Actionable output: the imperative next move, tied to `primary`. */
-  recommendation: z.string(),
+  recommendation: z.string().trim().min(1),
   reasoning: z.string(),
   primary: z.array(actionSchema),
   alternatives: z.array(actionSchema).optional(),

--- a/packages/schemas/src/signals.ts
+++ b/packages/schemas/src/signals.ts
@@ -122,7 +122,10 @@ export const isInlineAction = (action: Action): boolean =>
 // --- ThreadRead -----------------------------------------------------------
 
 export const threadReadSchema = z.object({
+  /** Thread summary: the customer situation (what they want or reported). */
   summary: z.string(),
+  /** Actionable output: the imperative next move, tied to `primary`. */
+  recommendation: z.string(),
   reasoning: z.string(),
   primary: z.array(actionSchema),
   alternatives: z.array(actionSchema).optional(),
@@ -138,6 +141,7 @@ export type ThreadRead = z.infer<typeof threadReadSchema>;
 export const fingerprintAgentRead = (read: ThreadRead): string => {
   const payload = {
     summary: read.summary,
+    recommendation: read.recommendation,
     reasoning: read.reasoning,
     primary: read.primary,
     alternatives: read.alternatives ?? [],


### PR DESCRIPTION
## Summary

- Adds a `recommendation` field to `ThreadRead`, splitting the inbox headline into a customer situation (`summary`) and an imperative next move (`recommendation`)
- Updates the synthesis pipeline prompt and normalization to generate both fields separately, with eval dataset fixtures updated accordingly
- Renders `summary` and `recommendation` as distinct lines in the thread read card, with the recommendation emphasized when present

## Test plan

- [ ] Run synthesis eval: `bun run --filter worker eval:similarity` (or the synthesis eval suite if separate)
- [ ] Trigger a new thread read in local dev and confirm the card shows situation + recommendation on separate lines
- [ ] Verify mark_duplicate recommendations still render thread links correctly
- [ ] Confirm existing thread reads without `recommendation` degrade gracefully (summary shown as primary text)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the inbox headline into `summary` and `recommendation` and enforce a non‑empty `recommendation`. Updated synthesis, normalization, and the web UI to generate, validate, and display them separately.

- New Features
  - Added `recommendation` to the `ThreadRead` schema and `fingerprintAgentRead`.
  - Enforced a trimmed, non-empty `recommendation` in both `ThreadRead` and synthesis output; bad reads are rejected.
  - Updated synthesis prompt, normalization, and eval dataset to produce `summary` + `recommendation` with thread links in `recommendation` for `mark_duplicate`.
  - `ThreadReadCard` now always renders `summary` (secondary) and `recommendation` (primary) on separate lines.

- Migration
  - `recommendation` is required; backfill or resynthesize any existing reads before enabling this change.
  - To validate, run: bun run --filter worker eval:similarity.

<sup>Written for commit 60042f560b6f362d45f9e57559f284628c177c27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thread read cards now display the recommendation separately from the summary (with updated emphasis/styling when both are present).
  * Synthesized read results now include a recommendation field, enriching what users see.

* **Bug Fixes**
  * Recommendation changes are now treated as distinct, preventing stale or mismatched read states.
  * Improved normalization and test coverage around empty/trimmed drafts to keep recommendations consistent and reliably shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#312** 👈 current
2. #313
<!-- stack:links:end -->