### PR TITLE
feat(connectors,api): generic capability-dispatch, GitHub issue-tracker behind it (FRO-192)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,6 +60,19 @@ A deterministic, no-LLM helper (not a pipeline processor) that action-emitting p
 
 A receipt of work the Agent performed without human approval. Stored in `autonomousAction`. Carries an undo affordance when the action is reversible by construction.
 
+### Connector
+
+The reusable provider code (Discord, Slack, GitHub) that adapts one external system to FrontDesk. A connector statically **declares** the set of [capabilities](#capability) it provides; the FrontDesk core interacts with those capabilities generically and never references a named provider. Distinct from an [integration](#integration), which is *one org's installed instance* of a connector.
+_Avoid_: "provider" or "adapter" as the noun for this (reserve "provider" for the external system's name string, e.g. `provider: "github"`).
+
+### Capability
+
+A role a [connector](#connector) can play, expressed as a typed interface (a bundle of methods) the connector opts into implementing. Planned kinds: support entry point, issue tracker, PR tracker, team notification center. A connector may implement any number of them (GitHub = issue tracker + PR tracker; Slack = support entry point + notification center; Discord = support entry point only). The core asks "does this org have an integration whose connector provides capability X?" rather than naming a provider.
+
+### Integration
+
+One org's installed, configured instance of a [connector](#connector). A row in the `integration` table (`type`, `enabled`, `configStr`), scoped by `organizationId`. "Integration" is the *installed connection*, not the code that powers it (that is the [connector](#connector)) and not the role it plays (that is a [capability](#capability)).
+
 ### Thread
 
 The unit of customer conversation in FrontDesk: a single stream of messages carrying its own state (status, labels, assignee) and the surface the Agent reads and acts on. A thread originates from one place — its `externalId` / `externalOrigin` record *where it came from* (Discord channel, Slack message, portal) — and may **link** to an [external issue](#external-issue) or [external pull request](#external-pull-request) without owning it. Stored in `thread`; the Agent's output for one lives on `thread.agentRead` (see [thread read](#thread-read)).

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@ai-sdk/google": "^3.0.7",
+    "@connectors/framework": "workspace:*",
     "@reflag/node-sdk": "^1.1.0",
     "@dodopayments/express": "^0.2.1",
     "@keyv/redis": "^5.1.5",

--- a/apps/api/src/lib/connector-registry.ts
+++ b/apps/api/src/lib/connector-registry.ts
@@ -10,6 +10,13 @@ import { schema } from "../live-state/schema";
 export const connectorRegistry = buildRegistry();
 
 /**
+ * Shared internal secret the core sends when invoking a connector capability,
+ * so the connector can authenticate the caller. Reuses the existing core↔
+ * connector bot key (`DISCORD_BOT_KEY`) — same trust boundary.
+ */
+export const connectorInvokeSecret = process.env.DISCORD_BOT_KEY ?? null;
+
+/**
  * Whether the org can offer `capability`, resolved from its enabled
  * integrations via the registry. Answers "can we offer this?"; a specific
  * invoked call still routes by a concrete target/integration.

--- a/apps/api/src/lib/connector-registry.ts
+++ b/apps/api/src/lib/connector-registry.ts
@@ -1,0 +1,32 @@
+import { buildRegistry, type Capability } from "@connectors/framework";
+import { schema } from "../live-state/schema";
+
+/**
+ * The connector registry, built once at boot from the connector manifests. The
+ * core dispatches capabilities generically through this — it never references a
+ * named provider.
+ */
+export const connectorRegistry = buildRegistry();
+
+/**
+ * Whether the org can offer `capability`, resolved from its enabled
+ * integrations via the registry. Answers "can we offer this?"; a specific
+ * invoked call still routes by a concrete target/integration.
+ */
+export async function orgHasCapability(
+  // biome-ignore lint/suspicious/noExplicitAny: live-state db handle
+  db: any,
+  organizationId: string,
+  capability: Capability,
+): Promise<boolean> {
+  const integrations = Object.values(
+    await db.find(schema.integration, {
+      where: { organizationId, enabled: true },
+    }),
+  ) as { type: string }[];
+
+  return connectorRegistry.hasCapability(
+    integrations.map((integration) => integration.type),
+    capability,
+  );
+}

--- a/apps/api/src/lib/connector-registry.ts
+++ b/apps/api/src/lib/connector-registry.ts
@@ -1,4 +1,5 @@
 import { buildRegistry, type Capability } from "@connectors/framework";
+import type { ServerDB } from "@live-state/sync/server";
 import { schema } from "../live-state/schema";
 
 /**
@@ -14,8 +15,7 @@ export const connectorRegistry = buildRegistry();
  * invoked call still routes by a concrete target/integration.
  */
 export async function orgHasCapability(
-  // biome-ignore lint/suspicious/noExplicitAny: live-state db handle
-  db: any,
+  db: Pick<ServerDB<typeof schema>, "find">,
   organizationId: string,
   capability: Capability,
 ): Promise<boolean> {
@@ -23,7 +23,7 @@ export async function orgHasCapability(
     await db.find(schema.integration, {
       where: { organizationId, enabled: true },
     }),
-  ) as { type: string }[];
+  );
 
   return connectorRegistry.hasCapability(
     integrations.map((integration) => integration.type),

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -530,7 +530,7 @@ export default publicRoute.withProcedures(({ mutation, query }) => ({
       type: "issue_created",
       metadata: {
         issueId: entity.id,
-        issueNumber: entity.number,
+        issueShortId: entity.shortId,
         issueLabel: entity.label,
       },
       replicatedStr: null,

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -484,6 +484,12 @@ export default publicRoute.withProcedures(({ mutation, query }) => ({
       throw new Error("CONNECTOR_NOT_REGISTERED");
     }
 
+    // An integration can be enabled before it's configured (`configStr` is
+    // nullable); fail with a clear error rather than forwarding a null config.
+    if (!integration.configStr) {
+      throw new Error("ISSUE_TRACKER_NOT_CONFIGURED");
+    }
+
     // Verify thread exists and belongs to the organization
     const thread = await db.findOne(schema.thread, req.input.threadId);
     if (!thread || thread.organizationId !== organizationId) {
@@ -516,6 +522,7 @@ export default publicRoute.withProcedures(({ mutation, query }) => ({
       threadId: req.input.threadId,
       organizationId,
       userId: actor?.userId ?? null,
+      userName: actor?.userName ?? null,
       type: "issue_created",
       metadata: {
         issueId: entity.id,

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -10,7 +10,10 @@ import {
   getWorkspaceActor,
   requireInternalApiKey,
 } from "../../lib/authorize";
-import { connectorRegistry } from "../../lib/connector-registry";
+import {
+  connectorInvokeSecret,
+  connectorRegistry,
+} from "../../lib/connector-registry";
 import {
   acceptInlineSuggestionInputSchema,
   acceptReadInputSchema,
@@ -516,6 +519,7 @@ export default publicRoute.withProcedures(({ mutation, query }) => ({
           target: req.input.target,
         },
       },
+      { secret: connectorInvokeSecret },
     );
 
     await runRecordActivity(db, {

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -1,5 +1,5 @@
 // TODO refactor with new live-state mental model
-import { formatGitHubId } from "@workspace/schemas/external-issue";
+import { invokeCapability, type NormalizedIssue } from "@connectors/framework";
 import { ulid } from "ulid";
 import z from "zod";
 import {
@@ -10,6 +10,23 @@ import {
   getWorkspaceActor,
   requireInternalApiKey,
 } from "../../lib/authorize";
+import { connectorRegistry } from "../../lib/connector-registry";
+import {
+  acceptInlineSuggestionInputSchema,
+  acceptReadInputSchema,
+  dismissInlineSuggestionInputSchema,
+  dismissReadInputSchema,
+  executeAutonomousBundleInputSchema,
+  runAcceptInlineSuggestion,
+  runAcceptRead,
+  runDismissInlineSuggestion,
+  runDismissRead,
+  runExecuteAutonomousBundle,
+  runUpsertInlineSuggestion,
+  runWriteHintSlot,
+  upsertInlineSuggestionInputSchema,
+  writeHintSlotInputSchema,
+} from "../../lib/signals/thread-procedures.js";
 import {
   archiveThreadInputSchema,
   assignUserInputSchema,
@@ -34,25 +51,9 @@ import {
   unlinkIssueInputSchema,
   unlinkPullRequestInputSchema,
 } from "../../lib/thread-mutations";
-import { runRecordActivity } from "../../lib/update-mutations";
-import {
-  acceptInlineSuggestionInputSchema,
-  acceptReadInputSchema,
-  dismissInlineSuggestionInputSchema,
-  dismissReadInputSchema,
-  executeAutonomousBundleInputSchema,
-  runAcceptInlineSuggestion,
-  runAcceptRead,
-  runDismissInlineSuggestion,
-  runDismissRead,
-  runExecuteAutonomousBundle,
-  runUpsertInlineSuggestion,
-  runWriteHintSlot,
-  upsertInlineSuggestionInputSchema,
-  writeHintSlotInputSchema,
-} from "../../lib/signals/thread-procedures.js";
-import { serializeMessageContent } from "../../lib/tiptap-content";
 import { nextThreadShortId } from "../../lib/thread-short-id";
+import { serializeMessageContent } from "../../lib/tiptap-content";
+import { runRecordActivity } from "../../lib/update-mutations";
 import { publicRoute } from "../factories";
 import { schema } from "../schema";
 
@@ -86,648 +87,639 @@ const threadCreateInputSchema = z.object({
   firstMessage: integrationFirstMessageSchema.optional(),
 });
 
-const GITHUB_SERVER_URL =
-  process.env.BASE_GITHUB_SERVER_URL || "http://localhost:3334";
-
 export default publicRoute.withProcedures(({ mutation, query }) => ({
-    create: mutation(threadCreateInputSchema).handler(async ({ req, db }) => {
-      const organizationId =
-        req.context?.publicApiKey?.ownerId ?? req.input.organizationId;
+  create: mutation(threadCreateInputSchema).handler(async ({ req, db }) => {
+    const organizationId =
+      req.context?.publicApiKey?.ownerId ?? req.input.organizationId;
 
-      if (!organizationId) {
-        throw new Error("MISSING_ORGANIZATION_ID");
-      }
+    if (!organizationId) {
+      throw new Error("MISSING_ORGANIZATION_ID");
+    }
 
-      const hasIntegrationOnlyFields =
-        req.input.id !== undefined ||
-        req.input.createdAt !== undefined ||
-        req.input.status !== undefined ||
-        req.input.discordChannelId !== undefined ||
-        req.input.externalId !== undefined ||
-        req.input.externalOrigin !== undefined ||
-        req.input.externalMetadataStr !== undefined ||
-        req.input.firstMessage !== undefined;
+    const hasIntegrationOnlyFields =
+      req.input.id !== undefined ||
+      req.input.createdAt !== undefined ||
+      req.input.status !== undefined ||
+      req.input.discordChannelId !== undefined ||
+      req.input.externalId !== undefined ||
+      req.input.externalOrigin !== undefined ||
+      req.input.externalMetadataStr !== undefined ||
+      req.input.firstMessage !== undefined;
 
-      const createFlow = authorizeThreadCreate(req, {
-        organizationId,
-        inputUserId: req.input.userId,
-        hasIntegrationOnlyFields,
-      });
+    const createFlow = authorizeThreadCreate(req, {
+      organizationId,
+      inputUserId: req.input.userId,
+      hasIntegrationOnlyFields,
+    });
 
-      if (createFlow === "workspace" && !req.input.author) {
+    if (createFlow === "workspace" && !req.input.author) {
+      throw new Error("MISSING_AUTHOR_INFO");
+    }
+
+    const content = serializeMessageContent(req.input.message);
+
+    const threadId = req.input.id ?? ulid().toLowerCase();
+    const firstMessage = req.input.firstMessage;
+
+    await db.transaction(async ({ trx }) => {
+      let authorId: string | undefined;
+
+      // Determine author based on context
+      if (createFlow === "portal") {
+        const { userId, userName } = getPortalAuthor(req, {
+          userName: req.input.userName,
+        });
+
+        const existingAuthor = Object.values(
+          await trx.find(schema.author, {
+            where: {
+              userId,
+              organizationId,
+            },
+          }),
+        );
+
+        authorId = existingAuthor[0]?.id;
+
+        if (!authorId) {
+          authorId = ulid().toLowerCase();
+          await trx.insert(schema.author, {
+            id: authorId,
+            userId,
+            metaId: null,
+            name: userName,
+            organizationId,
+          });
+        }
+      } else if (req.input.author) {
+        // API key flow - use metaId
+        const existingAuthor = Object.values(
+          await trx.find(schema.author, {
+            where: {
+              metaId: req.input.author.id,
+              organizationId: organizationId,
+            },
+          }),
+        );
+
+        authorId = existingAuthor[0]?.id;
+
+        if (!authorId) {
+          authorId = ulid().toLowerCase();
+          await trx.insert(schema.author, {
+            id: authorId,
+            name: req.input.author.name,
+            organizationId: organizationId,
+            metaId: req.input.author.id,
+            userId: null,
+          });
+        }
+      } else {
         throw new Error("MISSING_AUTHOR_INFO");
       }
 
-      const content = serializeMessageContent(req.input.message);
+      const shortId = await nextThreadShortId(trx, organizationId);
 
-      const threadId = req.input.id ?? ulid().toLowerCase();
-      const firstMessage = req.input.firstMessage;
-
-      await db.transaction(async ({ trx }) => {
-        let authorId: string | undefined;
-
-        // Determine author based on context
-        if (createFlow === "portal") {
-          const { userId, userName } = getPortalAuthor(req, {
-            userName: req.input.userName,
-          });
-
-          const existingAuthor = Object.values(
-            await trx.find(schema.author, {
-              where: {
-                userId,
-                organizationId,
-              },
-            }),
-          );
-
-          authorId = existingAuthor[0]?.id;
-
-          if (!authorId) {
-            authorId = ulid().toLowerCase();
-            await trx.insert(schema.author, {
-              id: authorId,
-              userId,
-              metaId: null,
-              name: userName,
-              organizationId,
-            });
-          }
-        } else if (req.input.author) {
-          // API key flow - use metaId
-          const existingAuthor = Object.values(
-            await trx.find(schema.author, {
-              where: {
-                metaId: req.input.author.id,
-                organizationId: organizationId,
-              },
-            }),
-          );
-
-          authorId = existingAuthor[0]?.id;
-
-          if (!authorId) {
-            authorId = ulid().toLowerCase();
-            await trx.insert(schema.author, {
-              id: authorId,
-              name: req.input.author.name,
-              organizationId: organizationId,
-              metaId: req.input.author.id,
-              userId: null,
-            });
-          }
-        } else {
-          throw new Error("MISSING_AUTHOR_INFO");
-        }
-
-        const shortId = await nextThreadShortId(trx, organizationId);
-
-        // Create thread
-        await trx.insert(schema.thread, {
-          id: threadId,
-          name: req.input.title,
-          organizationId: organizationId,
-          authorId: authorId,
-          status: req.input.status ?? 0,
-          priority: 0,
-          assignedUserId: null,
-          createdAt: req.input.createdAt ?? new Date(),
-          deletedAt: null,
-          discordChannelId: req.input.discordChannelId ?? null,
-          externalIssueId: null,
-          externalPrId: null,
-          externalId: req.input.externalId ?? null,
-          externalOrigin: req.input.externalOrigin ?? null,
-          externalMetadataStr: req.input.externalMetadataStr ?? null,
-          shortId,
-        });
-
-        // Create first message
-        await trx.insert(schema.message, {
-          id: firstMessage?.id ?? ulid().toLowerCase(),
-          authorId: authorId,
-          content: content,
-          threadId: threadId,
-          createdAt: firstMessage?.createdAt ?? new Date(),
-          origin: firstMessage?.origin ?? null,
-          externalMessageId: firstMessage?.externalMessageId ?? null,
-          isBackfill: firstMessage?.isBackfill ?? false,
-        });
-      });
-
-      const thread = Object.values(
-        await db.find(schema.thread, {
-          where: { id: threadId },
-          include: {
-            author: true,
-            messages: {
-              include: { author: true },
-            },
-          },
-        }),
-      )[0];
-
-      return thread;
-    }),
-    list: query(
-      z.object({
-        organizationId: z.string(),
-        status: z.number().optional(),
-        priority: z.number().optional(),
-        assignedUserId: z.string().nullable().optional(),
-        cursor: z.string().optional(),
-        limit: z.number().min(1).max(50).default(10),
-        direction: z.enum(["asc", "desc"]).default("desc"),
-      }),
-    ).handler(async ({ req, db }) => {
-      const {
-        organizationId,
-        status,
-        priority,
-        assignedUserId,
-        cursor,
-        limit,
-        direction,
-      } = req.input;
-
-      // authorize(req, { organizationId });
-
-      let query = db.thread.where({
-        organizationId,
+      // Create thread
+      await trx.insert(schema.thread, {
+        id: threadId,
+        name: req.input.title,
+        organizationId: organizationId,
+        authorId: authorId,
+        status: req.input.status ?? 0,
+        priority: 0,
+        assignedUserId: null,
+        createdAt: req.input.createdAt ?? new Date(),
         deletedAt: null,
+        discordChannelId: req.input.discordChannelId ?? null,
+        externalIssueId: null,
+        externalPrId: null,
+        externalId: req.input.externalId ?? null,
+        externalOrigin: req.input.externalOrigin ?? null,
+        externalMetadataStr: req.input.externalMetadataStr ?? null,
+        shortId,
       });
 
-      if (status !== undefined) {
-        query = query.where({ status });
-      }
-      if (priority !== undefined) {
-        query = query.where({ priority });
-      }
-      if (assignedUserId !== undefined) {
-        query = query.where({ assignedUserId });
-      }
+      // Create first message
+      await trx.insert(schema.message, {
+        id: firstMessage?.id ?? ulid().toLowerCase(),
+        authorId: authorId,
+        content: content,
+        threadId: threadId,
+        createdAt: firstMessage?.createdAt ?? new Date(),
+        origin: firstMessage?.origin ?? null,
+        externalMessageId: firstMessage?.externalMessageId ?? null,
+        isBackfill: firstMessage?.isBackfill ?? false,
+      });
+    });
 
-      if (cursor) {
-        const op = direction === "desc" ? "$lt" : "$gt";
-        query = query.where({ id: { [op]: cursor } });
-      }
-
-      const rows = await query
-        .include({
-          messages: { include: { author: true } },
+    const thread = Object.values(
+      await db.find(schema.thread, {
+        where: { id: threadId },
+        include: {
           author: true,
-          assignedUser: true,
+          messages: {
+            include: { author: true },
+          },
+        },
+      }),
+    )[0];
+
+    return thread;
+  }),
+  list: query(
+    z.object({
+      organizationId: z.string(),
+      status: z.number().optional(),
+      priority: z.number().optional(),
+      assignedUserId: z.string().nullable().optional(),
+      cursor: z.string().optional(),
+      limit: z.number().min(1).max(50).default(10),
+      direction: z.enum(["asc", "desc"]).default("desc"),
+    }),
+  ).handler(async ({ req, db }) => {
+    const {
+      organizationId,
+      status,
+      priority,
+      assignedUserId,
+      cursor,
+      limit,
+      direction,
+    } = req.input;
+
+    // authorize(req, { organizationId });
+
+    let query = db.thread.where({
+      organizationId,
+      deletedAt: null,
+    });
+
+    if (status !== undefined) {
+      query = query.where({ status });
+    }
+    if (priority !== undefined) {
+      query = query.where({ priority });
+    }
+    if (assignedUserId !== undefined) {
+      query = query.where({ assignedUserId });
+    }
+
+    if (cursor) {
+      const op = direction === "desc" ? "$lt" : "$gt";
+      query = query.where({ id: { [op]: cursor } });
+    }
+
+    const rows = await query
+      .include({
+        messages: { include: { author: true } },
+        author: true,
+        assignedUser: true,
+        labels: { include: { label: true } },
+      })
+      .orderBy("id", direction)
+      .limit(limit + 1)
+      .get();
+
+    const hasMore = rows.length > limit;
+    const threads = hasMore ? rows.slice(0, limit) : rows;
+
+    const nextCursor =
+      hasMore && threads.length > 0
+        ? (threads[threads.length - 1]?.id ?? null)
+        : null;
+
+    return { threads, nextCursor };
+  }),
+
+  /**
+   * Single thread with its full relation tree — portal thread page, workspace
+   * archive view, and devtools. Public, matching the old open `read` on
+   * threads. `onlyDeleted`/`deletedBefore` serve the archive (soft-deleted,
+   * pre-purge-window) lookups.
+   */
+  detail: query(
+    z
+      .object({
+        id: z.string().optional(),
+        shortId: z.number().optional(),
+        organizationId: z.string().optional(),
+        onlyDeleted: z.boolean().optional(),
+        deletedBefore: z.coerce.date().optional(),
+      })
+      .refine(
+        (input) => input.id !== undefined || input.shortId !== undefined,
+        { message: "THREAD_SELECTOR_REQUIRED" },
+      )
+      .refine(
+        (input) =>
+          input.shortId === undefined || input.organizationId !== undefined,
+        { message: "SHORT_ID_REQUIRES_ORGANIZATION" },
+      ),
+  ).handler(async ({ req, db }) => {
+    const { id, shortId, organizationId, onlyDeleted, deletedBefore } =
+      req.input;
+
+    const rows = await db.thread
+      .where({
+        ...(id !== undefined ? { id } : {}),
+        ...(shortId !== undefined ? { shortId } : {}),
+        ...(organizationId !== undefined ? { organizationId } : {}),
+        deletedAt: onlyDeleted
+          ? { $not: null, ...(deletedBefore ? { $lt: deletedBefore } : {}) }
+          : null,
+      })
+      .include({
+        author: true,
+        organization: true,
+        messages: { include: { author: true } },
+        assignedUser: true,
+        updates: { include: { user: true } },
+        labels: { include: { label: true } },
+      })
+      .get();
+
+    return rows[0];
+  }),
+
+  /** All threads with their org — sitemap generation. Public (open read). */
+  listAll: query().handler(async ({ db }) =>
+    db.thread
+      .where({ deletedAt: null })
+      .include({ organization: true, messages: true })
+      .get(),
+  ),
+
+  /** Thread lookup by external (platform) id — integration bot dedupe. */
+  byExternalId: query(
+    z.object({
+      externalId: z.string(),
+      // Required so dedupe/reads are always tenant-scoped — external ids can
+      // collide across organizations.
+      organizationId: z.string(),
+      externalOrigin: z.string().optional(),
+    }),
+  ).handler(async ({ req, db }) => {
+    const { externalId, organizationId, externalOrigin } = req.input;
+    return Object.values(
+      await db.find(schema.thread, {
+        where: {
+          externalId,
+          organizationId,
+          ...(externalOrigin !== undefined ? { externalOrigin } : {}),
+        },
+      }),
+    )[0];
+  }),
+
+  /**
+   * Threads by id (with messages + labels) — worker pipeline reads. Accepts a
+   * batch so callers can hydrate many threads in one round-trip.
+   */
+  byIds: query(z.object({ ids: z.array(z.string()) })).handler(
+    async ({ req, db }) => {
+      if (req.input.ids.length === 0) return [];
+      return db.thread
+        .where({ id: { $in: req.input.ids } })
+        .include({
+          messages: true,
           labels: { include: { label: true } },
         })
-        .orderBy("id", direction)
-        .limit(limit + 1)
         .get();
+    },
+  ),
 
-      const hasMore = rows.length > limit;
-      const threads = hasMore ? rows.slice(0, limit) : rows;
-
-      const nextCursor =
-        hasMore && threads.length > 0
-          ? (threads[threads.length - 1]?.id ?? null)
-          : null;
-
-      return { threads, nextCursor };
+  // TODO(signals-overhaul issue 10): rewrite against thread.agentRead /
+  // thread.inlineSuggestions (or replace with a new related-threads source).
+  // The suggestion table backing this was dropped in issue 02; returns [] now.
+  fetchRelatedThreads: mutation(
+    z.object({
+      threadId: z.string(),
+      organizationId: z.string(),
     }),
+  ).handler(async () => {
+    return [];
+  }),
+  /**
+   * @deprecated The web client now reads issues reactively from the
+   * org-scoped `externalEntity` mirror (synced via Live-State). This on-demand
+   * fetch is retired and stubbed to an empty result; the procedure surface is
+   * kept so the Router type stays stable until all consumers are confirmed
+   * migrated (FRO-185).
+   */
+  fetchGithubIssues: mutation(
+    z.object({
+      organizationId: z.string(),
+      state: z.enum(["open", "closed", "all"]).optional().default("open"),
+    }),
+  ).handler(async () => {
+    return { issues: [], count: 0 };
+  }),
+  /**
+   * @deprecated The web client now reads pull requests reactively from the
+   * org-scoped `externalEntity` mirror (synced via Live-State). This on-demand
+   * fetch is retired and stubbed to an empty result; the procedure surface is
+   * kept so the Router type stays stable until all consumers are confirmed
+   * migrated (FRO-185).
+   */
+  fetchGithubPullRequests: mutation(
+    z.object({
+      organizationId: z.string(),
+      state: z.enum(["open", "closed", "all"]).optional().default("open"),
+    }),
+  ).handler(async () => {
+    return { pullRequests: [], count: 0 };
+  }),
+  createIssue: mutation(
+    z.object({
+      organizationId: z.string(),
+      threadId: z.string(),
+      title: z.string(),
+      body: z.string().optional(),
+      // Opaque, connector-interpreted sub-resource selector (e.g. GitHub
+      // `{ owner, repo }`). Core forwards it untouched.
+      target: z.record(z.string(), z.unknown()),
+      // Optionally pin a specific issue-tracker integration; otherwise the
+      // org's first enabled provider is used.
+      integrationId: z.string().optional(),
+    }),
+  ).handler(async ({ req, db }) => {
+    const organizationId = req.input.organizationId;
 
-    /**
-     * Single thread with its full relation tree — portal thread page, workspace
-     * archive view, and devtools. Public, matching the old open `read` on
-     * threads. `onlyDeleted`/`deletedBefore` serve the archive (soft-deleted,
-     * pre-purge-window) lookups.
-     */
-    detail: query(
-      z
-        .object({
-          id: z.string().optional(),
-          shortId: z.number().optional(),
-          organizationId: z.string().optional(),
-          onlyDeleted: z.boolean().optional(),
-          deletedBefore: z.coerce.date().optional(),
-        })
-        .refine(
-          (input) => input.id !== undefined || input.shortId !== undefined,
-          { message: "THREAD_SELECTOR_REQUIRED" },
+    if (!organizationId) {
+      throw new Error("MISSING_ORGANIZATION_ID");
+    }
+
+    authorize(req, { organizationId });
+
+    const actor = req.context?.internalApiKey ? null : getWorkspaceActor(req);
+
+    // Resolve the target integration providing the issue-tracker capability
+    // from the org's enabled integrations, via the registry.
+    const enabledIntegrations = Object.values(
+      await db.find(schema.integration, {
+        where: { organizationId, enabled: true },
+        include: { organization: true },
+      }),
+    ) as any[]; // TODO: Remove type assertion when live-state supports includes properly
+
+    const providerTypes = new Set(
+      connectorRegistry
+        .providersOf("issue-tracker")
+        .map((entry) => entry.manifest.type),
+    );
+
+    const integration = req.input.integrationId
+      ? enabledIntegrations.find(
+          (i) => i.id === req.input.integrationId && providerTypes.has(i.type),
         )
-        .refine(
-          (input) =>
-            input.shortId === undefined || input.organizationId !== undefined,
-          { message: "SHORT_ID_REQUIRES_ORGANIZATION" },
-        ),
-    ).handler(async ({ req, db }) => {
-      const { id, shortId, organizationId, onlyDeleted, deletedBefore } =
-        req.input;
+      : enabledIntegrations.find((i) => providerTypes.has(i.type));
 
-      const rows = await db.thread
-        .where({
-          ...(id !== undefined ? { id } : {}),
-          ...(shortId !== undefined ? { shortId } : {}),
-          ...(organizationId !== undefined ? { organizationId } : {}),
-          deletedAt: onlyDeleted
-            ? { $not: null, ...(deletedBefore ? { $lt: deletedBefore } : {}) }
-            : null,
-        })
-        .include({
-          author: true,
-          organization: true,
-          messages: { include: { author: true } },
-          assignedUser: true,
-          updates: { include: { user: true } },
-          labels: { include: { label: true } },
-        })
-        .get();
+    if (!integration) {
+      throw new Error("ISSUE_TRACKER_NOT_CONFIGURED");
+    }
 
-      return rows[0];
-    }),
+    const entry = connectorRegistry.getByType(integration.type);
+    if (!entry) {
+      throw new Error("CONNECTOR_NOT_REGISTERED");
+    }
 
-    /** All threads with their org — sitemap generation. Public (open read). */
-    listAll: query().handler(async ({ db }) =>
-      db.thread
-        .where({ deletedAt: null })
-        .include({ organization: true, messages: true })
-        .get(),
-    ),
+    // Verify thread exists and belongs to the organization
+    const thread = await db.findOne(schema.thread, req.input.threadId);
+    if (!thread || thread.organizationId !== organizationId) {
+      throw new Error("THREAD_NOT_FOUND");
+    }
 
-    /** Thread lookup by external (platform) id — integration bot dedupe. */
-    byExternalId: query(
-      z.object({
-        externalId: z.string(),
-        // Required so dedupe/reads are always tenant-scoped — external ids can
-        // collide across organizations.
-        organizationId: z.string(),
-        externalOrigin: z.string().optional(),
-      }),
-    ).handler(async ({ req, db }) => {
-      const { externalId, organizationId, externalOrigin } = req.input;
-      return Object.values(
-        await db.find(schema.thread, {
-          where: {
-            externalId,
-            organizationId,
-            ...(externalOrigin !== undefined ? { externalOrigin } : {}),
-          },
-        }),
-      )[0];
-    }),
+    // Append FrontDesk footer to issue body
+    const orgSlug = integration.organization.slug;
+    const threadPortalUrl = `https://${orgSlug}.tryfrontdesk.app/threads/${thread.id}`;
+    const footer = `\n\n---\n\nIssue created using FrontDesk. [Click to view thread](${threadPortalUrl}).`;
+    const body = (req.input.body ?? "") + footer;
 
-    /**
-     * Threads by id (with messages + labels) — worker pipeline reads. Accepts a
-     * batch so callers can hydrate many threads in one round-trip.
-     */
-    byIds: query(z.object({ ids: z.array(z.string()) })).handler(
-      async ({ req, db }) => {
-        if (req.input.ids.length === 0) return [];
-        return db.thread
-          .where({ id: { $in: req.input.ids } })
-          .include({
-            messages: true,
-            labels: { include: { label: true } },
-          })
-          .get();
-      },
-    ),
-
-    // TODO(signals-overhaul issue 10): rewrite against thread.agentRead /
-    // thread.inlineSuggestions (or replace with a new related-threads source).
-    // The suggestion table backing this was dropped in issue 02; returns [] now.
-    fetchRelatedThreads: mutation(
-      z.object({
-        threadId: z.string(),
-        organizationId: z.string(),
-      }),
-    ).handler(async () => {
-      return [];
-    }),
-    /**
-     * @deprecated The web client now reads issues reactively from the
-     * org-scoped `externalEntity` mirror (synced via Live-State). This on-demand
-     * fetch is retired and stubbed to an empty result; the procedure surface is
-     * kept so the Router type stays stable until all consumers are confirmed
-     * migrated (FRO-185).
-     */
-    fetchGithubIssues: mutation(
-      z.object({
-        organizationId: z.string(),
-        state: z.enum(["open", "closed", "all"]).optional().default("open"),
-      }),
-    ).handler(async () => {
-      return { issues: [], count: 0 };
-    }),
-    /**
-     * @deprecated The web client now reads pull requests reactively from the
-     * org-scoped `externalEntity` mirror (synced via Live-State). This on-demand
-     * fetch is retired and stubbed to an empty result; the procedure surface is
-     * kept so the Router type stays stable until all consumers are confirmed
-     * migrated (FRO-185).
-     */
-    fetchGithubPullRequests: mutation(
-      z.object({
-        organizationId: z.string(),
-        state: z.enum(["open", "closed", "all"]).optional().default("open"),
-      }),
-    ).handler(async () => {
-      return { pullRequests: [], count: 0 };
-    }),
-    createGithubIssue: mutation(
-      z.object({
-        organizationId: z.string(),
-        threadId: z.string(),
-        title: z.string(),
-        body: z.string().optional(),
-        owner: z.string(),
-        repo: z.string(),
-      }),
-    ).handler(async ({ req, db }) => {
-      const organizationId = req.input.organizationId;
-
-      if (!organizationId) {
-        throw new Error("MISSING_ORGANIZATION_ID");
-      }
-
-      authorize(req, { organizationId });
-
-      const actor = req.context?.internalApiKey
-        ? null
-        : getWorkspaceActor(req);
-
-      // Get GitHub integration config
-      const integration = Object.values(
-        await db.find(schema.integration, {
-          where: {
-            organizationId,
-            type: "github",
-            enabled: true,
-          },
-          include: {
-            organization: true,
-          },
-        }),
-      )[0] as any; // TODO: Remove type assertion when live-state supports includes properly
-
-      if (!integration || !integration.configStr) {
-        throw new Error("GITHUB_INTEGRATION_NOT_CONFIGURED");
-      }
-
-      const config = JSON.parse(integration.configStr);
-      const { repos, installationId } = config;
-
-      if (!repos || repos.length === 0) {
-        throw new Error("GITHUB_REPOSITORIES_NOT_CONFIGURED");
-      }
-
-      if (!installationId) {
-        throw new Error("GITHUB_INSTALLATION_NOT_CONFIGURED");
-      }
-
-      // Verify the repository is in the connected repos
-      const targetRepo = repos.find(
-        (r: { owner: string; name: string }) =>
-          r.owner === req.input.owner && r.name === req.input.repo,
-      );
-
-      if (!targetRepo) {
-        throw new Error("GITHUB_REPOSITORY_NOT_CONNECTED");
-      }
-
-      // Verify thread exists and belongs to the organization
-      const thread = await db.findOne(schema.thread, req.input.threadId);
-      if (!thread || thread.organizationId !== organizationId) {
-        throw new Error("THREAD_NOT_FOUND");
-      }
-
-      // Append FrontDesk footer to issue body
-      const orgSlug = integration.organization.slug;
-      const threadPortalUrl = `https://${orgSlug}.tryfrontdesk.app/threads/${thread.id}`;
-      const footer = `\n\n---\n\nIssue created using FrontDesk. [Click to view thread](${threadPortalUrl}).`;
-      const body = (req.input.body ?? "") + footer;
-
-      const response = await fetch(`${GITHUB_SERVER_URL}/api/issues`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          installation_id: installationId.toString(),
-          owner: req.input.owner,
-          repo: req.input.repo,
+    // Dispatch generically: the connector interprets its own opaque config
+    // (`configStr`, forwarded untouched) and the target sub-resource.
+    const { entity } = await invokeCapability<{ entity: NormalizedIssue }>(
+      entry.invokeUrl,
+      {
+        capability: "issue-tracker",
+        method: "create",
+        config: integration.configStr,
+        payload: {
           title: req.input.title,
-          body: body,
-        }),
-      });
-
-      if (!response.ok) {
-        const error = await response.text();
-        console.error("Failed to create GitHub issue:", error);
-        throw new Error("GITHUB_ISSUE_CREATION_FAILED");
-      }
-
-      const data = (await response.json()) as {
-        issue: {
-          id: number;
-          number: number;
-          title: string;
-          body: string;
-          state: string;
-          html_url: string;
-        };
-      };
-
-      await runRecordActivity(db, {
-        threadId: req.input.threadId,
-        organizationId,
-        userId: actor?.userId ?? null,
-        type: "github_issue_created",
-        metadata: {
-          issueId: data.issue.id,
-          issueNumber: data.issue.number,
-          issueLabel: `${req.input.owner}/${req.input.repo}#${data.issue.number}`,
+          body,
+          target: req.input.target,
         },
-        replicatedStr: null,
-      });
+      },
+    );
 
-      // The created issue propagates into the `externalEntity` mirror via the
-      // GitHub webhook upsert, which syncs reactively to the web client.
+    await runRecordActivity(db, {
+      threadId: req.input.threadId,
+      organizationId,
+      userId: actor?.userId ?? null,
+      type: "issue_created",
+      metadata: {
+        issueId: entity.id,
+        issueNumber: entity.number,
+        issueLabel: entity.label,
+      },
+      replicatedStr: null,
+    });
 
-      return {
-        issue: {
-          id: formatGitHubId(data.issue.id, req.input.owner, req.input.repo),
-          number: data.issue.number,
-          title: data.issue.title,
-          body: data.issue.body,
-          state: data.issue.state,
-          url: data.issue.html_url,
-          repository: {
-            owner: req.input.owner,
-            name: req.input.repo,
-            fullName: targetRepo.fullName,
-          },
-        },
-      };
-    }),
-    executeAutonomousBundle: mutation(
-      executeAutonomousBundleInputSchema,
-    ).handler(async ({ req, db }) => {
+    // The created issue propagates into the `externalEntity` mirror via the
+    // connector's webhook upsert, which syncs reactively to the web client.
+
+    return {
+      issue: entity,
+    };
+  }),
+  executeAutonomousBundle: mutation(executeAutonomousBundleInputSchema).handler(
+    async ({ req, db }) => {
       requireInternalApiKey(req.context);
 
       return runExecuteAutonomousBundle(db, req.input);
-    }),
-    acceptRead: mutation(acceptReadInputSchema).handler(async ({ req, db }) => {
-      return runAcceptRead(req, db, req.input);
-    }),
-    dismissRead: mutation(dismissReadInputSchema).handler(
-      async ({ req, db }) => {
-        return runDismissRead(req, db, req.input);
-      },
-    ),
-    acceptInlineSuggestion: mutation(acceptInlineSuggestionInputSchema).handler(
-      async ({ req, db }) => {
-        return runAcceptInlineSuggestion(req, db, req.input);
-      },
-    ),
-    dismissInlineSuggestion: mutation(
-      dismissInlineSuggestionInputSchema,
-    ).handler(async ({ req, db }) => {
+    },
+  ),
+  acceptRead: mutation(acceptReadInputSchema).handler(async ({ req, db }) => {
+    return runAcceptRead(req, db, req.input);
+  }),
+  dismissRead: mutation(dismissReadInputSchema).handler(async ({ req, db }) => {
+    return runDismissRead(req, db, req.input);
+  }),
+  acceptInlineSuggestion: mutation(acceptInlineSuggestionInputSchema).handler(
+    async ({ req, db }) => {
+      return runAcceptInlineSuggestion(req, db, req.input);
+    },
+  ),
+  dismissInlineSuggestion: mutation(dismissInlineSuggestionInputSchema).handler(
+    async ({ req, db }) => {
       return runDismissInlineSuggestion(req, db, req.input);
-    }),
-    upsertInlineSuggestion: mutation(upsertInlineSuggestionInputSchema).handler(
-      async ({ req, db }) => {
-        requireInternalApiKey(req.context);
-        return runUpsertInlineSuggestion(db, req.input);
-      },
-    ),
-    writeHintSlot: mutation(writeHintSlotInputSchema).handler(
-      async ({ req, db }) => {
-        requireInternalApiKey(req.context);
-        return runWriteHintSlot(db, req.input);
-      },
-    ),
-    setStatus: mutation(setStatusInputSchema).handler(async ({ req, db }) => {
-      if (req.context?.internalApiKey) {
-        return runSetThreadStatus(
-          db,
-          req.input,
-          {
-            userId: null,
-            userName: req.input.userName ?? null,
-          },
-          { recordActivity: req.input.recordActivity ?? false },
-        );
-      }
+    },
+  ),
+  upsertInlineSuggestion: mutation(upsertInlineSuggestionInputSchema).handler(
+    async ({ req, db }) => {
+      requireInternalApiKey(req.context);
+      return runUpsertInlineSuggestion(db, req.input);
+    },
+  ),
+  writeHintSlot: mutation(writeHintSlotInputSchema).handler(
+    async ({ req, db }) => {
+      requireInternalApiKey(req.context);
+      return runWriteHintSlot(db, req.input);
+    },
+  ),
+  setStatus: mutation(setStatusInputSchema).handler(async ({ req, db }) => {
+    if (req.context?.internalApiKey) {
+      return runSetThreadStatus(
+        db,
+        req.input,
+        {
+          userId: null,
+          userName: req.input.userName ?? null,
+        },
+        { recordActivity: req.input.recordActivity ?? false },
+      );
+    }
 
-      assertInternalKeyForIntegrationFields(req, {
-        recordActivity: req.input.recordActivity,
-        activityMetadata: req.input.activityMetadata,
-        replicatedStr: req.input.replicatedStr,
+    assertInternalKeyForIntegrationFields(req, {
+      recordActivity: req.input.recordActivity,
+      activityMetadata: req.input.activityMetadata,
+      replicatedStr: req.input.replicatedStr,
+    });
+
+    authorize(req, {
+      organizationId: req.input.organizationId,
+      allowInternalApiKey: false,
+    });
+
+    const actor = getWorkspaceActor(req);
+
+    return runSetThreadStatus(db, req.input, {
+      userId: actor.userId,
+      userName: actor.userName,
+    });
+  }),
+  setPriority: mutation(setPriorityInputSchema).handler(async ({ req, db }) => {
+    authorize(req, {
+      organizationId: req.input.organizationId,
+      allowInternalApiKey: false,
+    });
+
+    const actor = getWorkspaceActor(req);
+
+    return runSetThreadPriority(db, req.input, {
+      userId: actor.userId,
+      userName: actor.userName,
+    });
+  }),
+  assignUser: mutation(assignUserInputSchema).handler(async ({ req, db }) => {
+    authorize(req, {
+      organizationId: req.input.organizationId,
+      allowInternalApiKey: false,
+    });
+
+    const actor = getWorkspaceActor(req);
+
+    return runAssignThreadUser(db, req.input, {
+      userId: actor.userId,
+      userName: actor.userName,
+    });
+  }),
+  linkIssue: mutation(linkIssueInputSchema).handler(async ({ req, db }) => {
+    authorize(req, {
+      organizationId: req.input.organizationId,
+      allowInternalApiKey: false,
+    });
+
+    const actor = getWorkspaceActor(req);
+
+    return runLinkIssue(db, req.input, {
+      userId: actor.userId,
+      userName: actor.userName,
+    });
+  }),
+  unlinkIssue: mutation(unlinkIssueInputSchema).handler(async ({ req, db }) => {
+    authorize(req, {
+      organizationId: req.input.organizationId,
+      allowInternalApiKey: false,
+    });
+
+    const actor = getWorkspaceActor(req);
+
+    return runUnlinkIssue(db, req.input, {
+      userId: actor.userId,
+      userName: actor.userName,
+    });
+  }),
+  linkPullRequest: mutation(linkPullRequestInputSchema).handler(
+    async ({ req, db }) => {
+      authorize(req, {
+        organizationId: req.input.organizationId,
+        allowInternalApiKey: false,
       });
-
-      authorize(req, { organizationId: req.input.organizationId, allowInternalApiKey: false });
 
       const actor = getWorkspaceActor(req);
 
-      return runSetThreadStatus(db, req.input, {
+      return runLinkPullRequest(db, req.input, {
         userId: actor.userId,
         userName: actor.userName,
       });
-    }),
-    setPriority: mutation(setPriorityInputSchema).handler(async ({ req, db }) => {
-      authorize(req, { organizationId: req.input.organizationId, allowInternalApiKey: false });
+    },
+  ),
+  unlinkPullRequest: mutation(unlinkPullRequestInputSchema).handler(
+    async ({ req, db }) => {
+      authorize(req, {
+        organizationId: req.input.organizationId,
+        allowInternalApiKey: false,
+      });
 
       const actor = getWorkspaceActor(req);
 
-      return runSetThreadPriority(db, req.input, {
+      return runUnlinkPullRequest(db, req.input, {
         userId: actor.userId,
         userName: actor.userName,
       });
-    }),
-    assignUser: mutation(assignUserInputSchema).handler(async ({ req, db }) => {
-      authorize(req, { organizationId: req.input.organizationId, allowInternalApiKey: false });
+    },
+  ),
+  markDuplicate: mutation(markDuplicateInputSchema).handler(
+    async ({ req, db }) => {
+      authorize(req, {
+        organizationId: req.input.organizationId,
+        allowInternalApiKey: false,
+      });
 
       const actor = getWorkspaceActor(req);
 
-      return runAssignThreadUser(db, req.input, {
+      return runMarkDuplicate(db, req.input, {
         userId: actor.userId,
         userName: actor.userName,
       });
-    }),
-    linkIssue: mutation(linkIssueInputSchema).handler(async ({ req, db }) => {
-      authorize(req, { organizationId: req.input.organizationId, allowInternalApiKey: false });
+    },
+  ),
+  archive: mutation(archiveThreadInputSchema).handler(async ({ req, db }) => {
+    authorize(req, {
+      organizationId: req.input.organizationId,
+      allowInternalApiKey: false,
+    });
 
-      const actor = getWorkspaceActor(req);
+    getWorkspaceActor(req);
 
-      return runLinkIssue(db, req.input, {
-        userId: actor.userId,
-        userName: actor.userName,
-      });
-    }),
-    unlinkIssue: mutation(unlinkIssueInputSchema).handler(async ({ req, db }) => {
-      authorize(req, { organizationId: req.input.organizationId, allowInternalApiKey: false });
+    return runArchiveThread(db, req.input);
+  }),
+  restore: mutation(restoreThreadInputSchema).handler(async ({ req, db }) => {
+    authorize(req, {
+      organizationId: req.input.organizationId,
+      allowInternalApiKey: false,
+    });
 
-      const actor = getWorkspaceActor(req);
+    getWorkspaceActor(req);
 
-      return runUnlinkIssue(db, req.input, {
-        userId: actor.userId,
-        userName: actor.userName,
-      });
-    }),
-    linkPullRequest: mutation(linkPullRequestInputSchema).handler(
-      async ({ req, db }) => {
-        authorize(req, { organizationId: req.input.organizationId, allowInternalApiKey: false });
+    return runRestoreThread(db, req.input);
+  }),
+  setAgentRead: mutation(setAgentReadInputSchema).handler(
+    async ({ req, db }) => {
+      requireInternalApiKey(req.context);
 
-        const actor = getWorkspaceActor(req);
-
-        return runLinkPullRequest(db, req.input, {
-          userId: actor.userId,
-          userName: actor.userName,
-        });
-      },
-    ),
-    unlinkPullRequest: mutation(unlinkPullRequestInputSchema).handler(
-      async ({ req, db }) => {
-        authorize(req, { organizationId: req.input.organizationId, allowInternalApiKey: false });
-
-        const actor = getWorkspaceActor(req);
-
-        return runUnlinkPullRequest(db, req.input, {
-          userId: actor.userId,
-          userName: actor.userName,
-        });
-      },
-    ),
-    markDuplicate: mutation(markDuplicateInputSchema).handler(
-      async ({ req, db }) => {
-        authorize(req, { organizationId: req.input.organizationId, allowInternalApiKey: false });
-
-        const actor = getWorkspaceActor(req);
-
-        return runMarkDuplicate(db, req.input, {
-          userId: actor.userId,
-          userName: actor.userName,
-        });
-      },
-    ),
-    archive: mutation(archiveThreadInputSchema).handler(async ({ req, db }) => {
-      authorize(req, { organizationId: req.input.organizationId, allowInternalApiKey: false });
-
-      getWorkspaceActor(req);
-
-      return runArchiveThread(db, req.input);
-    }),
-    restore: mutation(restoreThreadInputSchema).handler(async ({ req, db }) => {
-      authorize(req, { organizationId: req.input.organizationId, allowInternalApiKey: false });
-
-      getWorkspaceActor(req);
-
-      return runRestoreThread(db, req.input);
-    }),
-    setAgentRead: mutation(setAgentReadInputSchema).handler(
-      async ({ req, db }) => {
-        requireInternalApiKey(req.context);
-
-        return runSetAgentRead(db, req.input);
-      },
-    ),
-  }));
+      return runSetAgentRead(db, req.input);
+    },
+  ),
+}));

--- a/apps/web/src/components/threads/issues.tsx
+++ b/apps/web/src/components/threads/issues.tsx
@@ -168,13 +168,12 @@ export function IssuesSection({
     }) => {
       if (!currentOrg) throw new Error("No organization selected");
 
-      const result = await fetchClient.mutate.thread.createGithubIssue({
+      const result = await fetchClient.mutate.thread.createIssue({
         organizationId: currentOrg.id,
         threadId,
         title: title.trim(),
         body,
-        owner,
-        repo,
+        target: { owner, repo },
       });
 
       if (!result?.issue?.id || !result?.issue?.number || !result?.issue?.url) {

--- a/apps/web/src/components/threads/issues.tsx
+++ b/apps/web/src/components/threads/issues.tsx
@@ -176,7 +176,7 @@ export function IssuesSection({
         target: { owner, repo },
       });
 
-      if (!result?.issue?.id || !result?.issue?.number || !result?.issue?.url) {
+      if (!result?.issue?.id || !result?.issue?.shortId || !result?.issue?.url) {
         throw new Error("Invalid response from GitHub API");
       }
 
@@ -190,7 +190,9 @@ export function IssuesSection({
       // row arrives shortly after via the GitHub webhook upsert.
       setOptimisticIssue({
         externalKey: result.issue.id,
-        number: result.issue.number,
+        // The mirror row is GitHub-shaped (numeric `number`); parse the neutral
+        // `shortId` back to an int here in the GitHub-specific UI.
+        number: Number(result.issue.shortId),
         title: result.issue.title || variables.title,
         repoFullName: repo.fullName,
       });

--- a/apps/web/src/components/threads/updates.tsx
+++ b/apps/web/src/components/threads/updates.tsx
@@ -129,7 +129,7 @@ const PrChangedUpdateText = ({
   return "changed PR";
 };
 
-const GithubIssueCreatedUpdateText = ({
+const IssueCreatedUpdateText = ({
   metadata,
 }: {
   metadata: { [key: string]: unknown } | null;
@@ -246,8 +246,13 @@ export function Update({
       );
     }
 
-    if (update.type === "github_issue_created") {
-      return <GithubIssueCreatedUpdateText metadata={metadata} />;
+    // `github_issue_created` is the legacy type kept for existing rows; new
+    // rows use the provider-neutral `issue_created` from generic dispatch.
+    if (
+      update.type === "issue_created" ||
+      update.type === "github_issue_created"
+    ) {
+      return <IssueCreatedUpdateText metadata={metadata} />;
     }
 
     if (update.type === "marked_duplicate") {
@@ -306,7 +311,8 @@ export function Update({
               ))}
             {update.type === "issue_changed" && <Github className="size-3.5" />}
             {update.type === "pr_changed" && <Github className="size-3.5" />}
-            {update.type === "github_issue_created" && (
+            {(update.type === "issue_created" ||
+              update.type === "github_issue_created") && (
               <Github className="size-3.5" />
             )}
             {update.type === "marked_duplicate" && (

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@ai-sdk/google": "^3.0.7",
+        "@connectors/framework": "workspace:*",
         "@dodopayments/express": "^0.2.1",
         "@keyv/redis": "^5.1.5",
         "@live-state/sync": "catalog:",
@@ -217,10 +218,22 @@
         "tsx": "^4.19.3",
       },
     },
+    "connectors/framework": {
+      "name": "@connectors/framework",
+      "version": "0.0.0",
+      "dependencies": {
+        "zod": "catalog:",
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.2",
+        "typescript": "^5.7.0",
+      },
+    },
     "connectors/github": {
       "name": "github",
       "version": "0.0.0",
       "dependencies": {
+        "@connectors/framework": "workspace:*",
         "@live-state/sync": "catalog:",
         "@octokit/webhooks": "^14.0.0",
         "@workspace/schemas": "workspace:*",
@@ -675,6 +688,8 @@
     "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260103.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-kjMHGrnnZrOyQnXuJ8YpblKtjkv45o+utIYk4AZUoaUBbEltwn7CXucDa0MG0jsDDvCCwRabdaJSAXHV6JB/ZQ=="],
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260103.0", "", { "os": "win32", "cpu": "x64" }, "sha512-M7mZHV6uWVE+Mf8r/nT6/21N1+Z4JmZTPJjek3rB4n7netOJGZIUQwyuY+5gwOnq+qJsqHoU/RP7b4lFSoMZuQ=="],
+
+    "@connectors/framework": ["@connectors/framework@workspace:connectors/framework"],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -1870,7 +1885,7 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
-    "@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
+    "@types/node": ["@types/node@22.19.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA=="],
 
     "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
 
@@ -3730,7 +3745,7 @@
 
     "undici": ["undici@6.21.3", "", {}, "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="],
 
-    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
@@ -4540,9 +4555,17 @@
 
     "@slack/bolt/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
+    "@slack/logger/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
+
+    "@slack/oauth/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
+
+    "@slack/socket-mode/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
+
     "@slack/socket-mode/@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@slack/socket-mode/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
+    "@slack/web-api/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
 
     "@slack/web-api/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
@@ -4660,11 +4683,31 @@
 
     "@trigger.dev/sdk/ulid": ["ulid@2.4.0", "", { "bin": { "ulid": "bin/cli.js" } }, "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg=="],
 
+    "@types/body-parser/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
+
+    "@types/connect/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
+
+    "@types/cors/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
+
+    "@types/express-serve-static-core/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
+
+    "@types/jsonwebtoken/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
+
+    "@types/node-fetch/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
+
+    "@types/pg/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
+
+    "@types/send/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
+
+    "@types/serve-static/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
+
+    "@types/ws/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
+
     "@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "@wll8/express-ws/ws": ["ws@7.5.5", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w=="],
 
-    "@workspace/ui/@types/node": ["@types/node@22.19.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA=="],
+    "@workspace/emails/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
 
     "@workspace/ui/vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
 
@@ -4680,8 +4723,6 @@
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
-    "api/@types/node": ["@types/node@22.19.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA=="],
-
     "autoevals/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "better-auth/zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
@@ -4692,6 +4733,8 @@
 
     "bullmq/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
+    "bun-types/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
+
     "c12/confbox": ["confbox@0.2.2", "", {}, "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ=="],
 
     "c12/pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
@@ -4701,8 +4744,6 @@
     "cheerio/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "cheerio/undici": ["undici@7.14.0", "", {}, "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ=="],
-
-    "cli/@types/node": ["@types/node@22.19.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA=="],
 
     "cliui/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
@@ -4726,7 +4767,7 @@
 
     "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
 
-    "discord/@types/node": ["@types/node@22.19.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA=="],
+    "docs/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
 
     "docs/lucide-react": ["lucide-react@0.552.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-g9WCjmfwqbexSnZE+2cl21PCfXOcqnGeWeMTNAOGEfpPbm/ZF4YIq77Z8qWrxbu660EKuLB4nSLggoKnCb+isw=="],
 
@@ -4741,6 +4782,8 @@
     "elysia/file-type": ["file-type@21.3.0", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA=="],
 
     "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "engine.io/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
 
     "engine.io/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
@@ -4767,8 +4810,6 @@
     "fumadocs-ui/tailwind-merge": ["tailwind-merge@3.4.0", "", {}, "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g=="],
 
     "get-stream/is-stream": ["is-stream@4.0.1", "", {}, "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="],
-
-    "github/@types/node": ["@types/node@22.19.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA=="],
 
     "hast-util-raw/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
@@ -4838,6 +4879,8 @@
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
+    "protobufjs/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
+
     "raw-body/iconv-lite": ["iconv-lite@0.7.1", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw=="],
 
     "react-email/jiti": ["jiti@2.4.2", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A=="],
@@ -4872,8 +4915,6 @@
 
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
-    "svix/@types/node": ["@types/node@22.19.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA=="],
-
     "svix/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
@@ -4887,8 +4928,6 @@
     "vite-node/es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "vite-tsconfig-paths/tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
-
-    "web/@types/node": ["@types/node@22.19.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA=="],
 
     "web/@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
@@ -5348,6 +5387,8 @@
 
     "@aws-sdk/signature-v4-multi-region/@smithy/signature-v4/@smithy/util-utf8": ["@smithy/util-utf8@4.2.0", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw=="],
 
+    "@discordjs/ws/@types/ws/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
+
     "@dodopayments/express/express/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "@dodopayments/express/express/body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
@@ -5534,6 +5575,14 @@
 
     "@slack/bolt/express/type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
+    "@slack/logger/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@slack/oauth/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@slack/socket-mode/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@slack/web-api/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
     "@smithy/chunked-blob-reader-native/@smithy/util-base64/@smithy/util-buffer-from": ["@smithy/util-buffer-from@4.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew=="],
 
     "@smithy/chunked-blob-reader-native/@smithy/util-base64/@smithy/util-utf8": ["@smithy/util-utf8@4.2.0", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw=="],
@@ -5588,7 +5637,27 @@
 
     "@trigger.dev/core/socket.io/engine.io": ["engine.io@6.5.5", "", { "dependencies": { "@types/cookie": "^0.4.1", "@types/cors": "^2.8.12", "@types/node": ">=10.0.0", "accepts": "~1.3.4", "base64id": "2.0.0", "cookie": "~0.4.1", "cors": "~2.8.5", "debug": "~4.3.1", "engine.io-parser": "~5.2.1", "ws": "~8.17.1" } }, "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA=="],
 
-    "@workspace/ui/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "@types/body-parser/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/connect/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/cors/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/express-serve-static-core/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/jsonwebtoken/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/node-fetch/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/pg/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/send/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/serve-static/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/ws/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@workspace/emails/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@workspace/ui/vitest/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
@@ -5614,11 +5683,9 @@
 
     "ai/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
-    "api/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
-
     "body-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
-    "cli/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "cliui/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
@@ -5684,17 +5751,17 @@
 
     "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
-    "discord/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "docs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "elysia/file-type/strtok3": ["strtok3@10.3.4", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg=="],
+
+    "engine.io/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "express/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
-
-    "github/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "miniflare/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
 
@@ -5748,11 +5815,9 @@
 
     "ora/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "react-scan/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
-    "svix/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
 
@@ -5859,8 +5924,6 @@
     "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ=="],
 
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
-
-    "web/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "web/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
@@ -6072,6 +6135,8 @@
 
     "@aws-sdk/signature-v4-multi-region/@smithy/signature-v4/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@4.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew=="],
 
+    "@discordjs/ws/@types/ws/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
     "@dodopayments/express/express/body-parser/iconv-lite": ["iconv-lite@0.7.1", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw=="],
 
     "@dodopayments/express/express/type-is/media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
@@ -6123,6 +6188,8 @@
     "@smithy/core/@smithy/util-stream/@smithy/node-http-handler/@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.7", "", { "dependencies": { "@smithy/types": "^4.11.0", "@smithy/util-uri-escape": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-eKONSywHZxK4tBxe2lXEysh8wbBdvDWiA+RIuaxZSgCMmA0zMgoDpGLJhnyj+c0leOQprVnXOmcB4m+W9Rw7sg=="],
 
     "@tanstack/router-plugin/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "@trigger.dev/core/socket.io/engine.io/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
 
     "@trigger.dev/core/socket.io/engine.io/cookie": ["cookie@0.4.2", "", {}, "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="],
 
@@ -6239,6 +6306,8 @@
     "@smithy/core/@smithy/util-stream/@smithy/fetch-http-handler/@smithy/querystring-builder/@smithy/util-uri-escape": ["@smithy/util-uri-escape@4.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA=="],
 
     "@smithy/core/@smithy/util-stream/@smithy/node-http-handler/@smithy/querystring-builder/@smithy/util-uri-escape": ["@smithy/util-uri-escape@4.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA=="],
+
+    "@trigger.dev/core/socket.io/engine.io/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@aws-sdk/core/@smithy/smithy-client/@smithy/util-stream/@smithy/fetch-http-handler/@smithy/querystring-builder/@smithy/util-uri-escape": ["@smithy/util-uri-escape@4.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA=="],
 

--- a/connectors/framework/package.json
+++ b/connectors/framework/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@connectors/framework",
   "version": "0.0.0",
+  "private": true,
   "type": "module",
   "author": "front-desk",
   "exports": {

--- a/connectors/framework/package.json
+++ b/connectors/framework/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@connectors/framework",
+  "version": "0.0.0",
+  "type": "module",
+  "author": "front-desk",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "lint": "biome lint .",
+    "lint:fix": "biome lint --fix .",
+    "typecheck": "tsc --noEmit",
+    "format": "bun biome format ./src --fix"
+  },
+  "dependencies": {
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.2",
+    "typescript": "^5.7.0"
+  }
+}

--- a/connectors/framework/src/capabilities.ts
+++ b/connectors/framework/src/capabilities.ts
@@ -47,7 +47,11 @@ export type IssueTrackerCreatePayload = z.infer<
 export interface NormalizedIssue {
   /** Stable, provider-scoped external key (e.g. `github:owner/repo#123`). */
   id: string;
-  number: number;
+  /**
+   * Provider-local short reference, as a string so any tracker fits (GitHub
+   * `"123"`, Jira `"PROJ-123"`, Linear `"ENG-456"`).
+   */
+  shortId: string;
   title: string;
   body: string;
   state: string;

--- a/connectors/framework/src/capabilities.ts
+++ b/connectors/framework/src/capabilities.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+
+/**
+ * The capabilities a connector can provide. The FrontDesk core interacts with
+ * these generically and never references a named provider.
+ *
+ * Capabilities are asymmetric by call direction:
+ * - *Emitting* (connector → core): `support-entry-point`.
+ * - *Invoked* (core → connector): `issue-tracker`, `pr-tracker`,
+ *   `notification-center`.
+ *
+ * See `docs/adr/0008-connector-capability-framework.md`.
+ */
+export const CAPABILITIES = [
+  "support-entry-point",
+  "issue-tracker",
+  "pr-tracker",
+  "notification-center",
+] as const;
+
+export type Capability = (typeof CAPABILITIES)[number];
+
+export const isCapability = (value: string): value is Capability =>
+  (CAPABILITIES as readonly string[]).includes(value);
+
+/**
+ * `issue-tracker` capability — invoked method contracts.
+ *
+ * `create`: open a new issue on a target sub-resource. The `target` is an
+ * opaque, provider-interpreted sub-resource selector (e.g. a GitHub
+ * `{ owner, repo }`); core forwards it untouched.
+ */
+export const issueTrackerCreatePayloadSchema = z.object({
+  title: z.string().min(1),
+  body: z.string().default(""),
+  target: z.record(z.string(), z.unknown()),
+});
+
+export type IssueTrackerCreatePayload = z.infer<
+  typeof issueTrackerCreatePayloadSchema
+>;
+
+/**
+ * Normalized entity returned by an issue-tracker `create`. Provider-neutral:
+ * `id` is a stable external key, `label` a human-readable reference.
+ */
+export interface NormalizedIssue {
+  /** Stable, provider-scoped external key (e.g. `github:owner/repo#123`). */
+  id: string;
+  number: number;
+  title: string;
+  body: string;
+  state: string;
+  url: string;
+  /** Human-readable reference, e.g. `owner/repo#123`. */
+  label: string;
+}
+
+export interface IssueTrackerCreateResult {
+  entity: NormalizedIssue;
+}

--- a/connectors/framework/src/index.ts
+++ b/connectors/framework/src/index.ts
@@ -9,6 +9,8 @@ export {
 } from "./capabilities";
 export {
   CAPABILITY_INVOKE_PATH,
+  CAPABILITY_INVOKE_SECRET_HEADER,
+  CAPABILITY_INVOKE_TIMEOUT_MS,
   type InvokeEnvelope,
   invokeCapability,
   invokeEnvelopeSchema,

--- a/connectors/framework/src/index.ts
+++ b/connectors/framework/src/index.ts
@@ -1,0 +1,25 @@
+export {
+  CAPABILITIES,
+  type Capability,
+  type IssueTrackerCreatePayload,
+  type IssueTrackerCreateResult,
+  isCapability,
+  issueTrackerCreatePayloadSchema,
+  type NormalizedIssue,
+} from "./capabilities";
+export {
+  CAPABILITY_INVOKE_PATH,
+  type InvokeEnvelope,
+  invokeCapability,
+  invokeEnvelopeSchema,
+} from "./invoke";
+export {
+  type ConnectorManifest,
+  githubManifest,
+  manifests,
+} from "./manifest";
+export {
+  buildRegistry,
+  type ConnectorRegistry,
+  type RegistryEntry,
+} from "./registry";

--- a/connectors/framework/src/invoke.ts
+++ b/connectors/framework/src/invoke.ts
@@ -8,6 +8,13 @@ export const CAPABILITY_INVOKE_PATH = "/api/capabilities/invoke";
 export const CAPABILITY_INVOKE_TIMEOUT_MS = 10_000;
 
 /**
+ * Header carrying the shared internal secret on invoke requests. The connector
+ * host validates it so only the core (which holds the key) can dispatch
+ * capabilities. Same trust boundary as the connector→core bot key.
+ */
+export const CAPABILITY_INVOKE_SECRET_HEADER = "x-connector-secret";
+
+/**
  * The standardized invoke envelope. `config` is the integration's opaque
  * `configStr`, forwarded untouched — only the connector interprets it.
  */
@@ -30,16 +37,28 @@ export const invokeEnvelopeSchema = z.object({
  * POST a normalized envelope to a connector's invoke endpoint and return the
  * parsed JSON result. Throws on a non-2xx response, or on timeout after
  * {@link CAPABILITY_INVOKE_TIMEOUT_MS} so the caller fails fast.
+ *
+ * `secret` is the shared internal key, sent in
+ * {@link CAPABILITY_INVOKE_SECRET_HEADER} so the connector can authenticate the
+ * caller.
  */
 export async function invokeCapability<Result = unknown>(
   invokeUrl: string,
   envelope: InvokeEnvelope,
+  options: { secret?: string | null } = {},
 ): Promise<Result> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (options.secret) {
+    headers[CAPABILITY_INVOKE_SECRET_HEADER] = options.secret;
+  }
+
   let response: Response;
   try {
     response = await fetch(invokeUrl, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers,
       body: JSON.stringify(envelope),
       signal: AbortSignal.timeout(CAPABILITY_INVOKE_TIMEOUT_MS),
     });

--- a/connectors/framework/src/invoke.ts
+++ b/connectors/framework/src/invoke.ts
@@ -4,6 +4,9 @@ import type { Capability } from "./capabilities";
 /** Standardized HTTP path every connector host exposes for invoked capabilities. */
 export const CAPABILITY_INVOKE_PATH = "/api/capabilities/invoke";
 
+/** Bounded deadline for an invoke call so an unresponsive connector can't hang the caller. */
+export const CAPABILITY_INVOKE_TIMEOUT_MS = 10_000;
+
 /**
  * The standardized invoke envelope. `config` is the integration's opaque
  * `configStr`, forwarded untouched — only the connector interprets it.
@@ -25,17 +28,29 @@ export const invokeEnvelopeSchema = z.object({
 
 /**
  * POST a normalized envelope to a connector's invoke endpoint and return the
- * parsed JSON result. Throws on a non-2xx response.
+ * parsed JSON result. Throws on a non-2xx response, or on timeout after
+ * {@link CAPABILITY_INVOKE_TIMEOUT_MS} so the caller fails fast.
  */
 export async function invokeCapability<Result = unknown>(
   invokeUrl: string,
   envelope: InvokeEnvelope,
 ): Promise<Result> {
-  const response = await fetch(invokeUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(envelope),
-  });
+  let response: Response;
+  try {
+    response = await fetch(invokeUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(envelope),
+      signal: AbortSignal.timeout(CAPABILITY_INVOKE_TIMEOUT_MS),
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "TimeoutError") {
+      throw new Error(
+        `CAPABILITY_INVOKE_TIMEOUT: no response after ${CAPABILITY_INVOKE_TIMEOUT_MS}ms`,
+      );
+    }
+    throw error;
+  }
 
   if (!response.ok) {
     const detail = await response.text().catch(() => "");

--- a/connectors/framework/src/invoke.ts
+++ b/connectors/framework/src/invoke.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import type { Capability } from "./capabilities";
+
+/** Standardized HTTP path every connector host exposes for invoked capabilities. */
+export const CAPABILITY_INVOKE_PATH = "/api/capabilities/invoke";
+
+/**
+ * The standardized invoke envelope. `config` is the integration's opaque
+ * `configStr`, forwarded untouched — only the connector interprets it.
+ */
+export interface InvokeEnvelope<Payload = unknown> {
+  capability: Capability;
+  method: string;
+  config: string | null;
+  payload: Payload;
+}
+
+/** Runtime validator for the envelope, for connectors receiving invocations. */
+export const invokeEnvelopeSchema = z.object({
+  capability: z.string(),
+  method: z.string(),
+  config: z.string().nullable(),
+  payload: z.unknown(),
+});
+
+/**
+ * POST a normalized envelope to a connector's invoke endpoint and return the
+ * parsed JSON result. Throws on a non-2xx response.
+ */
+export async function invokeCapability<Result = unknown>(
+  invokeUrl: string,
+  envelope: InvokeEnvelope,
+): Promise<Result> {
+  const response = await fetch(invokeUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(envelope),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(
+      `CAPABILITY_INVOKE_FAILED: ${response.status} ${detail}`.trim(),
+    );
+  }
+
+  return (await response.json()) as Result;
+}

--- a/connectors/framework/src/manifest.ts
+++ b/connectors/framework/src/manifest.ts
@@ -1,0 +1,32 @@
+import type { Capability } from "./capabilities";
+
+/**
+ * A connector's static declaration. Ships with the connector and is the single
+ * source of truth the core builds its registry from at boot. The dynamic,
+ * per-org state (`enabled`, opaque `configStr`) lives on the `integration` row.
+ */
+export interface ConnectorManifest {
+  /** Matches the `integration` row's `type` (e.g. `"github"`). */
+  type: string;
+  /** Capabilities this connector provides. */
+  capabilities: Capability[];
+  /** Env var holding the connector host's base URL. */
+  baseUrlEnv: string;
+  /** Fallback base URL for local dev. */
+  defaultBaseUrl: string;
+}
+
+/**
+ * GitHub connector manifest. Declares `issue-tracker`; `pr-tracker` follows in
+ * FRO-193. Kept here (dependency-free) rather than in the connector app so the
+ * core can import it without pulling in octokit or creating a workspace cycle.
+ */
+export const githubManifest: ConnectorManifest = {
+  type: "github",
+  capabilities: ["issue-tracker"],
+  baseUrlEnv: "BASE_GITHUB_SERVER_URL",
+  defaultBaseUrl: "http://localhost:3334",
+};
+
+/** All known connector manifests. */
+export const manifests: ConnectorManifest[] = [githubManifest];

--- a/connectors/framework/src/registry.ts
+++ b/connectors/framework/src/registry.ts
@@ -40,7 +40,16 @@ export function buildRegistry(
   const entries = new Map<string, RegistryEntry>();
 
   for (const manifest of manifests) {
-    const baseUrl = env[manifest.baseUrlEnv] ?? manifest.defaultBaseUrl;
+    if (entries.has(manifest.type)) {
+      throw new Error(
+        `DUPLICATE_CONNECTOR_TYPE: ${manifest.type} is registered by more than one manifest`,
+      );
+    }
+
+    // Strip a trailing slash so env formatting can't alter the invoke path.
+    const baseUrl = (
+      env[manifest.baseUrlEnv] ?? manifest.defaultBaseUrl
+    ).replace(/\/+$/, "");
     entries.set(manifest.type, {
       manifest,
       baseUrl,

--- a/connectors/framework/src/registry.ts
+++ b/connectors/framework/src/registry.ts
@@ -1,0 +1,69 @@
+import type { Capability } from "./capabilities";
+import { CAPABILITY_INVOKE_PATH } from "./invoke";
+import {
+  type ConnectorManifest,
+  manifests as defaultManifests,
+} from "./manifest";
+
+/** A manifest with its resolved host location. */
+export interface RegistryEntry {
+  manifest: ConnectorManifest;
+  baseUrl: string;
+  /** Fully-resolved URL to POST invoke envelopes to. */
+  invokeUrl: string;
+}
+
+export interface ConnectorRegistry {
+  /** Look up the connector registered for an integration `type`. */
+  getByType(type: string): RegistryEntry | undefined;
+  /** Connectors that provide a given capability. */
+  providersOf(capability: Capability): RegistryEntry[];
+  /**
+   * Whether any of the org's enabled integration `types` provides `capability`.
+   * Answers "can we offer this?" — a specific invoked call still routes by a
+   * concrete target/integration.
+   */
+  hasCapability(
+    enabledTypes: Iterable<string>,
+    capability: Capability,
+  ): boolean;
+}
+
+/**
+ * Build the registry from connector manifests. Resolves each manifest's host
+ * location from `env` (falling back to its dev default) once, at boot.
+ */
+export function buildRegistry(
+  manifests: ConnectorManifest[] = defaultManifests,
+  env: Record<string, string | undefined> = process.env,
+): ConnectorRegistry {
+  const entries = new Map<string, RegistryEntry>();
+
+  for (const manifest of manifests) {
+    const baseUrl = env[manifest.baseUrlEnv] ?? manifest.defaultBaseUrl;
+    entries.set(manifest.type, {
+      manifest,
+      baseUrl,
+      invokeUrl: `${baseUrl}${CAPABILITY_INVOKE_PATH}`,
+    });
+  }
+
+  const providersOf = (capability: Capability): RegistryEntry[] =>
+    [...entries.values()].filter((entry) =>
+      entry.manifest.capabilities.includes(capability),
+    );
+
+  return {
+    getByType: (type) => entries.get(type),
+    providersOf,
+    hasCapability: (enabledTypes, capability) => {
+      const providerTypes = new Set(
+        providersOf(capability).map((entry) => entry.manifest.type),
+      );
+      for (const type of enabledTypes) {
+        if (providerTypes.has(type)) return true;
+      }
+      return false;
+    },
+  };
+}

--- a/connectors/framework/tsconfig.json
+++ b/connectors/framework/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "lib": ["es2022"],
+    "module": "preserve",
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "noUncheckedIndexedAccess": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["node"],
+    "verbatimModuleSyntax": true,
+    "baseUrl": "."
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/connectors/framework/tsconfig.json
+++ b/connectors/framework/tsconfig.json
@@ -7,6 +7,7 @@
     "module": "preserve",
     "moduleDetection": "force",
     "moduleResolution": "bundler",
+    "noUnusedLocals": true,
     "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,

--- a/connectors/github/package.json
+++ b/connectors/github/package.json
@@ -27,6 +27,7 @@
     "node": ">=20.18.0"
   },
   "dependencies": {
+    "@connectors/framework": "workspace:*",
     "@live-state/sync": "catalog:",
     "@octokit/webhooks": "^14.0.0",
     "@workspace/schemas": "workspace:*",

--- a/connectors/github/src/index.ts
+++ b/connectors/github/src/index.ts
@@ -3,7 +3,12 @@ import "./env";
 import { startBackfillWorker } from "./jobs/backfill";
 import { startReconcileWorker } from "./jobs/reconcile";
 import { app as githubApp } from "./lib/github";
-import { issuesRoutes, pullRequestsRoutes, setupRoutes } from "./routes";
+import {
+  capabilitiesRoutes,
+  issuesRoutes,
+  pullRequestsRoutes,
+  setupRoutes,
+} from "./routes";
 import { getPort } from "./utils";
 import { setupWebhooks } from "./webhooks";
 
@@ -12,6 +17,7 @@ startBackfillWorker();
 startReconcileWorker();
 
 const app = new Elysia()
+  .use(capabilitiesRoutes)
   .use(issuesRoutes)
   .use(pullRequestsRoutes)
   .use(setupRoutes)

--- a/connectors/github/src/routes/capabilities.ts
+++ b/connectors/github/src/routes/capabilities.ts
@@ -1,0 +1,127 @@
+import {
+  CAPABILITY_INVOKE_PATH,
+  invokeEnvelopeSchema,
+} from "@connectors/framework";
+import { formatGitHubId } from "@workspace/schemas/external-issue";
+import Elysia from "elysia";
+import { z } from "zod";
+import { createIssue } from "../lib/github";
+
+/**
+ * GitHub's opaque config, interpreted here — the core forwards `configStr`
+ * untouched and never parses `installationId`/`repos`.
+ */
+const githubConfigSchema = z.object({
+  installationId: z.coerce.number().int().positive(),
+  repos: z.array(
+    z.object({
+      owner: z.string(),
+      name: z.string(),
+      fullName: z.string(),
+    }),
+  ),
+});
+
+/** Opaque sub-resource selector for issue-tracker `create`, GitHub-shaped. */
+const createIssueTargetSchema = z.object({
+  owner: z.string().min(1),
+  repo: z.string().min(1),
+});
+
+const createIssuePayloadSchema = z.object({
+  title: z.string().min(1),
+  body: z.string().default(""),
+  target: createIssueTargetSchema,
+});
+
+/**
+ * Standardized capability-invocation endpoint. Dispatches on
+ * `{ capability, method }`; currently wraps octokit issue creation behind the
+ * `issue-tracker` / `create` contract.
+ */
+export const capabilitiesRoutes = new Elysia().post(
+  CAPABILITY_INVOKE_PATH,
+  async ({ body: requestBody, set }) => {
+    const envelope = invokeEnvelopeSchema.safeParse(requestBody);
+    if (!envelope.success) {
+      set.status = 400;
+      return {
+        error: envelope.error.issues[0]?.message ?? "Invalid invoke envelope",
+      };
+    }
+
+    const { capability, method, config, payload } = envelope.data;
+
+    if (capability !== "issue-tracker" || method !== "create") {
+      set.status = 404;
+      return {
+        error: `Unsupported capability/method: ${capability}/${method}`,
+      };
+    }
+
+    if (!config) {
+      set.status = 400;
+      return { error: "MISSING_CONFIG" };
+    }
+
+    let rawConfig: unknown;
+    try {
+      rawConfig = JSON.parse(config);
+    } catch {
+      set.status = 400;
+      return { error: "INVALID_CONFIG" };
+    }
+
+    const parsedConfig = githubConfigSchema.safeParse(rawConfig);
+    if (!parsedConfig.success) {
+      set.status = 400;
+      return { error: "INVALID_CONFIG" };
+    }
+
+    const parsedPayload = createIssuePayloadSchema.safeParse(payload);
+    if (!parsedPayload.success) {
+      set.status = 400;
+      return {
+        error: parsedPayload.error.issues[0]?.message ?? "Invalid payload",
+      };
+    }
+
+    const { installationId, repos } = parsedConfig.data;
+    const { title, body, target } = parsedPayload.data;
+
+    const repo = repos.find(
+      (r) => r.owner === target.owner && r.name === target.repo,
+    );
+    if (!repo) {
+      set.status = 400;
+      return { error: "REPOSITORY_NOT_CONNECTED" };
+    }
+
+    try {
+      const issue = await createIssue(
+        installationId,
+        target.owner,
+        target.repo,
+        title,
+        body,
+      );
+
+      set.status = 201;
+      return {
+        entity: {
+          id: formatGitHubId(issue.id, target.owner, target.repo),
+          number: issue.number,
+          title: issue.title,
+          body: issue.body ?? "",
+          state: issue.state,
+          url: issue.html_url,
+          label: `${target.owner}/${target.repo}#${issue.number}`,
+        },
+      };
+    } catch (error) {
+      console.error("Error creating issue:", error);
+      set.status = 500;
+      return { error: "Failed to create issue" };
+    }
+  },
+);

--- a/connectors/github/src/routes/capabilities.ts
+++ b/connectors/github/src/routes/capabilities.ts
@@ -1,5 +1,6 @@
 import {
   CAPABILITY_INVOKE_PATH,
+  CAPABILITY_INVOKE_SECRET_HEADER,
   invokeEnvelopeSchema,
 } from "@connectors/framework";
 import { formatGitHubId } from "@workspace/schemas/external-issue";
@@ -41,7 +42,18 @@ const createIssuePayloadSchema = z.object({
  */
 export const capabilitiesRoutes = new Elysia().post(
   CAPABILITY_INVOKE_PATH,
-  async ({ body: requestBody, set }) => {
+  async ({ body: requestBody, headers, set }) => {
+    // Only the core holds the shared secret; reject anyone else who can reach
+    // this host. Fails closed when the secret isn't configured.
+    const expectedSecret = process.env.DISCORD_BOT_KEY;
+    if (
+      !expectedSecret ||
+      headers[CAPABILITY_INVOKE_SECRET_HEADER] !== expectedSecret
+    ) {
+      set.status = 401;
+      return { error: "UNAUTHORIZED" };
+    }
+
     const envelope = invokeEnvelopeSchema.safeParse(requestBody);
     if (!envelope.success) {
       set.status = 400;

--- a/connectors/github/src/routes/capabilities.ts
+++ b/connectors/github/src/routes/capabilities.ts
@@ -122,7 +122,7 @@ export const capabilitiesRoutes = new Elysia().post(
       return {
         entity: {
           id: formatGitHubId(issue.id, target.owner, target.repo),
-          number: issue.number,
+          shortId: String(issue.number),
           title: issue.title,
           body: issue.body ?? "",
           state: issue.state,

--- a/connectors/github/src/routes/index.ts
+++ b/connectors/github/src/routes/index.ts
@@ -1,3 +1,4 @@
+export { capabilitiesRoutes } from "./capabilities";
 export { issuesRoutes } from "./issues";
 export { pullRequestsRoutes } from "./pull-requests";
 export { setupRoutes } from "./setup";

--- a/docs/adr/0008-connector-capability-framework.md
+++ b/docs/adr/0008-connector-capability-framework.md
@@ -1,0 +1,39 @@
+# Connector/capability framework for integrations
+
+We are replacing the pattern of one bespoke, provider-named integration app per external system with a **connector/capability framework**: a connector is reusable provider code that statically **declares the capabilities it provides**, and the FrontDesk core interacts with those capabilities generically — it never references a named provider. The four planned capabilities are `support-entry-point`, `issue-tracker`, `pr-tracker`, and `notification-center`; a connector may provide any number of them (GitHub = issue-tracker + pr-tracker; Slack = support-entry-point + notification-center; Discord = support-entry-point only). This dissolves the current coupling where the API hardcodes `type:"github"` orchestration (e.g. `thread.createGithubIssue`) and the connector app is a dumb HTTP proxy.
+
+See [`CONTEXT.md`](../../CONTEXT.md) for the `Connector` / `Capability` / `Integration` glossary terms.
+
+## Status
+
+accepted
+
+## Decisions
+
+- **Capabilities are asymmetric by call direction; every capability has two legs, and they differ only in which leg *defines* it and what the routing key is.**
+  - *Emitting* leg (connector → core): the connector pushes normalized data in through a framework-owned ingest API. This defines `support-entry-point`.
+  - *Invoked* leg (core → connector): the core calls a declared, typed method interface. This defines `issue-tracker`, `pr-tracker`, `notification-center`.
+  - Example of the two legs on one capability: `support-entry-point` emits inbound messages *and* is invoked to deliver replies/status back to the thread's origin; `issue-tracker` is invoked to create/close/link *and* keeps its targets fresh via an inbound webhook→mirror.
+
+- **Capability is not the routing key; the target is.** `hasCapability(org, cap)` and enumeration answer "can we offer this / what targets exist"; a specific invoked call always carries a concrete `integrationId` (or an entity ref that resolves to one). Acting on an existing entity routes via the mirrored entity's owning integration; creating a new entity routes via the chosen sub-resource (a repo belongs to exactly one installation). This is why a capability being one-to-many per org is not ambiguous.
+
+- **Where target-based routing doesn't apply, the org designates a primary integration per capability**, stored in `organization.settings.capabilityPrimary` (org-settings JSON, per the standing preference over config tables). `notification-center` has a single configured target that handles all notifications (no fan-out). Agent-initiated entity *creation* falls back to the primary issue/pr-tracker; humans still pick any target freely.
+
+- **The framework owns normalization.** A high-level ingest API (`ingest({ origin, externalThreadId, externalMessageId, author, body, isBackfill, … })`) owns thread upsert, author identity, origin tracking, dedup, and backfill semantics. A new support-entry-point connector shrinks to "translate provider event ↔ normalized shape" — this is the primary DX win. The outbound mirror of this is a normalized `deliver` interface the framework calls on the origin connector.
+
+- **The mirror is framework substrate, not a capability.** The webhook→`externalEntity` upsert (ADR 0007) is provider-private inbound ingestion that both tracker capabilities rely on to keep their targets fresh.
+
+- **Static declaration, dynamic installation.** A connector ships a static **manifest** (`type`, capabilities, host location) from which the core builds a registry at boot. The `integration` row stays dynamic per-org state: `type` + `enabled` + **opaque** `configStr` (the core forwards config untouched; only the connector interprets it).
+
+## Considered options
+
+- **Uniform capability interface (rejected).** Forcing a single call direction breaks down because `support-entry-point` is inbound-dominant (connector pushes threads in) while the others are outbound-invoked. We embrace the asymmetry instead.
+- **Process model — hybrid host + standalone escape hatch (chosen).** A shared connector-host app loads simple connectors as modules (GitHub, future Linear: declare capabilities + method handlers + webhook routes); connectors needing a bespoke long-lived runtime (Discord gateway, Slack bolt) run standalone but implement the same contracts. Rejected: collapsing *everything* into one process (the persistent gateway + bolt + webhooks sharing one blast radius); and keeping N fully standalone apps (no reduction in per-connector ceremony).
+- **Invocation transport — standardized HTTP surface (chosen).** Generalizes the status quo (the API already `fetch`es the GitHub app). Rejected: in-process imports (drags `octokit`/`discord.js` into API/worker) and queues (async, wrong for "create issue and return its id").
+- **Control plane stays provider-specific (explicit non-goal).** Connect/install/OAuth (GitHub App install, Slack OAuth, Discord invite) and config forms are irreducibly provider-specific and out of scope. "Opaque to core dispatch" ≠ "opaque to the settings UI" — the web settings surface stays provider-aware (e.g. GitHub repo picker) exactly as today. A declarative config-schema for generic form rendering is a possible later nicety, never a generic OAuth flow.
+
+## Consequences
+
+- Connector apps move out of `apps/` into a top-level **`connectors/`** root (host, standalone connectors, and the shared framework package); the Bun/Turbo workspace globs gain `connectors/*`.
+- The API's hardcoded provider procedures (`thread.createGithubIssue` and siblings) collapse into a single generic capability-dispatch path.
+- **Rollout: retrofit GitHub first.** GitHub proves invoked capabilities + mirror substrate + routing-by-target + the `type:"github"` collapse without touching the two ~1000-line emitting-heavy gateway apps. Discord/Slack migrate later, once the ingest contract is proven against real code.


### PR DESCRIPTION
Implements [FRO-192](https://linear.app/front-desk/issue/FRO-192). The core tracer bullet for the connector/capability framework ([FRO-190](https://linear.app/front-desk/issue/FRO-190)): route GitHub issue creation through generic capability-dispatch with **zero `type:"github"` in the API path**.

## What changed

**New `@connectors/framework` package** (`connectors/framework`)
- `capabilities.ts` — `Capability` union + the `issue-tracker`/`create` contract (`NormalizedIssue`, payload schema).
- `manifest.ts` — `ConnectorManifest` type + `githubManifest` (declares `type`, capabilities, host location). Kept dependency-free so core imports it without a workspace cycle.
- `registry.ts` — `buildRegistry()` resolves host URLs at boot; `getByType` / `providersOf` / `hasCapability`.
- `invoke.ts` — the standardized envelope `{ capability, method, config, payload }` + `invokeCapability()` HTTP client.

**GitHub connector**
- New `POST /api/capabilities/invoke` route: validates the envelope, **parses its own opaque config** (`installationId`/`repos`), verifies the repo is connected, wraps existing octokit `createIssue`, returns a normalized entity.

**API core**
- `lib/connector-registry.ts` — builds the registry at boot; `orgHasCapability()` resolves from the org's enabled integrations via the registry.
- `thread.createGithubIssue` → generic `thread.createIssue`: resolves the issue-tracker provider via the registry, forwards `configStr` **untouched**, POSTs the envelope, records the provider-neutral `issue_created` activity.

**Web** — `issues.tsx` calls `createIssue({ target: { owner, repo } })`; `updates.tsx` renders `issue_created` (legacy `github_issue_created` rows still render).

**Docs** — CONTEXT.md Connector/Capability/Integration glossary + ADR 0008.

## Acceptance criteria
- [x] `connectors/framework` exports capability types, manifest, registry, HTTP invoke contract
- [x] Core builds the registry at boot from connector manifests
- [x] Creating an issue from a thread works end-to-end via generic dispatch
- [x] No provider name (`"github"`) appears in the API dispatch procedure
- [x] The API no longer parses `configStr`; the connector interprets its own config
- [x] `hasCapability(org, "issue-tracker")` resolves from enabled integrations via the registry

## Out of scope
`external-entity.ts` still interprets GitHub config for the link/mirror substrate path — that's FRO-193, not the issue-creation dispatch this collapses.

## Verification
Full repo typecheck passes (11/11 packages); lint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds a generic connector/capability framework and routes GitHub issue creation through it so the API never references a provider by name. Implements FRO-192; adds shared-secret auth on capability invokes and switches the issue result to a provider‑neutral `shortId`.

- **New Features**
  - Added `@connectors/framework`: capability types, connector manifest, boot-time registry, and the standardized invoke envelope `{ capability, method, config, payload }`.
  - GitHub connector exposes `POST /api/capabilities/invoke`, parses its own config (`installationId`/`repos`), verifies the repo, creates the issue, and returns a normalized entity with `shortId`.
  - API resolves the `issue-tracker` provider via the registry and forwards `configStr` untouched with `thread.createIssue`; records provider-neutral `issue_created`.
  - Web calls `createIssue({ target: { owner, repo } })`, expects `issue.shortId`, and parses it for the GitHub optimistic chip; updates render `issue_created` (legacy `github_issue_created` rows still render).
  - Authenticate capability invokes with a shared secret: framework sends `x-connector-secret` from `DISCORD_BOT_KEY`, API passes it, GitHub validates and fails closed.
  - Docs add ADR 0008 and glossary updates.

- **Bug Fixes**
  - Bounded `invokeCapability` with a timeout to prevent hanging requests.
  - Registry now errors on duplicate connector `type` and normalizes base URLs.
  - Restored `configStr` null guard (ISSUE_TRACKER_NOT_CONFIGURED) and preserved `userName` in `issue_created` metadata.
  - Marked `@connectors/framework` private and enabled `noUnusedLocals`.

<sup>Written for commit 8dda20ff38705c63ca6802750d4c03f7665959e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider-neutral issue creation through connected issue-tracking integrations.
  * Enabled invocation via a standardized capability framework, with shared connector invocation authentication.
  * Added support for selecting a specific connected integration when creating an issue.
* **Bug Fixes**
  * Improved validation for connector invocation requests and referenced repositories; errors now surface more reliably.
* **Documentation**
  * Expanded the connector/capability/integration glossary and published the connector capability framework ADR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->