### PR TITLE
feat(api,apps): migrate reads to custom query procedures (live-state 1.0)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -61,6 +61,41 @@ await (storage as unknown as {
   init: (schema: unknown) => Promise<void>;
 }).init(schema);
 
+/**
+ * Mirror non-sensitive billing state (plan/status) onto `organization.settings`
+ * so every member gets correct feature gating. Billing identifiers stay on the
+ * owner-only `subscription` row and are never copied here.
+ */
+const mirrorPlanToOrgSettings = async (
+  organizationId: string,
+  patch: { plan?: string; status?: string | null },
+) => {
+  const org = Object.values(
+    await storage.find(schema.organization, {
+      where: { id: organizationId },
+    }),
+  )[0];
+  if (!org) return;
+
+  const rawSettings =
+    org.settings &&
+    typeof org.settings === "object" &&
+    !Array.isArray(org.settings)
+      ? (org.settings as Record<string, unknown>)
+      : {};
+
+  await storage.update(schema.organization, organizationId, {
+    settings: {
+      ...rawSettings,
+      ...(patch.plan !== undefined ? { plan: patch.plan } : {}),
+      ...(patch.status !== undefined
+        ? { subscriptionStatus: patch.status }
+        : {}),
+      // biome-ignore lint/suspicious/noExplicitAny: settings JSON is opaque here
+    } as any,
+  });
+};
+
 const lsServer = server({
   router,
   storage,
@@ -213,6 +248,11 @@ process.env.DODO_PAYMENTS_WEBHOOK_KEY &&
           subscriptionId: payload.data.subscription_id,
           seats: payload.data.quantity ?? 1,
         });
+
+        await mirrorPlanToOrgSettings(subscription.organizationId, {
+          plan,
+          status: "active",
+        });
       },
       onSubscriptionExpired: async (payload) => {
         const subscription = Object.values(
@@ -227,6 +267,10 @@ process.env.DODO_PAYMENTS_WEBHOOK_KEY &&
         await storage.update(schema.subscription, subscription.id, {
           status: "expired",
           updatedAt: new Date(),
+        });
+
+        await mirrorPlanToOrgSettings(subscription.organizationId, {
+          status: "expired",
         });
       },
       onSubscriptionPlanChanged: async (payload) => {
@@ -258,6 +302,11 @@ process.env.DODO_PAYMENTS_WEBHOOK_KEY &&
           updatedAt: new Date(),
           subscriptionId: payload.data.subscription_id,
         });
+
+        await mirrorPlanToOrgSettings(subscription.organizationId, {
+          plan,
+          status: payload.data.status,
+        });
       },
       onSubscriptionCancelled: async (payload) => {
         const subscription = Object.values(
@@ -272,6 +321,10 @@ process.env.DODO_PAYMENTS_WEBHOOK_KEY &&
         await storage.update(schema.subscription, subscription.id, {
           status: "cancelled",
           updatedAt: new Date(),
+        });
+
+        await mirrorPlanToOrgSettings(subscription.organizationId, {
+          status: "cancelled",
         });
       },
     }) as any,

--- a/apps/api/src/live-state/migrations/files/003_backfill_subscription_plan_to_settings.ts
+++ b/apps/api/src/live-state/migrations/files/003_backfill_subscription_plan_to_settings.ts
@@ -11,8 +11,13 @@ const migration: Migration = {
     const orgs = await db.organization.where({}).get();
 
     for (const org of orgs) {
+      // Order deterministically so a (rare) multi-row org mirrors its most
+      // recent billing state rather than an arbitrary row.
       const subscription = (
-        await db.subscription.where({ organizationId: org.id }).get()
+        await db.subscription
+          .where({ organizationId: org.id })
+          .orderBy("updatedAt", "desc")
+          .get()
       )[0];
 
       // Preserve any unrelated keys on settings — only patch plan/status.

--- a/apps/api/src/live-state/migrations/files/003_backfill_subscription_plan_to_settings.ts
+++ b/apps/api/src/live-state/migrations/files/003_backfill_subscription_plan_to_settings.ts
@@ -1,0 +1,40 @@
+import type { Migration } from "../types";
+
+/**
+ * Denormalize each org's `subscription.plan` / `subscription.status` into
+ * `organization.settings` so all members get correct feature gating without
+ * syncing the owner-only subscription row (which carries billing identifiers).
+ */
+const migration: Migration = {
+  name: "003_backfill_subscription_plan_to_settings",
+  up: async ({ db }) => {
+    const orgs = await db.organization.where({}).get();
+
+    for (const org of orgs) {
+      const subscription = (
+        await db.subscription.where({ organizationId: org.id }).get()
+      )[0];
+
+      // Preserve any unrelated keys on settings — only patch plan/status.
+      const rawSettings =
+        org.settings &&
+        typeof org.settings === "object" &&
+        !Array.isArray(org.settings)
+          ? (org.settings as Record<string, unknown>)
+          : {};
+
+      const next = {
+        ...rawSettings,
+        plan: subscription?.plan ?? "trial",
+        subscriptionStatus: subscription?.status ?? null,
+      };
+
+      await db.organization.update(org.id, {
+        // biome-ignore lint/suspicious/noExplicitAny: settings JSON is opaque to migrations
+        settings: next as any,
+      });
+    }
+  },
+};
+
+export default migration;

--- a/apps/api/src/live-state/migrations/files/index.ts
+++ b/apps/api/src/live-state/migrations/files/index.ts
@@ -1,5 +1,6 @@
 import type { Migration } from "../types";
 import m001 from "./001_backfill_thread_short_id";
 import m002 from "./002_seed_autonomy_settings";
+import m003 from "./003_backfill_subscription_plan_to_settings";
 
-export const migrations: Migration[] = [m001, m002];
+export const migrations: Migration[] = [m001, m002, m003];

--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -155,6 +155,8 @@ export const router = createRouter({
                 lastDigestSentAt: null,
               },
               actionAutonomy: getDefaultActionAutonomy(),
+              plan: "trial",
+              subscriptionStatus: null,
             },
           });
 
