### PR TITLE
feat(ui,web): add Tree component and use it in thread read card

### DIFF
--- a/apps/web/src/components/signals/action-row/thread-read-card.tsx
+++ b/apps/web/src/components/signals/action-row/thread-read-card.tsx
@@ -22,6 +22,14 @@ import {
   HoverCardTrigger,
 } from "@workspace/ui/components/hover-card";
 import { StatusIndicator } from "@workspace/ui/components/indicator";
+import {
+  TreeItem,
+  TreeItemRow,
+  TreeJoin,
+  TreeList,
+  TreeSkip,
+  TREE_ROW_GAP_PX,
+} from "@workspace/ui/components/tree";
 import { cn, formatRelativeTime } from "@workspace/ui/lib/utils";
 import type { schema } from "api/schema";
 import { Brain, Check, X } from "lucide-react";
@@ -94,6 +102,12 @@ function primaryReplyDraftMarkdown(primary: Action[]): string {
 function capitalize(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
+
+const treeRowClassName =
+  "flex min-h-8 min-w-0 items-stretch gap-1 overflow-visible text-sm";
+
+const treeContentClassName =
+  "flex min-w-0 flex-1 gap-2 py-1 text-foreground-primary";
 
 /**
  * Selected bundle actions in display order: reply always leads, the rest keep
@@ -321,9 +335,11 @@ function InlineSuggestionsRow({
   );
 
   return (
-    <div className="pl-6 mt-2 grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 items-center text-sm">
-      <div className="text-foreground-secondary">Quick suggestions</div>
-      <div className="flex gap-2 items-center flex-wrap group">
+    <div className="group flex min-w-0 flex-wrap items-center gap-x-4 gap-y-2 text-sm">
+      <span className="shrink-0 text-foreground-secondary">
+        Quick suggestions
+      </span>
+      <div className="flex min-w-0 flex-wrap items-center gap-2">
         {resolved.map((item) => (
           <HoverCard key={item.suggestion.id}>
             <HoverCardTrigger
@@ -634,37 +650,66 @@ export function ThreadReadCard({ thread, ctx }: Props) {
   return (
     <ActionRow.Root tier={urgencyTierFromScore(read.urgencyScore)}>
       <ActionRow.Header>
-        <ActionRow.Title>
-          <ThreadRef thread={thread} />
-          {read.createdAt ? (
-            <ActionRow.Meta>
-              {formatRelativeTime(new Date(read.createdAt))}
-            </ActionRow.Meta>
-          ) : null}
-        </ActionRow.Title>
-        <ActionRow.Reason>
-          <div className="flex min-w-0 flex-col gap-1">
-            <RichMarkdown
-              content={read.summary}
-              preset="inline"
-              className="text-foreground-secondary"
-            />
-            <RichMarkdown
-              content={read.recommendation}
-              preset="inline"
-              className="text-foreground-primary"
-            />
-          </div>
-        </ActionRow.Reason>
-        {inlineSuggestions.length > 0 && (
-          <InlineSuggestionsRow
-            suggestions={inlineSuggestions}
-            organizationId={ctx.organizationId}
-            busy={busyKey !== null}
-            onAccept={handleInlineAccept}
-            onDismiss={handleInlineDismiss}
-          />
-        )}
+        <TreeList>
+          <TreeItem>
+            <TreeItemRow>
+              <div className="flex w-full items-center gap-2 pr-16 text-sm text-foreground-primary">
+                <ThreadRef thread={thread} />
+                {read.createdAt ? (
+                  <ActionRow.Meta>
+                    {formatRelativeTime(new Date(read.createdAt))}
+                  </ActionRow.Meta>
+                ) : null}
+              </div>
+            </TreeItemRow>
+            <TreeList>
+              <TreeItem>
+                <div className={cn(treeRowClassName, "items-start")}>
+                  <TreeSkip
+                    stretchStart={TREE_ROW_GAP_PX}
+                    stretchEnd={read.recommendation ? TREE_ROW_GAP_PX : 0}
+                  />
+                  <div className={cn(treeContentClassName, "items-start")}>
+                    <RichMarkdown
+                      content={read.summary}
+                      preset="inline"
+                      className={
+                        read.recommendation
+                          ? "text-foreground-secondary"
+                          : "text-foreground-primary"
+                      }
+                    />
+                  </div>
+                </div>
+              </TreeItem>
+              {read.recommendation ? (
+                <TreeItem>
+                  <div className={cn(treeRowClassName, "items-start")}>
+                    <TreeJoin isLast stretchStart={TREE_ROW_GAP_PX} />
+                    <div className={cn(treeContentClassName, "items-start")}>
+                      <RichMarkdown
+                        content={read.recommendation}
+                        preset="inline"
+                        className="text-foreground-primary"
+                      />
+                    </div>
+                  </div>
+                </TreeItem>
+              ) : null}
+            </TreeList>
+            {inlineSuggestions.length > 0 ? (
+              <div className="py-1 pl-5">
+                <InlineSuggestionsRow
+                  suggestions={inlineSuggestions}
+                  organizationId={ctx.organizationId}
+                  busy={busyKey !== null}
+                  onAccept={handleInlineAccept}
+                  onDismiss={handleInlineDismiss}
+                />
+              </div>
+            ) : null}
+          </TreeItem>
+        </TreeList>
         <ActionRow.TopActions>
           <AgentReadReasoningTrigger reasoning={read.reasoning} />
           <ActionRow.Dismiss onClick={handleDismissRead} label="Dismiss read" />

--- a/apps/web/src/components/signals/action-row/thread-read-card.tsx
+++ b/apps/web/src/components/signals/action-row/thread-read-card.tsx
@@ -27,7 +27,6 @@ import {
   TreeItemRow,
   TreeJoin,
   TreeList,
-  TreeSkip,
   TREE_ROW_GAP_PX,
 } from "@workspace/ui/components/tree";
 import { cn, formatRelativeTime } from "@workspace/ui/lib/utils";
@@ -665,7 +664,8 @@ export function ThreadReadCard({ thread, ctx }: Props) {
             <TreeList>
               <TreeItem>
                 <div className={cn(treeRowClassName, "items-start")}>
-                  <TreeSkip
+                  <TreeJoin
+                    isLast={!read.recommendation}
                     stretchStart={TREE_ROW_GAP_PX}
                     stretchEnd={read.recommendation ? TREE_ROW_GAP_PX : 0}
                   />

--- a/packages/ui/src/components/tree.tsx
+++ b/packages/ui/src/components/tree.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { cn } from "@workspace/ui/lib/utils";
+import * as React from "react";
+
+type TreeGuide = "join" | "skip";
+
+type TreeIndicatorStretch = {
+  stretchStart?: number;
+  stretchEnd?: number;
+  stretchSide?: number;
+};
+
+type TreeItemPositionContextValue = {
+  guides: TreeGuide[];
+  isLast: boolean;
+  index: number;
+  depth: number;
+};
+
+const TreeItemPositionContext =
+  React.createContext<TreeItemPositionContextValue | null>(null);
+
+const indicatorClassName =
+  "relative w-4 shrink-0 self-stretch overflow-visible";
+
+/** Matches `gap-1` on tree rows and lists. */
+const TREE_ROW_GAP_PX = 4;
+
+/** Radius for the join branch corner. */
+const TREE_CORNER_RADIUS_PX = 4;
+
+function useTreeItemPosition() {
+  const ctx = React.use(TreeItemPositionContext);
+  if (!ctx) {
+    throw new Error("Tree parts must be used within <TreeList> → <TreeItem>.");
+  }
+  return ctx;
+}
+
+function useTreeItemPositionOptional() {
+  return React.use(TreeItemPositionContext);
+}
+
+function guidesForChildren(parent: TreeItemPositionContextValue): TreeGuide[] {
+  if (parent.guides.length === 0) {
+    return parent.isLast ? [] : ["join"];
+  }
+
+  return [...parent.guides, parent.isLast ? "skip" : "join"];
+}
+
+function verticalLineStyle({
+  stretchStart = 0,
+  stretchEnd = 0,
+  span = 1,
+}: TreeIndicatorStretch & { span?: number }): React.CSSProperties | undefined {
+  if (stretchStart === 0 && stretchEnd === 0) {
+    return undefined;
+  }
+
+  const spanPercent = span * 100;
+
+  return {
+    top: -stretchStart,
+    height: `calc(${spanPercent}% + ${stretchStart + stretchEnd}px)`,
+  };
+}
+
+type TreeListProps = React.ComponentProps<"ul">;
+
+function TreeList({ className, children, ...props }: TreeListProps) {
+  const parentPosition = React.use(TreeItemPositionContext);
+  const guidesForItems: TreeGuide[] = parentPosition
+    ? guidesForChildren(parentPosition)
+    : [];
+  const childDepth = parentPosition ? parentPosition.depth + 1 : 0;
+
+  const items = React.useMemo(
+    () => React.Children.toArray(children).filter(React.isValidElement),
+    [children],
+  );
+
+  return (
+    <ul
+      data-slot="tree-list"
+      className={cn("m-0 flex list-none flex-col p-0", className)}
+      {...props}
+    >
+      {items.map((child, index) => {
+        const isLast = index === items.length - 1;
+
+        return (
+          <TreeItemPositionContext.Provider
+            key={child.key ?? `tree-item-${index}`}
+            value={{
+              guides: guidesForItems,
+              isLast,
+              index,
+              depth: childDepth,
+            }}
+          >
+            {child}
+          </TreeItemPositionContext.Provider>
+        );
+      })}
+    </ul>
+  );
+}
+
+type TreeItemProps = React.ComponentProps<"li">;
+
+function TreeItem({ className, children, ...props }: TreeItemProps) {
+  const position = useTreeItemPosition();
+
+  return (
+    <TreeItemPositionContext.Provider value={position}>
+      <li
+        data-slot="tree-item"
+        className={cn("flex flex-col", className)}
+        {...props}
+      >
+        {children}
+      </li>
+    </TreeItemPositionContext.Provider>
+  );
+}
+
+type TreeItemRowProps = React.ComponentProps<"div">;
+
+function TreeItemRow({ className, children, ...props }: TreeItemRowProps) {
+  const { guides, isLast, depth } = useTreeItemPosition();
+
+  return (
+    <div
+      data-slot="tree-item-row"
+      className={cn(
+        "flex min-h-8 min-w-0 items-stretch gap-1 overflow-visible text-sm",
+        className,
+      )}
+      {...props}
+    >
+      {guides.map((guide, index) =>
+        guide === "join" ? (
+          <TreeSkip
+            // biome-ignore lint/suspicious/noArrayIndexKey: guide columns are positional
+            key={index}
+            stretchStart={TREE_ROW_GAP_PX}
+          />
+        ) : (
+          <div
+            // biome-ignore lint/suspicious/noArrayIndexKey: guide columns are positional
+            key={index}
+            data-slot="tree-gap"
+            className={indicatorClassName}
+          />
+        ),
+      )}
+      {depth > 0 ? (
+        <TreeJoin isLast={isLast} stretchStart={TREE_ROW_GAP_PX} />
+      ) : null}
+      <div
+        data-slot="tree-item-content"
+        className="flex min-w-0 flex-1 items-center gap-2 py-1 text-foreground-primary"
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+type TreeJoinProps = React.ComponentProps<"div"> &
+  TreeIndicatorStretch & {
+    isLast?: boolean;
+  };
+
+function TreeJoin({
+  className,
+  isLast: isLastProp,
+  stretchStart = 0,
+  stretchEnd = 0,
+  stretchSide = 0,
+  style,
+  ...props
+}: TreeJoinProps) {
+  const contextIsLast = useTreeItemPositionOptional()?.isLast;
+  const isLast = isLastProp ?? contextIsLast ?? false;
+
+  return (
+    <div
+      data-slot="tree-join"
+      className={cn(indicatorClassName, className)}
+      style={style}
+      {...props}
+    >
+      <span
+        aria-hidden
+        className="absolute left-1/2 box-border border-foreground-tertiary border-b border-l"
+        style={{
+          top: stretchStart > 0 ? -stretchStart : 0,
+          height:
+            stretchStart > 0
+              ? `calc(50% + ${stretchStart}px)`
+              : "50%",
+          width:
+            stretchSide > 0
+              ? `calc(50% + ${stretchSide}px)`
+              : "50%",
+          borderBottomLeftRadius: TREE_CORNER_RADIUS_PX,
+        }}
+      />
+      {!isLast ? (
+        <span
+          aria-hidden
+          className="absolute left-1/2 border-l border-foreground-tertiary"
+          style={{
+            top: "50%",
+            width: 0,
+            ...(stretchEnd > 0
+              ? { height: `calc(50% + ${stretchEnd}px)` }
+              : { bottom: 0 }),
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+type TreeSkipProps = React.ComponentProps<"div"> & TreeIndicatorStretch;
+
+function TreeSkip({
+  className,
+  stretchStart = 0,
+  stretchEnd = 0,
+  style,
+  ...props
+}: TreeSkipProps) {
+  const verticalStyle = verticalLineStyle({ stretchStart, stretchEnd });
+
+  return (
+    <div
+      data-slot="tree-skip"
+      className={cn(indicatorClassName, className)}
+      style={style}
+      {...props}
+    >
+      <span
+        aria-hidden
+        className="absolute left-1/2 border-l border-foreground-tertiary"
+        style={{
+          width: 0,
+          ...(!verticalStyle ? { top: 0, bottom: 0 } : verticalStyle),
+        }}
+      />
+    </div>
+  );
+}
+
+export {
+  TreeItem,
+  TreeItemRow,
+  TreeJoin,
+  TreeList,
+  TreeSkip,
+  TREE_ROW_GAP_PX,
+};
+
+export type { TreeGuide, TreeIndicatorStretch };

--- a/packages/ui/src/components/tree.tsx
+++ b/packages/ui/src/components/tree.tsx
@@ -226,7 +226,8 @@ function TreeJoin({
   );
 }
 
-type TreeSkipProps = React.ComponentProps<"div"> & TreeIndicatorStretch;
+type TreeSkipProps = React.ComponentProps<"div"> &
+  Omit<TreeIndicatorStretch, "stretchSide">;
 
 function TreeSkip({
   className,

--- a/packages/ui/src/routeTree.gen.ts
+++ b/packages/ui/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as TreeRouteImport } from './routes/tree'
 import { Route as ToggleGroupRouteImport } from './routes/toggle-group'
 import { Route as StatusIndicatorRouteImport } from './routes/status-indicator'
 import { Route as SegmentedControlRouteImport } from './routes/segmented-control'
@@ -19,6 +20,11 @@ import { Route as ButtonRouteImport } from './routes/button'
 import { Route as AvatarRouteImport } from './routes/avatar'
 import { Route as IndexRouteImport } from './routes/index'
 
+const TreeRoute = TreeRouteImport.update({
+  id: '/tree',
+  path: '/tree',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ToggleGroupRoute = ToggleGroupRouteImport.update({
   id: '/toggle-group',
   path: '/toggle-group',
@@ -75,6 +81,7 @@ export interface FileRoutesByFullPath {
   '/segmented-control': typeof SegmentedControlRoute
   '/status-indicator': typeof StatusIndicatorRoute
   '/toggle-group': typeof ToggleGroupRoute
+  '/tree': typeof TreeRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -86,6 +93,7 @@ export interface FileRoutesByTo {
   '/segmented-control': typeof SegmentedControlRoute
   '/status-indicator': typeof StatusIndicatorRoute
   '/toggle-group': typeof ToggleGroupRoute
+  '/tree': typeof TreeRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -98,6 +106,7 @@ export interface FileRoutesById {
   '/segmented-control': typeof SegmentedControlRoute
   '/status-indicator': typeof StatusIndicatorRoute
   '/toggle-group': typeof ToggleGroupRoute
+  '/tree': typeof TreeRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -111,6 +120,7 @@ export interface FileRouteTypes {
     | '/segmented-control'
     | '/status-indicator'
     | '/toggle-group'
+    | '/tree'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -122,6 +132,7 @@ export interface FileRouteTypes {
     | '/segmented-control'
     | '/status-indicator'
     | '/toggle-group'
+    | '/tree'
   id:
     | '__root__'
     | '/'
@@ -133,6 +144,7 @@ export interface FileRouteTypes {
     | '/segmented-control'
     | '/status-indicator'
     | '/toggle-group'
+    | '/tree'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -145,10 +157,18 @@ export interface RootRouteChildren {
   SegmentedControlRoute: typeof SegmentedControlRoute
   StatusIndicatorRoute: typeof StatusIndicatorRoute
   ToggleGroupRoute: typeof ToggleGroupRoute
+  TreeRoute: typeof TreeRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/tree': {
+      id: '/tree'
+      path: '/tree'
+      fullPath: '/tree'
+      preLoaderRoute: typeof TreeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/toggle-group': {
       id: '/toggle-group'
       path: '/toggle-group'
@@ -225,6 +245,7 @@ const rootRouteChildren: RootRouteChildren = {
   SegmentedControlRoute: SegmentedControlRoute,
   StatusIndicatorRoute: StatusIndicatorRoute,
   ToggleGroupRoute: ToggleGroupRoute,
+  TreeRoute: TreeRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/packages/ui/src/routes/-components/sidebar.tsx
+++ b/packages/ui/src/routes/-components/sidebar.tsx
@@ -166,6 +166,16 @@ export const RootSidebar = () => {
                       </Link>
                     </SidebarMenuButton>
                   </SidebarMenuItem>
+                  <SidebarMenuItem>
+                    <SidebarMenuButton
+                      data-active={matches.at(-1)?.pathname === "/tree"}
+                      asChild
+                    >
+                      <Link to="/tree">
+                        <span>Tree</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
                 </SidebarMenu>
               </SidebarGroupContent>
             </CollapsibleContent>

--- a/packages/ui/src/routes/tree.tsx
+++ b/packages/ui/src/routes/tree.tsx
@@ -1,0 +1,250 @@
+import { createFileRoute } from "@tanstack/react-router";
+import {
+  TreeItem,
+  TreeItemRow,
+  TreeJoin,
+  TreeList,
+  TreeSkip,
+} from "@workspace/ui/components/tree";
+import { Circle, FileText, Folder } from "lucide-react";
+import {
+  Anatomy,
+  type ComponentMeta,
+  Demo,
+  DocPage,
+  DocSection,
+  PropsTable,
+} from "./-components/doc-kit";
+
+export const meta: ComponentMeta = {
+  name: "Tree",
+  status: "stable",
+  description:
+    "A composable tree for nested rows with left-side guide columns. Skip draws a vertical guide through the row; Join branches into row content.",
+  import:
+    'import { TreeList, TreeItem, TreeItemRow } from "@workspace/ui/components/tree";',
+  whenToUse: [
+    "Showing nested structure where each row needs ancestor guide lines (thread timelines, file trees, nested activity).",
+    "You need skip vs gap columns to show whether an ancestor branch continues below the current row.",
+  ],
+  whenNotToUse: [
+    "Flat selectable lists — use Composite or a plain list.",
+    "Expandable navigation sidebars — use Sidebar or NavigationMenu.",
+    "Hierarchical data with built-in expand/collapse chrome — compose Collapsible inside TreeItemRow instead of expecting it here.",
+  ],
+  related: ["Composite", "Collapsible", "Separator"],
+};
+
+export const Route = createFileRoute(
+  // biome-ignore lint/suspicious/noExplicitAny: route tree is generated after adding new route files
+  "/tree" as any,
+)({
+  component: RouteComponent,
+});
+
+function SignalTreeDemo() {
+  return (
+    <TreeList className="max-w-md rounded-md border bg-background-secondary p-3">
+      <TreeItem>
+        <TreeItemRow>
+          <Folder className="size-3.5 text-foreground-secondary" />
+          <span>Thread read</span>
+        </TreeItemRow>
+        <TreeList>
+          <TreeItem>
+            <TreeItemRow>
+              <FileText className="size-3.5 text-foreground-secondary" />
+              <span>Summary generated</span>
+            </TreeItemRow>
+            <TreeList>
+              <TreeItem>
+                <TreeItemRow>
+                  <Circle className="size-3.5 text-foreground-tertiary" />
+                  <span className="text-foreground-secondary">
+                    Label suggestion
+                  </span>
+                </TreeItemRow>
+              </TreeItem>
+            </TreeList>
+          </TreeItem>
+          <TreeItem>
+            <TreeItemRow>
+              <FileText className="size-3.5 text-foreground-secondary" />
+              <span>Reply draft</span>
+            </TreeItemRow>
+          </TreeItem>
+        </TreeList>
+      </TreeItem>
+    </TreeList>
+  );
+}
+
+function RouteComponent() {
+  return (
+    <DocPage meta={meta}>
+      <DocSection
+        title="Basic"
+        description="Guides are computed automatically. Skip keeps a vertical line through the row. Join branches from the parent into row content."
+      >
+        <Demo
+          code={`<TreeList>
+  <TreeItem>
+    <TreeItemRow>Thread read</TreeItemRow>
+    <TreeList>
+      <TreeItem>
+        <TreeItemRow>Summary generated</TreeItemRow>
+        <TreeList>
+          <TreeItem>
+            <TreeItemRow>Label suggestion</TreeItemRow>
+          </TreeItem>
+        </TreeList>
+      </TreeItem>
+      <TreeItem>
+        <TreeItemRow>Reply draft</TreeItemRow>
+      </TreeItem>
+    </TreeList>
+  </TreeItem>
+</TreeList>`}
+        >
+          <SignalTreeDemo />
+        </Demo>
+      </DocSection>
+
+      <DocSection
+        title="Indicators"
+        description="Compose TreeJoin and TreeSkip manually when TreeItemRow is not a fit."
+      >
+        <Demo
+          code={`<div className="flex flex-col">
+  <div className="flex min-h-8 items-stretch gap-1 text-sm">
+    <TreeJoin />
+    <span className="flex flex-1 items-center py-1">First</span>
+  </div>
+  <div className="flex min-h-8 items-stretch gap-1 text-sm">
+    <TreeSkip />
+    <span className="flex flex-1 items-center py-1">Middle</span>
+  </div>
+  <div className="flex min-h-8 items-stretch gap-1 text-sm">
+    <TreeJoin isLast />
+    <span className="flex flex-1 items-center py-1">Last</span>
+  </div>
+</div>`}
+        >
+          <div className="max-w-md rounded-md border bg-background-secondary p-3">
+            <div className="flex flex-col">
+              <div className="flex min-h-8 items-stretch gap-1 text-sm">
+                <TreeJoin />
+                <span className="flex flex-1 items-center py-1 text-foreground-primary">
+                  First
+                </span>
+              </div>
+              <div className="flex min-h-8 items-stretch gap-1 text-sm">
+                <TreeSkip />
+                <span className="flex flex-1 items-center py-1 text-foreground-primary">
+                  Middle
+                </span>
+              </div>
+              <div className="flex min-h-8 items-stretch gap-1 text-sm">
+                <TreeJoin isLast />
+                <span className="flex flex-1 items-center py-1 text-foreground-primary">
+                  Last
+                </span>
+              </div>
+            </div>
+          </div>
+        </Demo>
+      </DocSection>
+
+      <DocSection
+        title="Stretch"
+        description="stretchStart, stretchEnd, and stretchSide extend guides beyond the indicator box — useful for bridging row gaps or reaching into content."
+      >
+        <Demo
+          code={`<div className="flex flex-col">
+  <div className="flex min-h-10 items-stretch gap-1 overflow-visible text-sm">
+    <TreeJoin stretchEnd={12} stretchSide={6} />
+    <span className="flex flex-1 items-center py-1">Parent</span>
+  </div>
+  <div className="flex min-h-10 items-stretch gap-1 overflow-visible text-sm">
+    <TreeSkip stretchStart={12} stretchEnd={12} />
+    <TreeJoin stretchStart={12} isLast stretchSide={6} />
+    <span className="flex flex-1 items-center py-1">Child</span>
+  </div>
+</div>`}
+        >
+          <div className="max-w-md rounded-md border bg-background-secondary p-3">
+            <div className="flex flex-col">
+              <div className="flex min-h-10 items-stretch gap-1 overflow-visible text-sm">
+                <TreeJoin stretchEnd={12} stretchSide={6} />
+                <span className="flex flex-1 items-center py-1 text-foreground-primary">
+                  Parent
+                </span>
+              </div>
+              <div className="flex min-h-10 items-stretch gap-1 overflow-visible text-sm">
+                <TreeSkip stretchStart={12} stretchEnd={12} />
+                <TreeJoin stretchStart={12} isLast stretchSide={6} />
+                <span className="flex flex-1 items-center py-1 text-foreground-primary">
+                  Child
+                </span>
+              </div>
+            </div>
+          </div>
+        </Demo>
+      </DocSection>
+
+      <DocSection
+        title="API"
+        description="Props in addition to the native element props."
+      >
+        <PropsTable
+          rows={[
+            {
+              name: "stretchStart",
+              type: "number",
+              default: "0",
+              description:
+                "Pixels to extend guides upward beyond the indicator box (TreeJoin, TreeSkip). TreeItemRow defaults this to the tree gap (4px, matching gap-1).",
+            },
+            {
+              name: "stretchEnd",
+              type: "number",
+              default: "0",
+              description:
+                "Pixels to extend guides downward beyond the indicator box (TreeJoin, TreeSkip).",
+            },
+            {
+              name: "stretchSide",
+              type: "number",
+              default: "0",
+              description:
+                "Pixels to extend the horizontal join branch rightward into row content (TreeJoin).",
+            },
+            {
+              name: "isLast (TreeJoin)",
+              type: "boolean",
+              default: "from context",
+              description:
+                "Last sibling uses a half-height vertical segment before the horizontal branch.",
+            },
+          ]}
+        />
+      </DocSection>
+
+      <DocSection
+        title="Anatomy"
+        description="Compose rows and nested lists explicitly — guides flow from parent TreeItem into child TreeList."
+      >
+        <Anatomy
+          code={`<TreeList>
+  <TreeItem>
+    <TreeItemRow>{label}</TreeItemRow>
+    <TreeList>
+      <TreeItem>…</TreeItem>
+    </TreeList>
+  </TreeItem>
+</TreeList>`}
+        />
+      </DocSection>
+    </DocPage>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a composable `Tree` primitive (`TreeList`, `TreeItem`, `TreeSkip`, `TreeJoin`) for nested rows with left-side guide lines
- Documents the component in UI Studio (`/tree`)
- Refactors `ThreadReadCard` to render summary, recommendation, and quick suggestions using the tree layout

Stacked on #312.

## Test plan

- [ ] Open UI Studio `/tree` and verify demos render correctly
- [ ] Open a thread read signal card and confirm summary/recommendation tree guides align
- [ ] Verify quick suggestions row layout with tree join lines

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a composable `Tree` UI primitive for nested rows with left guide lines and refactors the Thread Read card to use it for header, summary, recommendation, and quick suggestions. Documents the component in UI Studio at `/tree`.

- **New Features**
  - Adds `TreeList`, `TreeItem`, `TreeItemRow`, `TreeSkip`, `TreeJoin`, and `TREE_ROW_GAP_PX` to `@workspace/ui`.
  - `TreeItemRow` auto-computes guide columns; manual composition supports `stretchStart`, `stretchEnd`, and `stretchSide`; adds `/tree` docs and sidebar link.

- **Bug Fixes**
  - Corrects summary row guides in `ThreadReadCard` using `TreeJoin isLast={!read.recommendation}` to avoid a dangling continuation line.
  - Narrows `TreeSkip` props to omit `stretchSide`, preventing an unsupported DOM prop.

<sup>Written for commit 264e4c2963593697861cf7bd14b647dd4dc17822. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #312
2. **#313** 👈 current
<!-- stack:links:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Tree component documentation page with examples, API details, and anatomy guidance.
  * Added a Tree entry to the sidebar for easier navigation.
  * Introduced reusable Tree layout components for building nested, connected item lists.

* **UI Improvements**
  * Updated thread read cards to use the new tree-style layout for clearer hierarchy and spacing.
  * Refined quick suggestions layout for a cleaner, more flexible display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->