@@ -421,6 +423,10 @@ export const router = createRouter({
             .where({
               userId,
               ...(req.input.enabledOnly ? { enabled: true } : {}),
+              // Subscriptions are owner-only: when requested, restrict to the
+              // caller's owner memberships so billing data never leaks to
+              // non-owner members.
+              ...(req.input.withSubscriptions ? { role: "owner" } : {}),
             })
             .include({
               organization: req.input.withSubscriptions
@@ -455,7 +461,10 @@ export const router = createRouter({
                   },
                   invites: true,
                   integrations: true,
-                  subscriptions: true,
+                  // `subscriptions` is intentionally NOT synced here: it carries
+                  // billing identifiers and is owner-only (see subscription.forOrg).
+                  // Feature-gating state lives in organization.settings (plan,
+                  // subscriptionStatus), which syncs to every member.
                   labels: true,
                   organizationUsers: {
                     include: { user: true },

--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -14,12 +14,12 @@ import { addDays, addYears } from "date-fns";
 import { ulid } from "ulid";
 import { z } from "zod";
 import { publicKeys } from "../lib/api-key";
-import { authorize, assertInviteRecipient, authorizeSelfOrInternal, getWorkspaceActor } from "../lib/authorize";
+import { authorize, assertInviteRecipient, authorizeSelfOrInternal, getWorkspaceActor, requireInternalApiKey } from "../lib/authorize";
 import { dodopayments } from "../lib/payment";
 import { resend } from "../lib/resend";
 import { sendWelcomeEmail } from "../trigger/send-welcome-email";
 import { privateRoute, publicRoute } from "./factories";
-import { agentChatMessageRoute, agentChatRoute } from "./router/agent-chat";
+import { agentChatRoute } from "./router/agent-chat";
 import autonomousActionRoute from "./router/autonomous-action";
 import documentationSourcesRoute from "./router/documentation-sources";
 import externalEntityRoute from "./router/external-entity";
@@ -60,16 +60,58 @@ const RESERVED_ORG_SLUGS: readonly string[] = [
 export const router = createRouter({
   schema,
   routes: {
-    organization: publicRoute
-      .collectionRoute(schema.organization, {
-        read: () => true,
-        insert: () => false,
-        update: {
-          preMutation: () => false,
-          postMutation: () => false,
-        },
-      })
-      .withProcedures(({ mutation }) => ({
+    organization: publicRoute.withProcedures(({ mutation, query }) => ({
+        /** Single organization by slug — public portal shell. */
+        bySlug: query(z.object({ slug: z.string() })).handler(
+          async ({ db, req }) =>
+            Object.values(
+              await db.find(schema.organization, {
+                where: { slug: req.input.slug.toLowerCase() },
+              }),
+            )[0],
+        ),
+        /** Single organization by id — cli, worker, integration bots. */
+        byId: query(z.object({ id: z.string() })).handler(
+          async ({ db, req }) =>
+            db.organization.one(req.input.id).get(),
+        ),
+        /** All organizations — cli listing and public sitemap generation. */
+        list: query().handler(async ({ db }) =>
+          Object.values(await db.find(schema.organization, {})),
+        ),
+        // Un-executed query returned to integration clients (discord/slack/
+        // github), which load it via `client.load`. The whole-tree read has no
+        // per-resource backstop now (live-state 1.0), so it is gated to internal
+        // bot keys — the only callers — to avoid leaking every org's data.
+        load: query().handler(({ db, req }) => {
+          requireInternalApiKey(req.context);
+          return db.organization.include({
+            threads: {
+              include: {
+                messages: {
+                  include: {
+                    author: {
+                      include: { user: true },
+                    },
+                  },
+                },
+                updates: {
+                  include: { user: true },
+                },
+                labels: {
+                  include: { label: true },
+                },
+                author: {
+                  include: { user: true },
+                },
+              },
+            },
+            integrations: true,
+            authors: {
+              include: { user: true },
+            },
+          });
+        }),
         create: mutation(
           z.object({
             name: z.string(),
@@ -360,16 +402,77 @@ export const router = createRouter({
             }));
         }),
       })),
-    organizationUser: privateRoute
-      .collectionRoute(schema.organizationUser, {
-        read: () => true,
-        insert: () => false,
-        update: {
-          preMutation: () => false,
-          postMutation: () => false,
-        },
-      })
-      .withProcedures(({ mutation }) => ({
+    organizationUser: privateRoute.withProcedures(({ mutation, query }) => ({
+        /**
+         * The caller's own org memberships (each with its organization) — SSR
+         * loaders (billing, onboarding, workspace shell). Always scoped to the
+         * session user; `withSubscriptions` includes billing state for the
+         * owner-facing billing screen.
+         */
+        forUser: query(
+          z.object({
+            enabledOnly: z.boolean().optional(),
+            withSubscriptions: z.boolean().optional(),
+          }),
+        ).handler(async ({ req, db }) => {
+          const userId = req.context?.session?.userId;
+          if (!userId) throw new Error("UNAUTHORIZED");
+          return db.organizationUser
+            .where({
+              userId,
+              ...(req.input.enabledOnly ? { enabled: true } : {}),
+            })
+            .include({
+              organization: req.input.withSubscriptions
+                ? { include: { subscriptions: true } }
+                : true,
+            })
+            .get();
+        }),
+        // Un-executed query returned to the client, which loads it via
+        // `useLoadData`. Scoped to the session user server-side so the client
+        // never dictates which user's memberships (and org data) to sync.
+        load: query().handler(({ req, db }) =>
+          db.organizationUser
+            .where({ userId: req.context!.session!.userId })
+            .include({
+              organization: {
+                include: {
+                  threads: {
+                    include: {
+                      messages: {
+                        include: { author: true },
+                      },
+                      updates: {
+                        include: { user: true },
+                      },
+                      labels: {
+                        include: { label: true },
+                      },
+                      author: true,
+                      assignedUser: true,
+                    },
+                  },
+                  invites: true,
+                  integrations: true,
+                  subscriptions: true,
+                  labels: true,
+                  organizationUsers: {
+                    include: { user: true },
+                  },
+                  authors: true,
+                  onboardings: true,
+                  documentationSources: true,
+                  // TODO improve this to load only when needed
+                  agentChats: {
+                    include: { messages: true },
+                  },
+                  autonomousActions: true,
+                  externalEntities: true,
+                },
+              },
+            }),
+        ),
         inviteUser: mutation(
           z.object({
             organizationId: z.string(),
@@ -513,16 +616,7 @@ export const router = createRouter({
           });
         }),
       })),
-    user: publicRoute
-      .collectionRoute(schema.user, {
-        read: () => true,
-        insert: () => false,
-        update: {
-          preMutation: () => false,
-          postMutation: () => false,
-        },
-      })
-      .withProcedures(({ mutation }) => ({
+    user: publicRoute.withProcedures(({ mutation }) => ({
         updateProfile: mutation(
           z
             .object({
@@ -555,43 +649,49 @@ export const router = createRouter({
           });
         }),
       })),
-    author: publicRoute.collectionRoute(schema.author, {
-      read: () => true,
-      insert: () => false,
-      update: {
-        preMutation: () => false,
-        postMutation: () => false,
-      },
-    }),
-    invite: privateRoute
-      .collectionRoute(schema.invite, {
-        read: ({ ctx }) => {
-          if (ctx?.internalApiKey) return true;
-          if (!ctx?.session) return false;
-
-          return {
-            $or: [
-              {
-                organization: {
-                  organizationUsers: {
-                    userId: ctx.session.userId,
-                    enabled: true,
-                  },
-                },
-              },
-              {
-                email: ctx?.user?.email,
-              },
-            ],
-          };
+    author: publicRoute.withProcedures(({ query }) => ({
+      /** Authors by id (batch) — worker message-role resolution. */
+      byIds: query(z.object({ ids: z.array(z.string()) })).handler(
+        async ({ db, req }) => {
+          if (req.input.ids.length === 0) return [];
+          return Object.values(
+            await db.find(schema.author, {
+              where: { id: { $in: req.input.ids } },
+            }),
+          );
         },
-        insert: () => false,
-        update: {
-          preMutation: () => false,
-          postMutation: () => false,
-        },
-      })
-      .withProcedures(({ mutation }) => ({
+      ),
+    })),
+    invite: privateRoute.withProcedures(({ mutation, query }) => ({
+        /** Single invite by id, with org + creator — invitation accept page. */
+        byId: query(z.object({ id: z.string() })).handler(
+          async ({ db, req }) =>
+            db.invite
+              .one(req.input.id)
+              .include({ organization: true, creator: true })
+              .get(),
+        ),
+        /** Active, unexpired invites for an email — onboarding join prompt. */
+        forEmail: query(z.object({ email: z.string() })).handler(
+          async ({ db, req }) => {
+            const email = req.input.email;
+            // Callers may only look up their own email (internal keys excepted).
+            if (
+              !req.context?.internalApiKey &&
+              req.context?.user?.email?.toLowerCase() !== email.toLowerCase()
+            ) {
+              throw new Error("UNAUTHORIZED");
+            }
+            return db.invite
+              .where({
+                email,
+                active: true,
+                expiresAt: { $gt: new Date() },
+              })
+              .include({ organization: true })
+              .get();
+          },
+        ),
         accept: mutation(z.object({ id: z.string() })).handler(
           async ({ req, db }) => {
             await db.transaction(async ({ trx }) => {
@@ -668,42 +768,44 @@ export const router = createRouter({
         ),
       })),
     integration: integrationRoute,
-    allowlist: privateRoute.collectionRoute(schema.allowlist, {
-      read: ({ ctx }) => {
-        if (ctx?.internalApiKey) return true;
-        if (!ctx?.user?.email) return false;
-
-        return {
-          email: ctx.user.email.toLowerCase(),
-        };
-      },
-      insert: () => false,
-      update: {
-        preMutation: () => false,
-        postMutation: () => false,
-      },
-    }),
-    subscription: privateRoute.collectionRoute(schema.subscription, {
-      read: ({ ctx }) => {
-        if (ctx?.internalApiKey) return true;
-        if (!ctx?.session) return false;
-
-        return {
-          organization: {
-            organizationUsers: {
-              userId: ctx.session.userId,
-              enabled: true,
-              role: "owner",
-            },
-          },
-        };
-      },
-      insert: () => false,
-      update: {
-        preMutation: () => false,
-        postMutation: () => false,
-      },
-    }),
+    allowlist: privateRoute.withProcedures(({ query }) => ({
+      /** Whether an email is allowlisted — app gate in `beforeLoad`. */
+      forEmail: query(z.object({ email: z.string() })).handler(
+        async ({ db, req }) => {
+          const email = req.input.email.toLowerCase();
+          // Callers may only check their own email (internal keys excepted).
+          if (
+            !req.context?.internalApiKey &&
+            req.context?.user?.email?.toLowerCase() !== email
+          ) {
+            throw new Error("UNAUTHORIZED");
+          }
+          return Object.values(
+            await db.find(schema.allowlist, { where: { email } }),
+          )[0];
+        },
+      ),
+    })),
+    subscription: privateRoute.withProcedures(({ query }) => ({
+      /**
+       * Subscription for an org — billing UI and the integration bots' backfill
+       * gate. Owner-only for sessions (matching the old read clause); internal
+       * bot keys read freely.
+       */
+      forOrg: query(z.object({ organizationId: z.string() })).handler(
+        async ({ db, req }) => {
+          authorize(req, {
+            organizationId: req.input.organizationId,
+            role: "owner",
+          });
+          return Object.values(
+            await db.find(schema.subscription, {
+              where: { organizationId: req.input.organizationId },
+            }),
+          )[0];
+        },
+      ),
+    })),
     // Mirror of external issues/PRs. Default mutators are disabled; writes go
     // through the route's custom `upsert` / `softDelete` procedures.
     externalEntity: externalEntityRoute,
@@ -714,18 +816,8 @@ export const router = createRouter({
     onboarding: onboardingRoute,
     documentationSource: documentationSourcesRoute,
     agentChat: agentChatRoute,
-    agentChatMessage: agentChatMessageRoute,
     ...labelsRoute,
     ...pipelineRoutes,
-    // Server-only: migration bookkeeping managed by the boot-time runner.
-    migration: publicRoute.collectionRoute(schema.migration, {
-      read: () => false,
-      insert: () => false,
-      update: {
-        preMutation: () => false,
-        postMutation: () => false,
-      },
-    }),
   },
 });
 

--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -665,20 +665,31 @@ export const router = createRouter({
     invite: privateRoute.withProcedures(({ mutation, query }) => ({
         /** Single invite by id, with org + creator — invitation accept page. */
         byId: query(z.object({ id: z.string() })).handler(
-          async ({ db, req }) =>
-            db.invite
+          async ({ db, req }) => {
+            const invite = await db.invite
               .one(req.input.id)
               .include({ organization: true, creator: true })
-              .get(),
+              .get();
+            if (!invite) return undefined;
+            // Only the recipient, an org member, or an internal key may read
+            // the invite (which exposes email, org, and creator).
+            const callerEmail = req.context?.user?.email?.toLowerCase();
+            if (callerEmail !== invite.email.toLowerCase()) {
+              authorize(req, { organizationId: invite.organizationId });
+            }
+            return invite;
+          },
         ),
         /** Active, unexpired invites for an email — onboarding join prompt. */
         forEmail: query(z.object({ email: z.string() })).handler(
           async ({ db, req }) => {
-            const email = req.input.email;
+            // Invites are stored lowercased; normalize so casing differences
+            // don't hide a valid invite.
+            const email = req.input.email.toLowerCase();
             // Callers may only look up their own email (internal keys excepted).
             if (
               !req.context?.internalApiKey &&
-              req.context?.user?.email?.toLowerCase() !== email.toLowerCase()
+              req.context?.user?.email?.toLowerCase() !== email
             ) {
               throw new Error("UNAUTHORIZED");
             }

--- a/apps/api/src/live-state/router/agent-chat.ts
+++ b/apps/api/src/live-state/router/agent-chat.ts
@@ -22,28 +22,7 @@ import {
   STATUS_LABELS,
 } from "./agent-chat-core";
 
-export const agentChatRoute = privateRoute
-  .collectionRoute(schema.agentChat, {
-    read: ({ ctx }) => {
-      if (ctx?.internalApiKey) return true;
-      if (!ctx?.session) return false;
-
-      return {
-        organization: {
-          organizationUsers: {
-            userId: ctx.session.userId,
-            enabled: true,
-          },
-        },
-      };
-    },
-    insert: () => false,
-    update: {
-      preMutation: () => false,
-      postMutation: () => false,
-    },
-  })
-  .withProcedures(({ mutation }) => ({
+export const agentChatRoute = privateRoute.withProcedures(({ mutation }) => ({
     create: mutation(
       z.object({
         organizationId: z.string(),
@@ -783,28 +762,6 @@ export const agentChatRoute = privateRoute
     }),
   }));
 
-export const agentChatMessageRoute = privateRoute.collectionRoute(
-  schema.agentChatMessage,
-  {
-    read: ({ ctx }) => {
-      if (ctx?.internalApiKey) return true;
-      if (!ctx?.session) return false;
-
-      return {
-        agentChat: {
-          organization: {
-            organizationUsers: {
-              userId: ctx.session.userId,
-              enabled: true,
-            },
-          },
-        },
-      };
-    },
-    insert: () => false,
-    update: {
-      preMutation: () => false,
-      postMutation: () => false,
-    },
-  },
-);
+// `agentChatMessage` no longer needs its own route: messages are written via
+// `agentChat.sendMessage` and read as part of the org tree (agentChats.messages).
+// A resource is queryable by virtue of being in the schema (live-state 1.0).

--- a/apps/api/src/live-state/router/autonomous-action.ts
+++ b/apps/api/src/live-state/router/autonomous-action.ts
@@ -13,30 +13,8 @@ import {
 import { authorize, getWorkspaceActor, requireInternalApiKey } from "../../lib/authorize";
 import { runRecordActivity } from "../../lib/update-mutations";
 import { privateRoute } from "../factories";
-import { schema } from "../schema";
 
-export default privateRoute
-  .collectionRoute(schema.autonomousAction, {
-    read: ({ ctx }) => {
-      if (ctx?.internalApiKey) return true;
-      if (!ctx?.session) return false;
-
-      return {
-        organization: {
-          organizationUsers: {
-            userId: ctx.session.userId,
-            enabled: true,
-          },
-        },
-      };
-    },
-    insert: () => false,
-    update: {
-      preMutation: () => false,
-      postMutation: () => false,
-    },
-  })
-  .withProcedures(({ mutation }) => ({
+export default privateRoute.withProcedures(({ mutation }) => ({
     record: mutation(recordAutonomousActionInputSchema).handler(
       async ({ req, db }) => {
         // Receipts are written by the worker only — never by user sessions or

--- a/apps/api/src/live-state/router/documentation-sources.ts
+++ b/apps/api/src/live-state/router/documentation-sources.ts
@@ -151,28 +151,7 @@ const checkFeatureFlag = async (organizationId: string) => {
   }
 };
 
-export default privateRoute
-  .collectionRoute(schema.documentationSource, {
-    read: ({ ctx }) => {
-      if (ctx?.internalApiKey) return true;
-      if (!ctx?.session) return false;
-
-      return {
-        organization: {
-          organizationUsers: {
-            userId: ctx.session.userId,
-            enabled: true,
-          },
-        },
-      };
-    },
-    insert: () => false,
-    update: {
-      preMutation: () => false,
-      postMutation: () => false,
-    },
-  })
-  .withProcedures(({ mutation }) => ({
+export default privateRoute.withProcedures(({ mutation }) => ({
     syncCrawlProgress: mutation(syncCrawlProgressInputSchema).handler(
       async ({ req, db }) => {
         requireInternalApiKey(req.context);

--- a/apps/api/src/live-state/router/external-entity.ts
+++ b/apps/api/src/live-state/router/external-entity.ts
@@ -70,6 +70,7 @@ export default privateRoute.withProcedures(({ mutation, query }) => ({
           where: {
             organizationId: req.input.organizationId,
             repoFullName: req.input.repoFullName,
+            provider: "github",
             deletedAt: null,
           },
         }),

--- a/apps/api/src/live-state/router/external-entity.ts
+++ b/apps/api/src/live-state/router/external-entity.ts
@@ -53,29 +53,29 @@ const externalEntityFields = z.object({
   baseRef: z.string().nullable(),
 });
 
-export default privateRoute
-  .collectionRoute(schema.externalEntity, {
-    read: ({ ctx }) => {
-      if (ctx?.internalApiKey) return true;
-      if (!ctx?.session) return false;
-
-      return {
-        organization: {
-          organizationUsers: {
-            userId: ctx.session.userId,
-            enabled: true,
+export default privateRoute.withProcedures(({ mutation, query }) => ({
+    /**
+     * Non-deleted mirror rows for a repo — the reconcile job's cursor/baseline.
+     * Internal (integration) use only; in-app reads flow through the org tree.
+     */
+    listForRepo: query(
+      z.object({
+        organizationId: z.string(),
+        repoFullName: z.string(),
+      }),
+    ).handler(async ({ req, db }) => {
+      requireInternalApiKey(req.context);
+      return Object.values(
+        await db.find(schema.externalEntity, {
+          where: {
+            organizationId: req.input.organizationId,
+            repoFullName: req.input.repoFullName,
+            deletedAt: null,
           },
-        },
-      };
-    },
-    // Writes go through the custom procedures only.
-    insert: () => false,
-    update: {
-      preMutation: () => false,
-      postMutation: () => false,
-    },
-  })
-  .withProcedures(({ mutation }) => ({
+        }),
+      );
+    }),
+
     /**
      * Insert or update the mirror row identified by
      * `(organizationId, externalKey)`. Refreshes `lastSyncedAt` and clears any

--- a/apps/api/src/live-state/router/integration.ts
+++ b/apps/api/src/live-state/router/integration.ts
@@ -36,12 +36,14 @@ export default privateRoute.withProcedures(({ mutation, query }) => ({
     // bot keys read freely; sessions are scoped to their org membership via
     // `authorize`. In-app reads still flow through the org-tree load procedure.
 
-    /** Single integration by id (bot config refetch, web redirect handlers). */
+    /**
+     * Single integration by id — internal (bot) use only, so it can't be used
+     * to probe whether an arbitrary integration id exists. In-app reads flow
+     * through the org tree; web redirect handlers use `forOrg`.
+     */
     byId: query(z.object({ id: z.string() })).handler(async ({ req, db }) => {
-      const integration = await db.integration.one(req.input.id).get();
-      if (!integration) return undefined;
-      authorize(req, { organizationId: integration.organizationId });
-      return integration;
+      requireInternalApiKey(req.context);
+      return db.integration.one(req.input.id).get();
     }),
 
     /** Single integration for an org, optionally filtered by type/enabled. */

--- a/apps/api/src/live-state/router/integration.ts
+++ b/apps/api/src/live-state/router/integration.ts
@@ -1,6 +1,6 @@
 import { ulid } from "ulid";
 import { z } from "zod";
-import { authorize } from "../../lib/authorize";
+import { authorize, requireInternalApiKey } from "../../lib/authorize";
 import { privateRoute } from "../factories";
 import { schema } from "../schema";
 import { slackChannelsCache } from "./slack-channels";
@@ -30,28 +30,54 @@ const updateInstallationInputSchema = z
     { message: "NO_FIELDS_TO_UPDATE" },
   );
 
-export default privateRoute
-  .collectionRoute(schema.integration, {
-    read: ({ ctx }) => {
-      if (ctx?.internalApiKey) return true;
-      if (!ctx?.session) return false;
+export default privateRoute.withProcedures(({ mutation, query }) => ({
+    // --- Reads ---------------------------------------------------------------
+    // Replaces the removed default-query path. Auth is per-handler now: internal
+    // bot keys read freely; sessions are scoped to their org membership via
+    // `authorize`. In-app reads still flow through the org-tree load procedure.
 
-      return {
-        organization: {
-          organizationUsers: {
-            userId: ctx.session.userId,
-            enabled: true,
+    /** Single integration by id (bot config refetch, web redirect handlers). */
+    byId: query(z.object({ id: z.string() })).handler(async ({ req, db }) => {
+      const integration = await db.integration.one(req.input.id).get();
+      if (!integration) return undefined;
+      authorize(req, { organizationId: integration.organizationId });
+      return integration;
+    }),
+
+    /** Single integration for an org, optionally filtered by type/enabled. */
+    forOrg: query(
+      z.object({
+        organizationId: z.string(),
+        type: z.string().optional(),
+        enabled: z.boolean().optional(),
+      }),
+    ).handler(async ({ req, db }) => {
+      const { organizationId, type, enabled } = req.input;
+      authorize(req, { organizationId });
+      return Object.values(
+        await db.find(schema.integration, {
+          where: {
+            organizationId,
+            ...(type !== undefined ? { type } : {}),
+            ...(enabled !== undefined ? { enabled } : {}),
           },
-        },
-      };
-    },
-    insert: () => false,
-    update: {
-      preMutation: () => false,
-      postMutation: () => false,
-    },
-  })
-  .withProcedures(({ mutation }) => ({
+        }),
+      )[0];
+    }),
+
+    /** All integrations of a given type across orgs — internal (bot) use only. */
+    listByType: query(z.object({ type: z.string() })).handler(
+      async ({ req, db }) => {
+        requireInternalApiKey(req.context);
+        return Object.values(
+          await db.find(schema.integration, {
+            where: { type: req.input.type },
+          }),
+        );
+      },
+    ),
+
+    // --- Mutations -----------------------------------------------------------
     connectInstallation: mutation(connectInstallationInputSchema).handler(
       async ({ req, db }) => {
         const { organizationId, type, enabled, configStr, id, createdAt, updatedAt } =

--- a/apps/api/src/live-state/router/labels.ts
+++ b/apps/api/src/live-state/router/labels.ts
@@ -95,8 +95,9 @@ export default {
         organizationId: z.string(),
         enabled: z.boolean().optional(),
       }),
-    ).handler(async ({ req, db }) =>
-      Object.values(
+    ).handler(async ({ req, db }) => {
+      authorize(req, { organizationId: req.input.organizationId });
+      return Object.values(
         await db.find(schema.label, {
           where: {
             organizationId: req.input.organizationId,
@@ -105,8 +106,8 @@ export default {
               : {}),
           },
         }),
-      ),
-    ),
+      );
+    }),
 
     create: mutation(
       z.object({

--- a/apps/api/src/live-state/router/labels.ts
+++ b/apps/api/src/live-state/router/labels.ts
@@ -88,14 +88,26 @@ const findThreadForAuthorizedOrganizations = async (
 };
 
 export default {
-  label: publicRoute.collectionRoute(schema.label, {
-    read: () => true,
-    insert: () => false,
-    update: {
-      preMutation: () => false,
-      postMutation: () => false,
-    },
-  }).withProcedures(({ mutation }) => ({
+  label: publicRoute.withProcedures(({ mutation, query }) => ({
+    /** Org's labels (optionally only enabled) — worker inline-label processor. */
+    forOrg: query(
+      z.object({
+        organizationId: z.string(),
+        enabled: z.boolean().optional(),
+      }),
+    ).handler(async ({ req, db }) =>
+      Object.values(
+        await db.find(schema.label, {
+          where: {
+            organizationId: req.input.organizationId,
+            ...(req.input.enabled !== undefined
+              ? { enabled: req.input.enabled }
+              : {}),
+          },
+        }),
+      ),
+    ),
+
     create: mutation(
       z.object({
         id: z.string().optional(),
@@ -308,12 +320,7 @@ export default {
     }),
   })),
 
-  threadLabel: publicRoute.collectionRoute(schema.threadLabel, {
-    read: () => true,
-    insert: () => false,
-    update: {
-      preMutation: () => false,
-      postMutation: () => false,
-    },
-  }),
+  // `threadLabel` no longer needs a route: it is written via the label
+  // attach/detach procedures and read as part of the org tree (thread.labels).
+  // A resource is queryable by virtue of being in the schema (live-state 1.0).
 };

--- a/apps/api/src/live-state/router/message.ts
+++ b/apps/api/src/live-state/router/message.ts
@@ -39,16 +39,29 @@ const setExternalMessageIdInputSchema = z.object({
   externalMessageId: z.string().min(1),
 });
 
-export default publicRoute
-  .collectionRoute(schema.message, {
-    read: () => true,
-    insert: () => false,
-    update: {
-      preMutation: () => false,
-      postMutation: () => false,
-    },
-  })
-  .withProcedures(({ mutation }) => ({
+export default publicRoute.withProcedures(({ mutation, query }) => ({
+    /**
+     * Existence/lookup of a message by its external (platform) id — dedupe
+     * checks in the integration bots. Public: mirrors the old open read.
+     */
+    byExternalId: query(
+      z.object({
+        externalMessageId: z.string(),
+        threadId: z.string().optional(),
+      }),
+    ).handler(async ({ req, db }) =>
+      Object.values(
+        await db.find(schema.message, {
+          where: {
+            externalMessageId: req.input.externalMessageId,
+            ...(req.input.threadId !== undefined
+              ? { threadId: req.input.threadId }
+              : {}),
+          },
+        }),
+      )[0],
+    ),
+
     create: mutation(messageCreateInputSchema).handler(async ({ req, db }) => {
       authorize(req, {
         organizationId: req.input.organizationId,

--- a/apps/api/src/live-state/router/onboarding.ts
+++ b/apps/api/src/live-state/router/onboarding.ts
@@ -5,28 +5,7 @@ import { authorize } from "../../lib/authorize";
 import { privateRoute } from "../factories";
 import { schema } from "../schema";
 
-export default privateRoute
-  .collectionRoute(schema.onboarding, {
-    read: ({ ctx }) => {
-      if (ctx?.internalApiKey) return true;
-      if (!ctx?.session) return false;
-
-      return {
-        organization: {
-          organizationUsers: {
-            userId: ctx.session.userId,
-            enabled: true,
-          },
-        },
-      };
-    },
-    insert: () => false,
-    update: {
-      preMutation: () => false,
-      postMutation: () => false,
-    },
-  })
-  .withProcedures(({ mutation }) => ({
+export default privateRoute.withProcedures(({ mutation }) => ({
     initialize: mutation(
       z.object({
         organizationId: z.string(),

--- a/apps/api/src/live-state/router/pipeline.ts
+++ b/apps/api/src/live-state/router/pipeline.ts
@@ -10,21 +10,25 @@ import {
   runUpsertIdempotencyKey,
   upsertIdempotencyKeyInputSchema,
 } from "../../lib/pipeline-mutations";
+import { z } from "zod";
 import { requireInternalApiKey } from "../../lib/authorize";
 import { publicRoute } from "../factories";
 import { schema } from "../schema";
 
 export const pipelineRoutes = {
-  pipelineIdempotencyKey: publicRoute
-    .collectionRoute(schema.pipelineIdempotencyKey, {
-      read: ({ ctx }) => !!ctx?.internalApiKey,
-      insert: () => false,
-      update: {
-        preMutation: () => false,
-        postMutation: () => false,
-      },
-    })
-    .withProcedures(({ mutation }) => ({
+  pipelineIdempotencyKey: publicRoute.withProcedures(({ mutation, query }) => ({
+      /** Idempotency keys by key value (batch) — worker internal only. */
+      byKeys: query(z.object({ keys: z.array(z.string()) })).handler(
+        async ({ req, db }) => {
+          requireInternalApiKey(req.context);
+          if (req.input.keys.length === 0) return [];
+          return Object.values(
+            await db.find(schema.pipelineIdempotencyKey, {
+              where: { key: { $in: req.input.keys } },
+            }),
+          );
+        },
+      ),
       upsert: mutation(upsertIdempotencyKeyInputSchema).handler(
         async ({ req, db }) => {
           requireInternalApiKey(req.context);
@@ -44,16 +48,16 @@ export const pipelineRoutes = {
         },
       ),
     })),
-  pipelineJob: publicRoute
-    .collectionRoute(schema.pipelineJob, {
-      read: ({ ctx }) => !!ctx?.internalApiKey,
-      insert: () => false,
-      update: {
-        preMutation: () => false,
-        postMutation: () => false,
-      },
-    })
-    .withProcedures(({ mutation }) => ({
+  pipelineJob: publicRoute.withProcedures(({ mutation, query }) => ({
+      /** Single pipeline job by id — worker internal only. */
+      byId: query(z.object({ id: z.string() })).handler(
+        async ({ req, db }) => {
+          requireInternalApiKey(req.context);
+          return Object.values(
+            await db.find(schema.pipelineJob, { where: { id: req.input.id } }),
+          )[0];
+        },
+      ),
       create: mutation(createPipelineJobInputSchema).handler(
         async ({ req, db }) => {
           requireInternalApiKey(req.context);

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -89,16 +89,7 @@ const threadCreateInputSchema = z.object({
 const GITHUB_SERVER_URL =
   process.env.BASE_GITHUB_SERVER_URL || "http://localhost:3334";
 
-export default publicRoute
-  .collectionRoute(schema.thread, {
-    read: () => true,
-    insert: () => false,
-    update: {
-      preMutation: () => false,
-      postMutation: () => false,
-    },
-  })
-  .withProcedures(({ mutation, query }) => ({
+export default publicRoute.withProcedures(({ mutation, query }) => ({
     create: mutation(threadCreateInputSchema).handler(async ({ req, db }) => {
       const organizationId =
         req.context?.publicApiKey?.ownerId ?? req.input.organizationId;
@@ -302,6 +293,89 @@ export default publicRoute
 
       return { threads, nextCursor };
     }),
+
+    /**
+     * Single thread with its full relation tree — portal thread page, workspace
+     * archive view, and devtools. Public, matching the old open `read` on
+     * threads. `onlyDeleted`/`deletedBefore` serve the archive (soft-deleted,
+     * pre-purge-window) lookups.
+     */
+    detail: query(
+      z.object({
+        id: z.string().optional(),
+        shortId: z.number().optional(),
+        organizationId: z.string().optional(),
+        onlyDeleted: z.boolean().optional(),
+        deletedBefore: z.coerce.date().optional(),
+      }),
+    ).handler(async ({ req, db }) => {
+      const { id, shortId, organizationId, onlyDeleted, deletedBefore } =
+        req.input;
+
+      const rows = await db.thread
+        .where({
+          ...(id !== undefined ? { id } : {}),
+          ...(shortId !== undefined ? { shortId } : {}),
+          ...(organizationId !== undefined ? { organizationId } : {}),
+          deletedAt: onlyDeleted
+            ? { $not: null, ...(deletedBefore ? { $lt: deletedBefore } : {}) }
+            : null,
+        })
+        .include({
+          author: true,
+          organization: true,
+          messages: { include: { author: true } },
+          assignedUser: true,
+          updates: { include: { user: true } },
+          labels: { include: { label: true } },
+        })
+        .get();
+
+      return rows[0];
+    }),
+
+    /** All threads with their org — sitemap generation. Public (open read). */
+    listAll: query().handler(async ({ db }) =>
+      db.thread.include({ organization: true, messages: true }).get(),
+    ),
+
+    /** Thread lookup by external (platform) id — integration bot dedupe. */
+    byExternalId: query(
+      z.object({
+        externalId: z.string(),
+        organizationId: z.string().optional(),
+        externalOrigin: z.string().optional(),
+      }),
+    ).handler(async ({ req, db }) => {
+      const { externalId, organizationId, externalOrigin } = req.input;
+      return Object.values(
+        await db.find(schema.thread, {
+          where: {
+            externalId,
+            ...(organizationId !== undefined ? { organizationId } : {}),
+            ...(externalOrigin !== undefined ? { externalOrigin } : {}),
+          },
+        }),
+      )[0];
+    }),
+
+    /**
+     * Threads by id (with messages + labels) — worker pipeline reads. Accepts a
+     * batch so callers can hydrate many threads in one round-trip.
+     */
+    byIds: query(z.object({ ids: z.array(z.string()) })).handler(
+      async ({ req, db }) => {
+        if (req.input.ids.length === 0) return [];
+        return db.thread
+          .where({ id: { $in: req.input.ids } })
+          .include({
+            messages: true,
+            labels: { include: { label: true } },
+          })
+          .get();
+      },
+    ),
+
     // TODO(signals-overhaul issue 10): rewrite against thread.agentRead /
     // thread.inlineSuggestions (or replace with a new related-threads source).
     // The suggestion table backing this was dropped in issue 02; returns [] now.

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -356,7 +356,9 @@ export default publicRoute.withProcedures(({ mutation, query }) => ({
     byExternalId: query(
       z.object({
         externalId: z.string(),
-        organizationId: z.string().optional(),
+        // Required so dedupe/reads are always tenant-scoped — external ids can
+        // collide across organizations.
+        organizationId: z.string(),
         externalOrigin: z.string().optional(),
       }),
     ).handler(async ({ req, db }) => {
@@ -365,7 +367,7 @@ export default publicRoute.withProcedures(({ mutation, query }) => ({
         await db.find(schema.thread, {
           where: {
             externalId,
-            ...(organizationId !== undefined ? { organizationId } : {}),
+            organizationId,
             ...(externalOrigin !== undefined ? { externalOrigin } : {}),
           },
         }),

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -301,13 +301,23 @@ export default publicRoute.withProcedures(({ mutation, query }) => ({
      * pre-purge-window) lookups.
      */
     detail: query(
-      z.object({
-        id: z.string().optional(),
-        shortId: z.number().optional(),
-        organizationId: z.string().optional(),
-        onlyDeleted: z.boolean().optional(),
-        deletedBefore: z.coerce.date().optional(),
-      }),
+      z
+        .object({
+          id: z.string().optional(),
+          shortId: z.number().optional(),
+          organizationId: z.string().optional(),
+          onlyDeleted: z.boolean().optional(),
+          deletedBefore: z.coerce.date().optional(),
+        })
+        .refine(
+          (input) => input.id !== undefined || input.shortId !== undefined,
+          { message: "THREAD_SELECTOR_REQUIRED" },
+        )
+        .refine(
+          (input) =>
+            input.shortId === undefined || input.organizationId !== undefined,
+          { message: "SHORT_ID_REQUIRES_ORGANIZATION" },
+        ),
     ).handler(async ({ req, db }) => {
       const { id, shortId, organizationId, onlyDeleted, deletedBefore } =
         req.input;
@@ -336,7 +346,10 @@ export default publicRoute.withProcedures(({ mutation, query }) => ({
 
     /** All threads with their org — sitemap generation. Public (open read). */
     listAll: query().handler(async ({ db }) =>
-      db.thread.include({ organization: true, messages: true }).get(),
+      db.thread
+        .where({ deletedAt: null })
+        .include({ organization: true, messages: true })
+        .get(),
     ),
 
     /** Thread lookup by external (platform) id — integration bot dedupe. */

--- a/apps/api/src/live-state/router/update.ts
+++ b/apps/api/src/live-state/router/update.ts
@@ -6,18 +6,8 @@ import {
   runRecordActivity,
 } from "../../lib/update-mutations";
 import { publicRoute } from "../factories";
-import { schema } from "../schema";
 
-export default publicRoute
-  .collectionRoute(schema.update, {
-    read: () => true,
-    insert: () => false,
-    update: {
-      preMutation: () => false,
-      postMutation: () => false,
-    },
-  })
-  .withProcedures(({ mutation }) => ({
+export default publicRoute.withProcedures(({ mutation }) => ({
     recordActivity: mutation(recordActivityInputSchema).handler(
       async ({ req, db }) => {
         authorize(req, {

--- a/apps/cli/src/commands/org/list.ts
+++ b/apps/cli/src/commands/org/list.ts
@@ -23,7 +23,7 @@ export const runOrgList = async (): Promise<{
   assertLocalhostApiUrl(getApiUrl());
 
   const webUrl = getWebUrl();
-  const organizations = await fetchClient.query.organization.get();
+  const organizations = await fetchClient.query.organization.list();
 
   const items: OrgListItem[] = organizations.map((org) => ({
     id: org.id,

--- a/apps/cli/src/lib/org.ts
+++ b/apps/cli/src/lib/org.ts
@@ -16,10 +16,10 @@ export const resolveOrganization = async (
   }
 
   const organization = ULID_RE.test(trimmed)
-    ? await fetchClient.query.organization.first({ id: trimmed.toLowerCase() }).get()
-    : await fetchClient.query.organization
-        .first({ slug: trimmed.toLowerCase() })
-        .get();
+    ? await fetchClient.query.organization.byId({ id: trimmed.toLowerCase() })
+    : await fetchClient.query.organization.bySlug({
+        slug: trimmed.toLowerCase(),
+      });
 
   if (!organization) {
     throw new Error(`Organization not found: ${trimmed}`);

--- a/apps/discord/src/index.ts
+++ b/apps/discord/src/index.ts
@@ -156,9 +156,7 @@ const backfillChannel = async (
 
     // Check budget and queue thread jobs (all inside lock so total stays accurate if enqueue fails)
     const budgetExhausted = await withBackfillLock(integrationId, async () => {
-      const integration = await fetchClient.query.integration
-        .first({ id: integrationId })
-        .get();
+      const integration = await fetchClient.query.integration.byId({ id: integrationId });
       const currentSettings = safeParseIntegrationSettings(
         integration?.configStr ?? null,
       );
@@ -196,9 +194,7 @@ const backfillChannel = async (
     if (!hasMoreArchived || budgetExhausted) {
       // This channel is done discovering — decrement channelsDiscovering
       await withBackfillLock(integrationId, async () => {
-        const integration = await fetchClient.query.integration
-          .first({ id: integrationId })
-          .get();
+        const integration = await fetchClient.query.integration.byId({ id: integrationId });
         const settings = safeParseIntegrationSettings(
           integration?.configStr ?? null,
         );
@@ -246,9 +242,7 @@ const backfillChannel = async (
     console.error(`    Error fetching threads from #${channel.name}:`, error);
     // Decrement channelsDiscovering on error so backfill can complete
     await withBackfillLock(integrationId, async () => {
-      const integration = await fetchClient.query.integration
-        .first({ id: integrationId })
-        .get();
+      const integration = await fetchClient.query.integration.byId({ id: integrationId });
       const settings = safeParseIntegrationSettings(
         integration?.configStr ?? null,
       );
@@ -306,9 +300,7 @@ const handleIntegrationChanges = async (
       // Migration: if syncedChannels is undefined, initialize from current selectedChannels
       // This prevents false trigger on first deploy with new code
       if (settings.syncedChannels === undefined) {
-        const latestIntegration = await fetchClient.query.integration
-          .first({ id: integration.id })
-          .get();
+        const latestIntegration = await fetchClient.query.integration.byId({ id: integration.id });
         await updateSyncedChannels(
           integration.id,
           latestIntegration?.configStr ?? integration.configStr,
@@ -335,9 +327,7 @@ const handleIntegrationChanges = async (
       if (addedChannels.length === 0) {
         // Persist cleanup only (no new channels to add)
         if (hadCleanup) {
-          const latestIntegration = await fetchClient.query.integration
-            .first({ id: integration.id })
-            .get();
+          const latestIntegration = await fetchClient.query.integration.byId({ id: integration.id });
           await updateSyncedChannels(
             integration.id,
             latestIntegration?.configStr ?? null,
@@ -349,9 +339,7 @@ const handleIntegrationChanges = async (
 
       // Consolidate cleanup + add into a single update; use fresh config to avoid overwriting concurrent changes
       const finalSynced = [...syncedChannels, ...addedChannels];
-      const latestIntegration = await fetchClient.query.integration
-        .first({ id: integration.id })
-        .get();
+      const latestIntegration = await fetchClient.query.integration.byId({ id: integration.id });
       const freshConfigStr = latestIntegration?.configStr ?? null;
 
       // Check if backfill feature is enabled for this organization
@@ -394,9 +382,7 @@ const handleIntegrationChanges = async (
 
       // Initialize/accumulate backfill status
       await withBackfillLock(integration.id, async () => {
-        const latestIntegration = await fetchClient.query.integration
-          .first({ id: integration.id })
-          .get();
+        const latestIntegration = await fetchClient.query.integration.byId({ id: integration.id });
         const latestSettings = safeParseIntegrationSettings(
           latestIntegration?.configStr ?? null,
         );
@@ -456,9 +442,7 @@ const backfillThread = async (
   organizationId: string,
 ) => {
   // Check if thread already exists in the database using externalId
-  const existingThread = await fetchClient.query.thread
-    .first({ externalId: thread.id, organizationId })
-    .get();
+  const existingThread = await fetchClient.query.thread.byExternalId({ externalId: thread.id, organizationId });
 
   if (existingThread) {
     // Thread exists (re-added channel), sync status and backfill missing messages
@@ -591,9 +575,7 @@ const backfillMessages = async (
     if (message.author.bot) continue;
 
     // Check if message already exists in the database
-    const existingMessage = await fetchClient.query.message
-      .first({ externalMessageId: message.id })
-      .get();
+    const existingMessage = await fetchClient.query.message.byExternalId({ externalMessageId: message.id });
 
     if (!existingMessage) {
       await backfillMessage(message, existingThread.id, organizationId);
@@ -648,7 +630,7 @@ client.on("messageCreate", async (message) => {
   let portalMessageOrgSlug: string | null = null;
 
   const integration = (
-    await fetchClient.query.integration.where({ type: "discord" }).get()
+    await fetchClient.query.integration.listByType({ type: "discord" })
   ).find((i) => {
     const parsed = safeParseIntegrationSettings(i.configStr);
     return parsed?.guildId === message.guild?.id;
@@ -697,9 +679,7 @@ client.on("messageCreate", async (message) => {
     });
 
     try {
-      const organization = await fetchClient.query.organization
-        .first({ id: integration.organizationId })
-        .get();
+      const organization = await fetchClient.query.organization.byId({ id: integration.organizationId });
 
       if (organization?.slug) {
         const showPortalMessage =
@@ -798,12 +778,7 @@ const handleMessages = async (
 ) => {
   for (const message of messages) {
     // TODO this is not consistent, either we make this part of the include or we wait until the store is bootstrapped. Remove the timeout when this is fixed.
-    const integration = await fetchClient.query.integration
-      .first({
-        organizationId: message.thread?.organizationId,
-        type: "discord",
-      })
-      .get();
+    const integration = await fetchClient.query.integration.forOrg({ organizationId: message.thread?.organizationId, type: "discord" });
 
     if (!integration || !integration.configStr) continue;
 
@@ -906,12 +881,7 @@ const handleUpdates = async (
 
     try {
       // TODO this is not consistent, either we make this part of the include or we wait until the store is bootstrapped. Remove the timeout when this is fixed.
-      const integration = await fetchClient.query.integration
-        .first({
-          organizationId: update.thread?.organizationId,
-          type: "discord",
-        })
-        .get();
+      const integration = await fetchClient.query.integration.forOrg({ organizationId: update.thread?.organizationId, type: "discord" });
 
       if (!integration || !integration.configStr) continue;
 
@@ -1007,9 +977,7 @@ client.once("ready", async () => {
     processThread: backfillThread,
     onThreadBackfillComplete: async (integrationId: string) => {
       await withBackfillLock(integrationId, async () => {
-        const integration = await fetchClient.query.integration
-          .first({ id: integrationId })
-          .get();
+        const integration = await fetchClient.query.integration.byId({ id: integrationId });
         const settings = safeParseIntegrationSettings(
           integration?.configStr ?? null,
         );

--- a/apps/discord/src/index.ts
+++ b/apps/discord/src/index.ts
@@ -778,7 +778,9 @@ const handleMessages = async (
 ) => {
   for (const message of messages) {
     // TODO this is not consistent, either we make this part of the include or we wait until the store is bootstrapped. Remove the timeout when this is fixed.
-    const integration = await fetchClient.query.integration.forOrg({ organizationId: message.thread?.organizationId, type: "discord" });
+    const organizationId = message.thread?.organizationId;
+    if (!organizationId) continue;
+    const integration = await fetchClient.query.integration.forOrg({ organizationId, type: "discord" });
 
     if (!integration || !integration.configStr) continue;
 
@@ -881,7 +883,9 @@ const handleUpdates = async (
 
     try {
       // TODO this is not consistent, either we make this part of the include or we wait until the store is bootstrapped. Remove the timeout when this is fixed.
-      const integration = await fetchClient.query.integration.forOrg({ organizationId: update.thread?.organizationId, type: "discord" });
+      const organizationId = update.thread?.organizationId;
+      if (!organizationId) continue;
+      const integration = await fetchClient.query.integration.forOrg({ organizationId, type: "discord" });
 
       if (!integration || !integration.configStr) continue;
 

--- a/apps/discord/src/lib/live-state.ts
+++ b/apps/discord/src/lib/live-state.ts
@@ -24,36 +24,7 @@ client.ws.addEventListener("error", (error) => {
   console.error("Live State error: ", error, error.error);
 });
 
-client.load(
-  store.query.organization
-    .include({
-      threads: {
-        include: {
-          messages: {
-            include: {
-              author: {
-                include: { user: true },
-              },
-            },
-          },
-          updates: {
-            include: { user: true },
-          },
-          labels: {
-            include: { label: true },
-          },
-          author: {
-            include: { user: true },
-          },
-        },
-      },
-      integrations: true,
-      authors: {
-        include: { user: true },
-      },
-    })
-    .buildQueryRequest(),
-);
+client.load(store.query.organization.load().buildQueryRequest());
 
 export const fetchClient = createFetchClient<Router>({
   url: process.env.LIVE_STATE_API_URL || "http://localhost:3333/api/ls",

--- a/apps/discord/src/lib/utils.ts
+++ b/apps/discord/src/lib/utils.ts
@@ -46,9 +46,9 @@ export const updateSyncedChannels = async (
 export const getBackfillLimit = async (
   organizationId: string,
 ): Promise<number | null> => {
-  const subscription = await fetchClient.query.subscription
-    .first({ organizationId })
-    .get();
+  const subscription = await fetchClient.query.subscription.forOrg({
+    organizationId,
+  });
   if (!subscription || subscription.plan === "trial") {
     return 100;
   }

--- a/apps/github/src/jobs/reconcile.ts
+++ b/apps/github/src/jobs/reconcile.ts
@@ -139,13 +139,10 @@ export const handleReconcileRepo = async (job: Job<ReconcileRepoJobData>) => {
 
   // Snapshot the current (non-deleted) mirror rows for this repo: the cursor for
   // skipping unchanged upserts, and the baseline for detecting deletions.
-  const mirrorRows = await fetchClient.query.externalEntity
-    .where({
-      organizationId: data.organizationId,
-      repoFullName: data.fullName,
-      deletedAt: null,
-    })
-    .get();
+  const mirrorRows = await fetchClient.query.externalEntity.listForRepo({
+    organizationId: data.organizationId,
+    repoFullName: data.fullName,
+  });
 
   const cursorByKey = new Map<string, number>();
   for (const row of mirrorRows) {

--- a/apps/github/src/lib/live-state.ts
+++ b/apps/github/src/lib/live-state.ts
@@ -24,36 +24,7 @@ client.ws.addEventListener("error", (error) => {
   console.error("Live State error: ", error, error.error);
 });
 
-client.load(
-  store.query.organization
-    .include({
-      threads: {
-        include: {
-          messages: {
-            include: {
-              author: {
-                include: { user: true },
-              },
-            },
-          },
-          updates: {
-            include: { user: true },
-          },
-          labels: {
-            include: { label: true },
-          },
-          author: {
-            include: { user: true },
-          },
-        },
-      },
-      integrations: true,
-      authors: {
-        include: { user: true },
-      },
-    })
-    .buildQueryRequest()
-);
+client.load(store.query.organization.load().buildQueryRequest());
 
 export const fetchClient = createFetchClient<Router>({
   url: process.env.LIVE_STATE_API_URL || "http://localhost:3333/api/ls",

--- a/apps/github/src/routes/setup.ts
+++ b/apps/github/src/routes/setup.ts
@@ -33,12 +33,10 @@ export const setupRoutes = new Elysia({ prefix: "/api/github" }).get(
     }
 
     try {
-      const integration = await fetchClient.query.integration
-        .first({
-          organizationId: orgId,
-          type: "github",
-        })
-        .get();
+      const integration = await fetchClient.query.integration.forOrg({
+        organizationId: orgId,
+        type: "github",
+      });
 
       if (!integration) {
         throw new Error("INTEGRATION_NOT_FOUND");

--- a/apps/slack/src/index.ts
+++ b/apps/slack/src/index.ts
@@ -467,12 +467,7 @@ const backfillMissingMessages = async (
     if (!msg.ts || msg.bot_id || !msg.user) continue;
 
     // Check if message already exists
-    const existingMessage = await fetchClient.query.message
-      .first({
-        externalMessageId: msg.ts,
-        threadId: existingThread.id,
-      })
-      .get();
+    const existingMessage = await fetchClient.query.message.byExternalId({ externalMessageId: msg.ts, threadId: existingThread.id });
 
     if (!existingMessage) {
       await backfillMessage(client, msg, existingThread.id, organizationId);
@@ -498,9 +493,7 @@ const backfillThread = async (
   organizationId: string,
 ): Promise<void> => {
   // Check if thread already exists
-  const existingThread = await fetchClient.query.thread
-    .first({ externalId: threadTs, externalOrigin: "slack" })
-    .get();
+  const existingThread = await fetchClient.query.thread.byExternalId({ externalId: threadTs, externalOrigin: "slack" });
 
   if (existingThread) {
     // Thread exists, backfill missing messages
@@ -559,9 +552,7 @@ const backfillChannel = async (
 
     // Check budget and queue thread jobs (all inside lock so total stays accurate if enqueue fails)
     await withBackfillLock(integrationId, async () => {
-      const integration = await fetchClient.query.integration
-        .first({ id: integrationId })
-        .get();
+      const integration = await fetchClient.query.integration.byId({ id: integrationId });
       const currentSettings = safeParseIntegrationSettings(
         integration?.configStr ?? null,
       );
@@ -611,9 +602,7 @@ const backfillChannel = async (
 
     // Determine if there are more pages
     const budgetExhausted = await (async () => {
-      const integration = await fetchClient.query.integration
-        .first({ id: integrationId })
-        .get();
+      const integration = await fetchClient.query.integration.byId({ id: integrationId });
       const settings = safeParseIntegrationSettings(
         integration?.configStr ?? null,
       );
@@ -628,9 +617,7 @@ const backfillChannel = async (
     if (!hasMorePages || budgetExhausted) {
       // This channel is done discovering — decrement channelsDiscovering
       await withBackfillLock(integrationId, async () => {
-        const integration = await fetchClient.query.integration
-          .first({ id: integrationId })
-          .get();
+        const integration = await fetchClient.query.integration.byId({ id: integrationId });
         const settings = safeParseIntegrationSettings(
           integration?.configStr ?? null,
         );
@@ -755,9 +742,7 @@ const handleIntegrationChanges = async (
 
       // Initialize/accumulate backfill status
       await withBackfillLock(integration.id, async () => {
-        const latestIntegration = await fetchClient.query.integration
-          .first({ id: integration.id })
-          .get();
+        const latestIntegration = await fetchClient.query.integration.byId({ id: integration.id });
         const latestSettings = safeParseIntegrationSettings(
           latestIntegration?.configStr ?? null,
         );
@@ -890,9 +875,7 @@ app.message(
       });
 
       try {
-        const organization = await fetchClient.query.organization
-          .first({ id: integration.organizationId })
-          .get();
+        const organization = await fetchClient.query.organization.byId({ id: integration.organizationId });
 
         if (organization?.slug) {
           const showPortalMessage =
@@ -1198,9 +1181,7 @@ const handleUpdates = async (
     processThread: backfillThread,
     onThreadBackfillComplete: async (integrationId: string) => {
       await withBackfillLock(integrationId, async () => {
-        const integration = await fetchClient.query.integration
-          .first({ id: integrationId })
-          .get();
+        const integration = await fetchClient.query.integration.byId({ id: integrationId });
         const settings = safeParseIntegrationSettings(
           integration?.configStr ?? null,
         );

--- a/apps/slack/src/index.ts
+++ b/apps/slack/src/index.ts
@@ -493,7 +493,7 @@ const backfillThread = async (
   organizationId: string,
 ): Promise<void> => {
   // Check if thread already exists
-  const existingThread = await fetchClient.query.thread.byExternalId({ externalId: threadTs, externalOrigin: "slack" });
+  const existingThread = await fetchClient.query.thread.byExternalId({ externalId: threadTs, organizationId, externalOrigin: "slack" });
 
   if (existingThread) {
     // Thread exists, backfill missing messages

--- a/apps/slack/src/lib/live-state.ts
+++ b/apps/slack/src/lib/live-state.ts
@@ -24,36 +24,7 @@ client.ws.addEventListener("error", (error) => {
   console.error("Live State error: ", error, error.error);
 });
 
-client.load(
-  store.query.organization
-    .include({
-      threads: {
-        include: {
-          messages: {
-            include: {
-              author: {
-                include: { user: true },
-              },
-            },
-          },
-          updates: {
-            include: { user: true },
-          },
-          labels: {
-            include: { label: true },
-          },
-          author: {
-            include: { user: true },
-          },
-        },
-      },
-      integrations: true,
-      authors: {
-        include: { user: true },
-      },
-    })
-    .buildQueryRequest()
-);
+client.load(store.query.organization.load().buildQueryRequest());
 
 export const fetchClient = createFetchClient<Router>({
   url: process.env.LIVE_STATE_API_URL ?? "http://localhost:3333/api/ls",

--- a/apps/slack/src/lib/utils.ts
+++ b/apps/slack/src/lib/utils.ts
@@ -23,9 +23,7 @@ export const updateSyncedChannels = async (
   integrationId: string,
   syncedChannels: string[],
 ) => {
-  const latestIntegration = await fetchClient.query.integration
-    .first({ id: integrationId })
-    .get();
+  const latestIntegration = await fetchClient.query.integration.byId({ id: integrationId });
   const current = safeParseIntegrationSettings(
     latestIntegration?.configStr ?? null,
   ) ?? {};
@@ -38,9 +36,7 @@ export const updateSyncedChannels = async (
 export const getBackfillLimit = async (
   organizationId: string,
 ): Promise<number | null> => {
-  const subscription = await fetchClient.query.subscription
-    .first({ organizationId })
-    .get();
+  const subscription = await fetchClient.query.subscription.forOrg({ organizationId });
   if (!subscription || subscription.plan === "trial") {
     return 100;
   }

--- a/apps/web/src/components/devtools/devtools-menu/duplicate-thread-command.tsx
+++ b/apps/web/src/components/devtools/devtools-menu/duplicate-thread-command.tsx
@@ -52,13 +52,7 @@ export const DuplicateThreadMenuItem = () => {
         }
         where = { shortId: parsed.shortId, organizationId: activeOrgId };
       }
-      const thread = await fetchClient.query.thread
-        .first(where)
-        .include({
-          author: true,
-          messages: { include: { author: true } },
-        })
-        .get();
+      const thread = await fetchClient.query.thread.detail(where);
 
       if (!thread) {
         toast.error("Thread not found");

--- a/apps/web/src/components/devtools/devtools-menu/thread-route-for-devtools.tsx
+++ b/apps/web/src/components/devtools/devtools-menu/thread-route-for-devtools.tsx
@@ -22,8 +22,9 @@ export const resolveThreadUlid = async (
   if (parsed.kind === "ulid") return parsed.id;
   const orgId = getDefaultStore().get(activeOrganizationAtom)?.id;
   if (!orgId) return null;
-  const thread = await fetchClient.query.thread
-    .first({ shortId: parsed.shortId, organizationId: orgId })
-    .get();
+  const thread = await fetchClient.query.thread.detail({
+    shortId: parsed.shortId,
+    organizationId: orgId,
+  });
   return thread?.id ?? null;
 };

--- a/apps/web/src/lib/hooks/query/use-organization-plan.ts
+++ b/apps/web/src/lib/hooks/query/use-organization-plan.ts
@@ -25,7 +25,9 @@ export const useOrganizationPlan = () => {
   );
 
   const settings = safeParseOrgSettings(org?.settings);
-  const rawPlan = (settings.plan as PlanType) ?? "trial";
+  // `settings.plan` is already validated against the plan literals by the
+  // schema (unknown values coerce to "trial"), so no cast/fallback is needed.
+  const rawPlan: PlanType = settings.plan;
   const status = settings.subscriptionStatus;
 
   // Treat "beta-feedback" as "starter" plan for feature checks (free plan access)

--- a/apps/web/src/lib/hooks/query/use-organization-plan.ts
+++ b/apps/web/src/lib/hooks/query/use-organization-plan.ts
@@ -1,4 +1,5 @@
 import { useLiveQuery } from "@live-state/sync/client";
+import { safeParseOrgSettings } from "@workspace/schemas/organization";
 import { useAtomValue } from "jotai/react";
 import { activeOrganizationAtom } from "~/lib/atoms";
 import { query } from "~/lib/live-state";
@@ -8,17 +9,24 @@ export type PlanType = "trial" | "starter" | "pro" | "beta-feedback";
 /**
  * Gets the effective plan for the current organization.
  * "beta-feedback" plans are treated as "starter" (free plan) for feature checks.
+ *
+ * Plan/status are read from `organization.settings` (denormalized from the
+ * owner-only `subscription` row) so every member gets correct feature gating
+ * without syncing billing identifiers. Billing details (customerId, createdAt,
+ * subscriptionId) live behind the owner-only `subscription.forOrg` query.
  */
 export const useOrganizationPlan = () => {
   const currentOrg = useAtomValue(activeOrganizationAtom);
 
-  const subscription = useLiveQuery(
-    query.subscription.first({
-      organizationId: currentOrg?.id,
+  const org = useLiveQuery(
+    query.organization.first({
+      id: currentOrg?.id,
     })
   );
 
-  const rawPlan = (subscription?.plan as PlanType) ?? "trial";
+  const settings = safeParseOrgSettings(org?.settings);
+  const rawPlan = (settings.plan as PlanType) ?? "trial";
+  const status = settings.subscriptionStatus;
 
   // Treat "beta-feedback" as "starter" plan for feature checks (free plan access)
   const effectivePlan: PlanType =
@@ -30,7 +38,7 @@ export const useOrganizationPlan = () => {
   const isBetaFeedback = rawPlan === "beta-feedback";
 
   return {
-    subscription,
+    status,
     plan: effectivePlan,
     rawPlan,
     isTrial,

--- a/apps/web/src/lib/server-funcs/invitations.tsx
+++ b/apps/web/src/lib/server-funcs/invitations.tsx
@@ -21,15 +21,7 @@ export const getInvitation = createServerFn({
     const { user } = sessionData;
 
     const invitation = await fetchClient.query.invite
-      .where({
-        id: data.id,
-      })
-      .include({
-        organization: true,
-        creator: true,
-      })
-      .get()
-      .then((v) => v[0])
+      .byId({ id: data.id })
       .catch(() => null);
 
     if (!invitation) {

--- a/apps/web/src/lib/server-funcs/payment.ts
+++ b/apps/web/src/lib/server-funcs/payment.ts
@@ -14,17 +14,10 @@ const authorizeOrganizationUser = async (customerId: string) => {
   const { user } = sessionData;
 
   const organizationUser = (
-    await fetchClient.query.organizationUser
-      .where({
-        userId: user.id,
-        enabled: true,
-      })
-      .include({
-        organization: {
-          include: { subscriptions: true },
-        },
-      })
-      .get()
+    await fetchClient.query.organizationUser.forUser({
+      enabledOnly: true,
+      withSubscriptions: true,
+    })
   ).find(
     (v) =>
       (v as any).organization?.subscriptions?.[0]?.customerId === customerId

--- a/apps/web/src/routes/app/_workspace/_main/threads/archive/$id.tsx
+++ b/apps/web/src/routes/app/_workspace/_main/threads/archive/$id.tsx
@@ -51,24 +51,11 @@ export const Route = createFileRoute(
   component: RouteComponent,
   loader: async ({ params }) => {
     const { id } = params;
-    const thread = (
-      await fetchClient.query.thread
-        .where({
-          id,
-          deletedAt: {
-            $not: null,
-            $lt: add(new Date(), {
-              days: DAYS_UNTIL_DELETION,
-            }),
-          },
-        })
-        .include({
-          organization: true,
-          messages: { include: { author: true } },
-          assignedUser: true,
-        })
-        .get()
-    )[0];
+    const thread = await fetchClient.query.thread.detail({
+      id,
+      onlyDeleted: true,
+      deletedBefore: add(new Date(), { days: DAYS_UNTIL_DELETION }),
+    });
     return { thread };
   },
   head: ({ loaderData }) => {

--- a/apps/web/src/routes/app/_workspace/route.tsx
+++ b/apps/web/src/routes/app/_workspace/route.tsx
@@ -75,7 +75,7 @@ function RouteComponent() {
   // This is needed to set the active organization in the organization switcher
   useOrganizationSwitcher();
 
-  const { user } = Route.useRouteContext();
+  const { user, organizationUsers } = Route.useRouteContext();
 
   const posthog = usePostHog();
 
@@ -96,7 +96,30 @@ function RouteComponent() {
       });
     }
   }, [currentOrg?.id, currentOrg?.name, posthog]);
-  const { subscription, plan, isBetaFeedback } = useOrganizationPlan();
+  const { plan, status, isBetaFeedback } = useOrganizationPlan();
+
+  // Billing (subscription identifiers + trial start) is owner-only. Non-owners
+  // are still feature-gated by `plan`/`status` but never see the upgrade flow.
+  const isOwner =
+    organizationUsers?.some(
+      (orgUser) =>
+        orgUser.organizationId === currentOrg?.id && orgUser.role === "owner",
+    ) ?? false;
+
+  const [subscription, setSubscription] = useState<
+    Awaited<ReturnType<typeof fetchClient.query.subscription.forOrg>> | undefined
+  >(undefined);
+
+  useEffect(() => {
+    if (!isOwner || !currentOrg?.id) {
+      setSubscription(undefined);
+      return;
+    }
+    fetchClient.query.subscription
+      .forOrg({ organizationId: currentOrg.id })
+      .then(setSubscription)
+      .catch(() => setSubscription(undefined));
+  }, [isOwner, currentOrg?.id]);
 
   const seats =
     useLiveQuery(
@@ -114,12 +137,14 @@ function RouteComponent() {
     ? isAfter(new Date(), proTrialEndDate)
     : false;
 
-  // Don't show trial expired dialog for beta-feedback plans
+  // Only owners see the trial-expired upgrade dialog (they own billing).
+  // Don't show it for beta-feedback plans.
   const showTrialExpiredDialog =
+    isOwner &&
     plan === "trial" &&
     !isBetaFeedback &&
     trialEnded &&
-    subscription?.status !== "active";
+    status !== "active";
 
   const [isSubscribing, setIsSubscribing] = useState(false);
 

--- a/apps/web/src/routes/app/_workspace/route.tsx
+++ b/apps/web/src/routes/app/_workspace/route.tsx
@@ -115,10 +115,20 @@ function RouteComponent() {
       setSubscription(undefined);
       return;
     }
+    // Guard against out-of-order responses when switching orgs so billing state
+    // only ever reflects the latest fetch.
+    let cancelled = false;
     fetchClient.query.subscription
       .forOrg({ organizationId: currentOrg.id })
-      .then(setSubscription)
-      .catch(() => setSubscription(undefined));
+      .then((result) => {
+        if (!cancelled) setSubscription(result);
+      })
+      .catch(() => {
+        if (!cancelled) setSubscription(undefined);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [isOwner, currentOrg?.id]);
 
   const seats =

--- a/apps/web/src/routes/app/_workspace/route.tsx
+++ b/apps/web/src/routes/app/_workspace/route.tsx
@@ -50,13 +50,7 @@ export const Route = createFileRoute("/app/_workspace")({
 
     orgUsers = {
       organizationUsers: await fetchClient.query.organizationUser
-        .where({
-          userId: user.id,
-        })
-        .include({
-          organization: true,
-        })
-        .get()
+        .forUser({})
         .catch(() => []),
     };
 

--- a/apps/web/src/routes/app/_workspace/settings/organization/billing.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/billing.tsx
@@ -22,7 +22,7 @@ import { useAtomValue } from "jotai/react";
 import { useEffect, useState } from "react";
 import { activeOrganizationAtom } from "~/lib/atoms";
 import { useOrganizationPlan } from "~/lib/hooks/query/use-organization-plan";
-import { query } from "~/lib/live-state";
+import { fetchClient, query } from "~/lib/live-state";
 import {
   cancelSubscription,
   createCheckoutSession,
@@ -49,7 +49,24 @@ export const Route = createFileRoute(
 
 function RouteComponent() {
   const currentOrg = useAtomValue(activeOrganizationAtom);
-  const { subscription, plan, isBetaFeedback } = useOrganizationPlan();
+  const { plan, isBetaFeedback } = useOrganizationPlan();
+
+  // Billing identifiers (customerId/subscriptionId) are owner-only and no longer
+  // synced into the local store; fetch the full subscription on demand.
+  const [subscription, setSubscription] = useState<
+    Awaited<ReturnType<typeof fetchClient.query.subscription.forOrg>> | undefined
+  >(undefined);
+
+  useEffect(() => {
+    if (!currentOrg?.id) {
+      setSubscription(undefined);
+      return;
+    }
+    fetchClient.query.subscription
+      .forOrg({ organizationId: currentOrg.id })
+      .then(setSubscription)
+      .catch(() => setSubscription(undefined));
+  }, [currentOrg?.id]);
 
   const seats =
     useLiveQuery(

--- a/apps/web/src/routes/app/_workspace/settings/organization/billing.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/billing.tsx
@@ -50,6 +50,15 @@ export const Route = createFileRoute(
 function RouteComponent() {
   const currentOrg = useAtomValue(activeOrganizationAtom);
   const { plan, isBetaFeedback } = useOrganizationPlan();
+  const { organizationUsers } = Route.useRouteContext();
+
+  // `subscription.forOrg` is owner-only server-side; mirror that here so
+  // non-owners skip the wasted call and its silently-caught error.
+  const isOwner =
+    organizationUsers?.some(
+      (orgUser) =>
+        orgUser.organizationId === currentOrg?.id && orgUser.role === "owner",
+    ) ?? false;
 
   // Billing identifiers (customerId/subscriptionId) are owner-only and no longer
   // synced into the local store; fetch the full subscription on demand.
@@ -58,15 +67,25 @@ function RouteComponent() {
   >(undefined);
 
   useEffect(() => {
-    if (!currentOrg?.id) {
+    if (!isOwner || !currentOrg?.id) {
       setSubscription(undefined);
       return;
     }
+    // Guard against out-of-order responses when switching orgs so billing state
+    // only ever reflects the latest fetch.
+    let cancelled = false;
     fetchClient.query.subscription
       .forOrg({ organizationId: currentOrg.id })
-      .then(setSubscription)
-      .catch(() => setSubscription(undefined));
-  }, [currentOrg?.id]);
+      .then((result) => {
+        if (!cancelled) setSubscription(result);
+      })
+      .catch(() => {
+        if (!cancelled) setSubscription(undefined);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOwner, currentOrg?.id]);
 
   const seats =
     useLiveQuery(

--- a/apps/web/src/routes/app/_workspace/settings/organization/integration/discord/redirect.ts
+++ b/apps/web/src/routes/app/_workspace/settings/organization/integration/discord/redirect.ts
@@ -25,14 +25,10 @@ export const Route = createFileRoute(
           if (data.guild_id && data.state) {
             const [orgId, csrfToken] = data.state.split("_");
 
-            const integration = (
-              await fetchClient.query.integration
-                .where({
-                  organizationId: orgId,
-                  type: "discord",
-                })
-                .get()
-            )[0];
+            const integration = await fetchClient.query.integration.forOrg({
+              organizationId: orgId,
+              type: "discord",
+            });
 
             if (!integration) {
               throw new Error("INTEGRATION_NOT_FOUND");

--- a/apps/web/src/routes/app/_workspace/settings/organization/integration/slack/redirect.ts
+++ b/apps/web/src/routes/app/_workspace/settings/organization/integration/slack/redirect.ts
@@ -24,14 +24,10 @@ export const Route = createFileRoute(
           if (data.code && data.state) {
             const [orgId, csrfToken] = data.state.split("_");
 
-            const integration = (
-              await fetchClient.query.integration
-                .where({
-                  organizationId: orgId,
-                  type: "slack",
-                })
-                .get()
-            )[0];
+            const integration = await fetchClient.query.integration.forOrg({
+              organizationId: orgId,
+              type: "slack",
+            });
 
             if (!integration) {
               throw new Error("INTEGRATION_NOT_FOUND");

--- a/apps/web/src/routes/app/onboarding/index.tsx
+++ b/apps/web/src/routes/app/onboarding/index.tsx
@@ -20,27 +20,10 @@ export const Route = createFileRoute("/app/onboarding/")({
 
     const [orgUsers, invites] = await Promise.all([
       fetchClient.query.organizationUser
-        .where({
-          userId: user.id,
-          enabled: true,
-        })
-        .include({
-          organization: true,
-        })
-        .get()
+        .forUser({ enabledOnly: true })
         .catch(() => null),
       fetchClient.query.invite
-        .where({
-          email: user.email,
-          active: true,
-          expiresAt: {
-            $gt: new Date(),
-          },
-        })
-        .include({
-          organization: true,
-        })
-        .get()
+        .forEmail({ email: user.email })
         .catch(() => null),
     ]);
 

--- a/apps/web/src/routes/app/route.tsx
+++ b/apps/web/src/routes/app/route.tsx
@@ -31,11 +31,9 @@ export const Route = createFileRoute("/app")({
       });
     }
 
-    const allowlist = await fetchClient.query.allowlist
-      .first({
-        email: sessionData.user.email,
-      })
-      .get();
+    const allowlist = await fetchClient.query.allowlist.forEmail({
+      email: sessionData.user.email,
+    });
 
     if (!allowlist) {
       throw redirect({
@@ -58,7 +56,6 @@ export const Route = createFileRoute("/app")({
 });
 
 function App() {
-  const { user } = Route.useRouteContext();
   useEffect(() => {
     client.ws.connect();
 
@@ -67,50 +64,7 @@ function App() {
     };
   }, []);
 
-  useLoadData(
-    client,
-    query.organizationUser
-      .where({
-        userId: user.id,
-      })
-      .include({
-        organization: {
-          include: {
-            threads: {
-              include: {
-                messages: {
-                  include: { author: true },
-                },
-                updates: {
-                  include: { user: true },
-                },
-                labels: {
-                  include: { label: true },
-                },
-                author: true,
-                assignedUser: true,
-              },
-            },
-            invites: true,
-            integrations: true,
-            subscriptions: true,
-            labels: true,
-            organizationUsers: {
-              include: { user: true },
-            },
-            authors: true,
-            onboardings: true,
-            documentationSources: true,
-            // TODO improve this to load only when needed
-            agentChats: {
-              include: { messages: true },
-            },
-            autonomousActions: true,
-            externalEntities: true,
-          },
-        },
-      }),
-  );
+  useLoadData(client, query.organizationUser.load());
 
   return (
     <>

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -37,7 +37,7 @@ export const Route = createFileRoute("/sitemap.xml")({
           },
         ];
 
-        const organizations = await fetchClient.query.organization.get();
+        const organizations = await fetchClient.query.organization.list();
 
         const baseUrlObj = new URL(baseUrl);
 

--- a/apps/web/src/routes/support/$slug/route.tsx
+++ b/apps/web/src/routes/support/$slug/route.tsx
@@ -65,7 +65,7 @@ export const Route = createFileRoute("/support/$slug")({
 
     const [newPortalSessionData, newOrganizationData] = await Promise.all([
       getPortalAuthUser(),
-      fetchClient.query.organization.first({ slug: slug }).get(),
+      fetchClient.query.organization.bySlug({ slug }),
     ]);
 
     portalSessionData = newPortalSessionData;

--- a/apps/web/src/routes/support/$slug/sitemap[.]xml.ts
+++ b/apps/web/src/routes/support/$slug/sitemap[.]xml.ts
@@ -13,12 +13,10 @@ export const Route = createFileRoute("/support/$slug/sitemap.xml")({
     handlers: {
       GET: async () => {
         // Fetch all organizations
-        const organizations = await fetchClient.query.organization.get();
+        const organizations = await fetchClient.query.organization.list();
 
         // Fetch all threads for all organizations
-        const allThreads = await fetchClient.query.thread
-          .include({ organization: true, messages: true })
-          .get();
+        const allThreads = await fetchClient.query.thread.listAll();
 
         // Build the URL list
         const urls: Array<{

--- a/apps/web/src/routes/support/$slug/threads/$id.tsx
+++ b/apps/web/src/routes/support/$slug/threads/$id.tsx
@@ -49,20 +49,7 @@ export const Route = createFileRoute("/support/$slug/threads/$id")({
         ? { id: parsed.id, organizationId: context.organization.id }
         : { shortId: parsed.shortId, organizationId: context.organization.id };
 
-    const thread = (
-      await fetchClient.query.thread
-        .where(where)
-        .include({
-          author: true,
-          messages: { include: { author: true } },
-          assignedUser: true,
-          updates: { include: { user: true } },
-          labels: {
-            include: { label: true },
-          },
-        })
-        .get()
-    )[0];
+    const thread = await fetchClient.query.thread.detail(where);
 
     if (!thread) {
       throw notFound();

--- a/apps/worker/src/lib/autonomy.ts
+++ b/apps/worker/src/lib/autonomy.ts
@@ -14,10 +14,9 @@ type OrgRow = {
 export async function getOrgActionAutonomy(
   organizationId: string,
 ): Promise<Record<ActionKind, AutonomyLevel>> {
-  const rows = (await fetchClient.query.organization
-    .where({ id: organizationId })
-    .get()) as OrgRow[];
-  const org = rows[0];
+  const org = (await fetchClient.query.organization.byId({
+    id: organizationId,
+  })) as OrgRow | undefined;
   const parsed = safeParseOrgSettings(org?.settings);
   return { ...getDefaultActionAutonomy(), ...(parsed.actionAutonomy ?? {}) };
 }

--- a/apps/worker/src/lib/database/client.ts
+++ b/apps/worker/src/lib/database/client.ts
@@ -21,15 +21,7 @@ export const fetchThreadWithRelations = async (
   threadId: string,
 ): Promise<Thread | null> => {
   try {
-    const threads = await fetchClient.query.thread
-      .where({ id: threadId })
-      .include({
-        messages: true,
-        labels: {
-          include: { label: true },
-        },
-      })
-      .get();
+    const threads = await fetchClient.query.thread.byIds({ ids: [threadId] });
 
     const thread = threads[0];
     return (thread as Thread) ?? null;
@@ -52,17 +44,7 @@ export const fetchThreadsWithRelations = async (
   }
 
   try {
-    const results = await fetchClient.query.thread
-      .where({
-        id: { $in: threadIds },
-      })
-      .include({
-        messages: true,
-        labels: {
-          include: { label: true },
-        },
-      })
-      .get();
+    const results = await fetchClient.query.thread.byIds({ ids: threadIds });
 
     for (const thread of results) {
       threads.set(thread.id, thread as Thread);

--- a/apps/worker/src/lib/message-roles.ts
+++ b/apps/worker/src/lib/message-roles.ts
@@ -13,16 +13,11 @@ export const resolveMessageRoles = async (
   threadAuthorId: string | null | undefined,
 ): Promise<Map<string, MessageRole>> => {
   const unique = [...new Set(authorIds.filter(Boolean))];
-  const rows = await Promise.all(
-    unique.map(
-      (id) =>
-        fetchClient.query.author.where({ id }).get() as Promise<
-          Array<{ id: string; userId: string | null }>
-        >,
-    ),
-  );
+  const rows = (await fetchClient.query.author.byIds({
+    ids: unique,
+  })) as Array<{ id: string; userId: string | null }>;
   const map = new Map<string, MessageRole>();
-  for (const [row] of rows) {
+  for (const row of rows) {
     if (!row) continue;
     if (row.id === threadAuthorId) map.set(row.id, "customer");
     else if (row.userId) map.set(row.id, "agent");

--- a/apps/worker/src/lib/read-hints.ts
+++ b/apps/worker/src/lib/read-hints.ts
@@ -13,9 +13,9 @@ type SlotEvidenceMap = {
 };
 
 export async function readHintBag(threadId: string): Promise<Hints> {
-  const rows = (await fetchClient.query.thread
-    .where({ id: threadId })
-    .get()) as Array<{ hints: Hints | null }>;
+  const rows = (await fetchClient.query.thread.byIds({
+    ids: [threadId],
+  })) as Array<{ hints: Hints | null }>;
   return rows[0]?.hints ?? {};
 }
 

--- a/apps/worker/src/pipeline/core/idempotency.ts
+++ b/apps/worker/src/pipeline/core/idempotency.ts
@@ -23,9 +23,9 @@ export const checkIdempotency = async (
   hash: string,
 ): Promise<boolean> => {
   try {
-    const existing = await fetchClient.query.pipelineIdempotencyKey
-      .first({ key })
-      .get();
+    const existing = (
+      await fetchClient.query.pipelineIdempotencyKey.byKeys({ keys: [key] })
+    )[0];
 
     if (!existing) {
       return false;
@@ -93,9 +93,9 @@ export const batchCheckIdempotency = async (
 
   try {
     const keys = keyHashPairs.map((p) => p.key);
-    const existingKeys = await fetchClient.query.pipelineIdempotencyKey
-      .where({ key: { $in: keys } })
-      .get();
+    const existingKeys = await fetchClient.query.pipelineIdempotencyKey.byKeys({
+      keys,
+    });
 
     const existingMap = new Map<string, string>();
     for (const existing of existingKeys) {
@@ -136,9 +136,9 @@ export const batchCheckIdempotencyKeyExists = async (
   }
 
   try {
-    const existingKeys = await fetchClient.query.pipelineIdempotencyKey
-      .where({ key: { $in: keys } })
-      .get();
+    const existingKeys = await fetchClient.query.pipelineIdempotencyKey.byKeys({
+      keys,
+    });
 
     const existingSet = new Set(existingKeys.map((k) => k.key));
 

--- a/apps/worker/src/pipeline/core/persistence.ts
+++ b/apps/worker/src/pipeline/core/persistence.ts
@@ -44,9 +44,7 @@ export const updatePipelineJobStatus = async (
   additionalMetadata?: Partial<PipelineJobMetadata>,
 ): Promise<boolean> => {
   try {
-    const existing = await fetchClient.query.pipelineJob
-      .first({ id: jobId })
-      .get();
+    const existing = await fetchClient.query.pipelineJob.byId({ id: jobId });
 
     if (!existing) {
       console.error(`Pipeline job ${jobId} not found`);
@@ -77,9 +75,7 @@ export const completePipelineJob = async (
   result: PipelineExecutionResult,
 ): Promise<boolean> => {
   try {
-    const existing = await fetchClient.query.pipelineJob
-      .first({ id: jobId })
-      .get();
+    const existing = await fetchClient.query.pipelineJob.byId({ id: jobId });
 
     if (!existing) {
       console.error(`Pipeline job ${jobId} not found`);
@@ -111,9 +107,7 @@ export const failPipelineJob = async (
   error: string,
 ): Promise<boolean> => {
   try {
-    const existing = await fetchClient.query.pipelineJob
-      .first({ id: jobId })
-      .get();
+    const existing = await fetchClient.query.pipelineJob.byId({ id: jobId });
 
     if (!existing) {
       console.error(`Pipeline job ${jobId} not found`);
@@ -148,9 +142,7 @@ export const getPipelineJob = async (
   updatedAt: Date;
 } | null> => {
   try {
-    const job = await fetchClient.query.pipelineJob
-      .first({ id: jobId })
-      .get();
+    const job = await fetchClient.query.pipelineJob.byId({ id: jobId });
 
     if (!job) {
       return null;

--- a/apps/worker/src/pipeline/processors/inline-track/label/processor.ts
+++ b/apps/worker/src/pipeline/processors/inline-track/label/processor.ts
@@ -74,9 +74,10 @@ export const labelClassifierProcessor: ProcessorDefinition<LabelClassifierOutput
           };
         }
 
-        const orgLabels = (await fetchClient.query.label
-          .where({ organizationId: thread.organizationId, enabled: true })
-          .get()) as LabelRow[];
+        const orgLabels = (await fetchClient.query.label.forOrg({
+          organizationId: thread.organizationId,
+          enabled: true,
+        })) as LabelRow[];
 
         if (orgLabels.length === 0) {
           return {

--- a/bun.lock
+++ b/bun.lock
@@ -407,7 +407,7 @@
     "csstype": "^3.1.3",
   },
   "catalog": {
-    "@live-state/sync": "1.0.0-canary-1",
+    "@live-state/sync": "1.0.0-canary-2",
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "better-auth": "^1.4.0",
@@ -904,7 +904,7 @@
 
     "@keyv/serialize": ["@keyv/serialize@1.1.1", "", {}, "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA=="],
 
-    "@live-state/sync": ["@live-state/sync@1.0.0-canary-1", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-deep-equal": "^3.1.3", "idb": "^8.0.3", "js-xxhash": "^4.0.0", "kysely": "^0.28.2", "qs": "^6.14.0", "ws": "^8.18.0", "zod": "^4.1.9" }, "peerDependencies": { "@types/react": ">=18.0.0", "react": ">=18.0.0" }, "optionalPeers": ["@types/react", "react"] }, "sha512-75fkMo3a1V9yDG6fzdlRKnx9JaCzpsxcmJTBPehgUhfDQagqCYb/PnhMaayva1qGpS3l97KMwLM7P7qz0fJwPQ=="],
+    "@live-state/sync": ["@live-state/sync@1.0.0-canary-2", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-deep-equal": "^3.1.3", "idb": "^8.0.3", "js-xxhash": "^4.0.0", "kysely": "^0.28.2", "qs": "^6.14.0", "ws": "^8.18.0", "zod": "^4.1.9" }, "peerDependencies": { "@types/react": ">=18.0.0", "react": ">=18.0.0" }, "optionalPeers": ["@types/react", "react"] }, "sha512-xNnP4SAvmcem172am6kRPtro5yr+D35TuR+qJINYCugxAQz4VO2/K1tqz4G5H0yTcgLkXtk5Szr9xP5sCdtyPA=="],
 
     "@lukeed/ms": ["@lukeed/ms@2.0.2", "", {}, "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -407,7 +407,7 @@
     "csstype": "^3.1.3",
   },
   "catalog": {
-    "@live-state/sync": "0.0.7-pr-3",
+    "@live-state/sync": "1.0.0-canary-1",
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "better-auth": "^1.4.0",
@@ -904,7 +904,7 @@
 
     "@keyv/serialize": ["@keyv/serialize@1.1.1", "", {}, "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA=="],
 
-    "@live-state/sync": ["@live-state/sync@0.0.7-pr-3", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-deep-equal": "^3.1.3", "idb": "^8.0.3", "js-xxhash": "^4.0.0", "kysely": "^0.28.2", "qs": "^6.14.0", "ws": "^8.18.0", "zod": "^4.1.9" }, "peerDependencies": { "@types/react": ">=18.0.0", "react": ">=18.0.0" }, "optionalPeers": ["@types/react", "react"] }, "sha512-thJCbveUFxjUpKOAIQ8c5SbL+r2oDylN3Cu9R54WArPS1IPDNhQ5jXkX5pliv6wwL0eJ0F8+CDI+U2lCA9I42Q=="],
+    "@live-state/sync": ["@live-state/sync@1.0.0-canary-1", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-deep-equal": "^3.1.3", "idb": "^8.0.3", "js-xxhash": "^4.0.0", "kysely": "^0.28.2", "qs": "^6.14.0", "ws": "^8.18.0", "zod": "^4.1.9" }, "peerDependencies": { "@types/react": ">=18.0.0", "react": ">=18.0.0" }, "optionalPeers": ["@types/react", "react"] }, "sha512-75fkMo3a1V9yDG6fzdlRKnx9JaCzpsxcmJTBPehgUhfDQagqCYb/PnhMaayva1qGpS3l97KMwLM7P7qz0fJwPQ=="],
 
     "@lukeed/ms": ["@lukeed/ms@2.0.2", "", {}, "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       "packages/*"
     ],
     "catalog": {
-      "@live-state/sync": "1.0.0-canary-1",
+      "@live-state/sync": "1.0.0-canary-2",
       "@types/react": "^19.2.3",
       "@types/react-dom": "^19.2.3",
       "better-auth": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       "packages/*"
     ],
     "catalog": {
-      "@live-state/sync": "0.0.7-pr-3",
+      "@live-state/sync": "1.0.0-canary-1",
       "@types/react": "^19.2.3",
       "@types/react-dom": "^19.2.3",
       "better-auth": "^1.4.0",

--- a/packages/schemas/src/organization.ts
+++ b/packages/schemas/src/organization.ts
@@ -27,7 +27,13 @@ export const organizationSettingsSchema = z.object({
   // Non-sensitive billing state, denormalized from the owner-only `subscription`
   // row so all members get correct feature gating. Billing identifiers
   // (customerId/subscriptionId) stay owner-only and are never synced here.
-  plan: z.string().default("trial"),
+  // Constrained to the supported plan literals so stored settings can't drift
+  // from the union the feature-gating logic assumes; unknown values coerce to
+  // "trial" instead of leaking through as an arbitrary string.
+  plan: z
+    .enum(["trial", "starter", "pro", "beta-feedback"])
+    .catch("trial")
+    .default("trial"),
   subscriptionStatus: z.string().nullable().default(null),
 });
 

--- a/packages/schemas/src/organization.ts
+++ b/packages/schemas/src/organization.ts
@@ -24,6 +24,11 @@ export const organizationSettingsSchema = z.object({
   timezone: z.string().default("UTC"),
   digest: digestSettingsSchema.default(digestSettingsDefaults),
   actionAutonomy: actionAutonomyMapSchema.optional(),
+  // Non-sensitive billing state, denormalized from the owner-only `subscription`
+  // row so all members get correct feature gating. Billing identifiers
+  // (customerId/subscriptionId) stay owner-only and are never synced here.
+  plan: z.string().default("trial"),
+  subscriptionStatus: z.string().nullable().default(null),
 });
 
 export type OrganizationSettings = z.infer<typeof organizationSettingsSchema>;


### PR DESCRIPTION
## Summary

Bumps `@live-state/sync` to `1.0.0-canary-1`, which removes `collectionRoute` and the default-query path (ADR-0002): resources are read only through **named query procedures**, with authorization enforced **per-handler**. This migrates the whole monorepo to that model.

## Server (`apps/api`)
- Remove all **22** `collectionRoute(...)` configs; move read-auth into handlers.
- Add consolidated read procedures: `organization.{bySlug,byId,list}`, `organizationUser.forUser`, `integration.{byId,forOrg,listByType}`, `thread.{detail,byExternalId,byIds,listAll}`, `message.byExternalId`, `author.byIds`, `invite.{byId,forEmail}`, `allowlist.forEmail`, `subscription.forOrg`, `label.forOrg`, `externalEntity.listForRepo`, `pipelineJob.byId`, `pipelineIdempotencyKey.byKeys`.
- Auth preserved/tightened: `organization.load` is now **internal-key gated** (was an unbacked public whole-tree read); `subscription.forOrg` stays **owner-only**; `allowlist`/`invite.forEmail` are scoped to the caller's own email.
- Drop dead routes `threadLabel`, `agentChatMessage`, `migration` (read via the org tree, or unused).

## Clients
Rewrite all **63** fetch-client reads to the new procedures across `web`/`discord`/`slack`/`github`/`cli`/`worker`, consolidating repeated lookups (worker per-author lookups → `author.byIds`; bot integration refetches → `integration.byId`; portal org → `organization.bySlug`). Local optimistic-store reads (`store.query.*`) are unchanged.

## ⚠️ Known blocker — do not merge until resolved
The **4** builder-returning `.load()` calls (`web/routes/app/route.tsx`, `{discord,slack,github}/lib/live-state.ts`) do **not** type-check against the published `@live-state/sync` build.

Root cause is library-side: the package's `exports.*.types` point at an unshipped `src/`, so consumers fall back to the split `dist/*.d.ts` where `/server` and `/client` each declare their own `QueryBuilder`. The client then collapses a handler's builder return to `Promise<QueryBuilder>` (no `buildQueryRequest`). Proven by resolving types from source (error disappears). **Fix is in the library:** share one `QueryBuilder` across the bundled dts and point `exports.*.types` at it, then re-pin the catalog. No casts were added to work around it.

Everything else type-checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates all reads to named query procedures with per-handler auth under `@live-state/sync` 1.0, and hardens billing by mirroring plan/status to `organization.settings` with stricter validation and owner-only fetch flows. UI now guards owner-only subscription fetches and races; sitemap and integrations remain tenant-safe.

- **Refactors**
  - Replaced `collectionRoute`/default queries with named read procedures across core resources (organization, orgUser, integration, thread, message, author, invite, allowlist, subscription, label, externalEntity, pipeline*).
  - Billing hardening: added `plan` and `subscriptionStatus` to `organization.settings`, constrained `plan` to known literals (unknown => `trial`), backfilled via migration 003 with deterministic ordering, and mirrored on subscription webhooks; org creation seeds `plan=trial`. `organizationUser.forUser` includes subscriptions only for owner memberships; web reads plan/status from settings and fetches `subscription.forOrg` only for owners, with guards against org-switch race conditions.
  - Tightened auth and scopes: `organization.load` is internal-key only; `subscription.forOrg` owner-only; allowlist/invite lookups restricted to caller’s email; `integration.byId` internal-only; `thread.byExternalId` requires `organizationId`.
  - Removed dead routes: `threadLabel`, `agentChatMessage`, `migration`.
  - Client rewrites across `web`/`discord`/`slack`/`github`/`cli`/`worker`, switching to new procedures (`organization.{bySlug,byId,list,load}`, `organizationUser.{forUser,load}`, `integration.{byId,forOrg,listByType}`, `thread.{detail,byExternalId,byIds,listAll}`, `message.byExternalId`, `author.byIds`, `invite.{byId,forEmail}`, `allowlist.forEmail`, `subscription.forOrg`, `label.forOrg`, `externalEntity.listForRepo`, `pipelineJob.byId`, `pipelineIdempotencyKey.byKeys`). Sitemaps now use `organization.list` and `thread.listAll` (excludes soft-deleted).
  - Post-review hardening: `label.forOrg` enforces org auth; `thread.detail` requires id/shortId and scopes shortId to org; `thread.listAll` skips soft-deleted threads; `invite.byId` limited to recipient/org member/internal; `invite.forEmail` lowercases emails; `externalEntity.listForRepo` restricted to provider `github`; Discord skips replication when a thread lacks `organizationId`.

- **Dependencies**
  - Bumped `@live-state/sync` to `1.0.0-canary-2`, which resolves the previous `.load()` type issue; no local casts needed.

<sup>Written for commit e92c8942b62a30c6cdd06a9c18e9037282cc0ebc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added targeted Live State query endpoints for threads, messages (by external id), integrations, labels, pipeline idempotency keys/jobs, and external entities.
  * Expanded organization and organization-user APIs with improved, per-endpoint access handling and richer organization loading.
  * Mirrored subscription plan/status into organization settings (with a backfill migration) and updated organization plan/status handling in the web UI.
* **Bug Fixes**
  * Reduced eager-loading for initial loads, archive, and sitemap flows; improved lookup reliability via dedicated helpers and batch queries.
* **Chores**
  * Refactored routing to procedure-based endpoints and updated client query usage across apps; removed/merged legacy route entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->