### PR TITLE
feat(connectors,api): GitHub pr-tracker capability + close/link through dispatch (FRO-193)

### DIFF
--- a/apps/api/src/lib/capability-dispatch.ts
+++ b/apps/api/src/lib/capability-dispatch.ts
@@ -1,0 +1,101 @@
+import {
+  type Capability,
+  type CapabilityEntityRef,
+  invokeCapability,
+} from "@connectors/framework";
+import type { InferLiveObject } from "@live-state/sync";
+import type { ServerDB } from "@live-state/sync/server";
+import { schema } from "../live-state/schema";
+import { connectorInvokeSecret, connectorRegistry } from "./connector-registry";
+
+type ExternalEntityRow = InferLiveObject<typeof schema.externalEntity>;
+
+/** Provider-neutral reference the connector acts on, straight from the mirror. */
+export const buildEntityRef = (
+  entity: ExternalEntityRow,
+): CapabilityEntityRef => ({
+  externalKey: entity.externalKey,
+  repoFullName: entity.repoFullName,
+  number: entity.number,
+  url: entity.url,
+});
+
+/**
+ * Resolve the enabled integration that owns a mirrored `entity` and provides
+ * `capability`. Routes purely by the entity's own `provider` matched against the
+ * integration `type` — no provider-name literal and no capability-level
+ * selection: the target *is* the entity. Returns the integration and its
+ * registry entry, or `null` when the org has no matching configured integration
+ * whose connector provides the capability.
+ */
+export const resolveEntityCapabilityTarget = async (
+  db: Pick<ServerDB<typeof schema>, "find">,
+  organizationId: string,
+  entity: Pick<ExternalEntityRow, "provider">,
+  capability: Capability,
+) => {
+  const integrations = Object.values(
+    await db.find(schema.integration, {
+      where: { organizationId, enabled: true },
+    }),
+  );
+
+  const integration = integrations.find((i) => i.type === entity.provider);
+  if (!integration?.configStr) return null;
+
+  const entry = connectorRegistry.getByType(integration.type);
+  if (!entry?.manifest.capabilities.includes(capability)) return null;
+
+  return { integration, entry };
+};
+
+/**
+ * Push a thread's closed/open state onto its linked external issue, routed by
+ * the mirrored issue's owning integration. Best-effort: a connector failure is
+ * logged and swallowed so it never blocks the thread status change. A no-op when
+ * the issue isn't mirrored, is already in the desired state, or the org has no
+ * issue-tracker integration for the entity's provider.
+ */
+export const syncLinkedIssueState = async (
+  db: Pick<ServerDB<typeof schema>, "find">,
+  args: { organizationId: string; externalIssueId: string; closed: boolean },
+): Promise<void> => {
+  try {
+    const entity = Object.values(
+      await db.find(schema.externalEntity, {
+        where: {
+          organizationId: args.organizationId,
+          externalKey: args.externalIssueId,
+          type: "issue",
+          deletedAt: null,
+        },
+      }),
+    )[0];
+    if (!entity) return;
+
+    const state = args.closed ? "closed" : "open";
+    // Mirror already reflects the desired state — nothing to push.
+    if (entity.state === state) return;
+
+    const target = await resolveEntityCapabilityTarget(
+      db,
+      args.organizationId,
+      entity,
+      "issue-tracker",
+    );
+    if (!target) return;
+
+    await invokeCapability(
+      target.entry.invokeUrl,
+      {
+        capability: "issue-tracker",
+        method: "setState",
+        config: target.integration.configStr,
+        payload: { entity: buildEntityRef(entity), state },
+      },
+      { secret: connectorInvokeSecret },
+    );
+  } catch (error) {
+    console.error("Failed to sync linked issue state:", error);
+  }
+};

--- a/apps/api/src/lib/signals/handlers/link-pr.ts
+++ b/apps/api/src/lib/signals/handlers/link-pr.ts
@@ -1,8 +1,93 @@
+import { invokeCapability } from "@connectors/framework";
 import type { LinkPrAction } from "@workspace/schemas/signals";
+import { schema } from "../../../live-state/schema";
+import {
+  buildEntityRef,
+  resolveEntityCapabilityTarget,
+} from "../../capability-dispatch";
+import { connectorInvokeSecret } from "../../connector-registry";
+import { runRecordActivity } from "../../update-mutations";
 import type { ActionHandler } from "../types";
 
 export const linkPrHandler: ActionHandler<LinkPrAction> = {
-  async apply() {
-    throw new Error("LINK_PR_DEFERRED");
+  async apply(action, ctx) {
+    const thread = await ctx.db.thread.one(ctx.threadId).get();
+    if (!thread || thread.organizationId !== ctx.organizationId) {
+      throw new Error("THREAD_NOT_FOUND");
+    }
+
+    // The PR must already be mirrored — that mirrored entity is what routes the
+    // dispatch to its owning integration (routing-by-target). We match on the
+    // canonical URL the action carries; core never parses the provider's URL.
+    const entity = Object.values(
+      await ctx.db.find(schema.externalEntity, {
+        where: {
+          organizationId: ctx.organizationId,
+          url: action.prUrl,
+          type: "pull_request",
+          deletedAt: null,
+        },
+      }),
+    )[0];
+    if (!entity) {
+      throw new Error("LINK_PR_ENTITY_NOT_MIRRORED");
+    }
+
+    const target = await resolveEntityCapabilityTarget(
+      ctx.db,
+      ctx.organizationId,
+      entity,
+      "pr-tracker",
+    );
+    if (!target) {
+      throw new Error("PR_TRACKER_NOT_CONFIGURED");
+    }
+
+    const organization = Object.values(
+      await ctx.db.find(schema.organization, {
+        where: { id: ctx.organizationId },
+      }),
+    )[0];
+    if (!organization) {
+      throw new Error("ORGANIZATION_NOT_FOUND");
+    }
+
+    const threadUrl = `https://${organization.slug}.tryfrontdesk.app/threads/${ctx.threadId}`;
+
+    // Post the back-reference on the PR before recording the link locally, so a
+    // failed comment doesn't leave a link with no trace on the external side.
+    await invokeCapability(
+      target.entry.invokeUrl,
+      {
+        capability: "pr-tracker",
+        method: "link",
+        config: target.integration.configStr,
+        payload: {
+          entity: buildEntityRef(entity),
+          thread: { url: threadUrl, title: thread.name },
+        },
+      },
+      { secret: connectorInvokeSecret },
+    );
+
+    const oldPrId = thread.externalPrId ?? null;
+    await ctx.db.thread.update(ctx.threadId, {
+      externalPrId: entity.externalKey,
+    });
+
+    const newPrLabel = `${entity.repoFullName}#${entity.number}`;
+    await runRecordActivity(ctx.db, {
+      threadId: ctx.threadId,
+      organizationId: ctx.organizationId,
+      userId: ctx.actorUserId,
+      userName: ctx.actorUserName,
+      type: "pr_changed",
+      metadata: {
+        oldPrId,
+        newPrId: entity.externalKey,
+        oldPrLabel: null,
+        newPrLabel,
+      },
+    });
   },
 };

--- a/apps/api/src/lib/signals/handlers/link-pr.ts
+++ b/apps/api/src/lib/signals/handlers/link-pr.ts
@@ -11,8 +11,10 @@ import type { ActionHandler } from "../types";
 
 export const linkPrHandler: ActionHandler<LinkPrAction> = {
   async apply(action, ctx) {
-    const thread = await ctx.db.thread.one(ctx.threadId).get();
-    if (!thread || thread.organizationId !== ctx.organizationId) {
+    const thread = await ctx.db.thread
+      .first({ id: ctx.threadId, organizationId: ctx.organizationId })
+      .get();
+    if (!thread) {
       throw new Error("THREAD_NOT_FOUND");
     }
 
@@ -31,6 +33,12 @@ export const linkPrHandler: ActionHandler<LinkPrAction> = {
     )[0];
     if (!entity) {
       throw new Error("LINK_PR_ENTITY_NOT_MIRRORED");
+    }
+
+    // Already linked to this PR — no-op, mirroring the manual link mutation.
+    // Guards a retry/replay from re-posting the back-reference comment.
+    if (thread.externalPrId === entity.externalKey) {
+      return;
     }
 
     const target = await resolveEntityCapabilityTarget(

--- a/apps/api/src/lib/signals/types.ts
+++ b/apps/api/src/lib/signals/types.ts
@@ -12,6 +12,9 @@ export type SignalExecutionDb = Pick<
   | "autonomousAction"
   | "insert"
   | "transaction"
+  // `find` backs capability dispatch: resolving a linked/mirrored external
+  // entity's owning integration (issue-state sync, PR link).
+  | "find"
 >;
 
 export type ExecutionContext = {

--- a/apps/api/src/lib/thread-mutations.ts
+++ b/apps/api/src/lib/thread-mutations.ts
@@ -4,6 +4,7 @@ import { PRIORITY_LABELS, threadReadSchema } from "@workspace/schemas/signals";
 import { addDays } from "date-fns";
 import { z } from "zod";
 import { schema } from "../live-state/schema";
+import { syncLinkedIssueState } from "./capability-dispatch";
 import { statusActivityMetadata } from "./signals/activity";
 import { runRecordActivity } from "./update-mutations";
 
@@ -66,6 +67,7 @@ export const unlinkPullRequestInputSchema = z.object({
   userName: z.string().optional(),
 });
 
+export const STATUS_CLOSED = 3;
 export const STATUS_DUPLICATED = 4;
 
 export const markDuplicateInputSchema = z.object({
@@ -169,7 +171,7 @@ const resolveAssignedUserName = async (
 type ThreadRow = InferLiveObject<typeof schema.thread>;
 
 export const runSetThreadStatus = async (
-  db: ThreadWriteDb,
+  db: ThreadWriteDb & Pick<ServerDB<typeof schema>, "find">,
   input: z.infer<typeof setStatusInputSchema>,
   actor: {
     userId: string | null;
@@ -193,6 +195,19 @@ export const runSetThreadStatus = async (
   }
 
   await db.thread.update(input.threadId, { status: input.status });
+
+  // Keep a linked external issue in sync with the thread's closed state. Only
+  // fires when the thread crosses the closed boundary; routed by the linked
+  // issue's owning integration (best-effort, never blocks the status change).
+  const wasClosed = oldStatus === STATUS_CLOSED;
+  const isClosed = input.status === STATUS_CLOSED;
+  if (thread.externalIssueId && wasClosed !== isClosed) {
+    await syncLinkedIssueState(db, {
+      organizationId: input.organizationId,
+      externalIssueId: thread.externalIssueId,
+      closed: isClosed,
+    });
+  }
 
   const shouldRecordActivity =
     actor.userId !== null || options?.recordActivity === true;

--- a/apps/api/src/lib/thread-mutations.ts
+++ b/apps/api/src/lib/thread-mutations.ts
@@ -199,8 +199,9 @@ export const runSetThreadStatus = async (
   // Keep a linked external issue in sync with the thread's closed state. Only
   // fires when the thread crosses the closed boundary; routed by the linked
   // issue's owning integration (best-effort, never blocks the status change).
-  const wasClosed = oldStatus === STATUS_CLOSED;
-  const isClosed = input.status === STATUS_CLOSED;
+  // Statuses at or beyond `closed` (e.g. `duplicated`) count as closed.
+  const wasClosed = oldStatus >= STATUS_CLOSED;
+  const isClosed = input.status >= STATUS_CLOSED;
   if (thread.externalIssueId && wasClosed !== isClosed) {
     await syncLinkedIssueState(db, {
       organizationId: input.organizationId,

--- a/connectors/framework/src/capabilities.ts
+++ b/connectors/framework/src/capabilities.ts
@@ -63,3 +63,53 @@ export interface NormalizedIssue {
 export interface IssueTrackerCreateResult {
   entity: NormalizedIssue;
 }
+
+/**
+ * Provider-neutral reference to an already-mirrored external entity that the
+ * core hands a connector so it can act on it (close it, comment on it). Core
+ * fills these straight from the `externalEntity` mirror row; only the connector
+ * interprets them (e.g. GitHub resolves `repoFullName` + `number` against its
+ * configured repos). The core never parses them or names a provider.
+ */
+export const capabilityEntityRefSchema = z.object({
+  /** Provider-agnostic key: `provider:owner/repo#id` (see formatGitHubId). */
+  externalKey: z.string().min(1),
+  /** Repository the entity lives in, e.g. `owner/repo`. */
+  repoFullName: z.string().min(1),
+  /** Provider-local entity number (issue/PR number). */
+  number: z.number().int(),
+  /** Canonical external URL of the entity. */
+  url: z.string(),
+});
+
+export type CapabilityEntityRef = z.infer<typeof capabilityEntityRefSchema>;
+
+/**
+ * `issue-tracker` `setState` — push an open/closed state onto an existing issue,
+ * keeping the external issue in sync with its linked thread's status. Routed by
+ * the mirrored entity's owning integration; there is no provider selection.
+ */
+export const issueTrackerSetStatePayloadSchema = z.object({
+  entity: capabilityEntityRefSchema,
+  state: z.enum(["open", "closed"]),
+});
+
+export type IssueTrackerSetStatePayload = z.infer<
+  typeof issueTrackerSetStatePayloadSchema
+>;
+
+/**
+ * `pr-tracker` `link` — record a back-reference from an existing pull request to
+ * the FrontDesk thread it was linked to (a cross-link comment). The connector
+ * composes the provider-native comment from the neutral `thread` fields.
+ */
+export const prTrackerLinkPayloadSchema = z.object({
+  entity: capabilityEntityRefSchema,
+  thread: z.object({
+    /** Portal URL of the linked thread, for the back-reference. */
+    url: z.string(),
+    title: z.string().default(""),
+  }),
+});
+
+export type PrTrackerLinkPayload = z.infer<typeof prTrackerLinkPayloadSchema>;

--- a/connectors/framework/src/capabilities.ts
+++ b/connectors/framework/src/capabilities.ts
@@ -76,8 +76,8 @@ export const capabilityEntityRefSchema = z.object({
   externalKey: z.string().min(1),
   /** Repository the entity lives in, e.g. `owner/repo`. */
   repoFullName: z.string().min(1),
-  /** Provider-local entity number (issue/PR number). */
-  number: z.number().int(),
+  /** Provider-local entity number (issue/PR number); always ≥ 1. */
+  number: z.number().int().positive(),
   /** Canonical external URL of the entity. */
   url: z.string(),
 });

--- a/connectors/framework/src/index.ts
+++ b/connectors/framework/src/index.ts
@@ -1,11 +1,17 @@
 export {
   CAPABILITIES,
   type Capability,
+  type CapabilityEntityRef,
+  capabilityEntityRefSchema,
   type IssueTrackerCreatePayload,
   type IssueTrackerCreateResult,
+  type IssueTrackerSetStatePayload,
   isCapability,
   issueTrackerCreatePayloadSchema,
+  issueTrackerSetStatePayloadSchema,
   type NormalizedIssue,
+  type PrTrackerLinkPayload,
+  prTrackerLinkPayloadSchema,
 } from "./capabilities";
 export {
   CAPABILITY_INVOKE_PATH,

--- a/connectors/framework/src/manifest.ts
+++ b/connectors/framework/src/manifest.ts
@@ -17,13 +17,13 @@ export interface ConnectorManifest {
 }
 
 /**
- * GitHub connector manifest. Declares `issue-tracker`; `pr-tracker` follows in
- * FRO-193. Kept here (dependency-free) rather than in the connector app so the
- * core can import it without pulling in octokit or creating a workspace cycle.
+ * GitHub connector manifest. Declares both `issue-tracker` and `pr-tracker`.
+ * Kept here (dependency-free) rather than in the connector app so the core can
+ * import it without pulling in octokit or creating a workspace cycle.
  */
 export const githubManifest: ConnectorManifest = {
   type: "github",
-  capabilities: ["issue-tracker"],
+  capabilities: ["issue-tracker", "pr-tracker"],
   baseUrlEnv: "BASE_GITHUB_SERVER_URL",
   defaultBaseUrl: "http://localhost:3334",
 };

--- a/connectors/github/src/lib/github.ts
+++ b/connectors/github/src/lib/github.ts
@@ -70,6 +70,66 @@ export const createIssue = async (
   }
 };
 
+export const setIssueState = async (
+  installationId: number,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  state: "open" | "closed"
+) => {
+  try {
+    const octokit = await getOctokit(installationId);
+    const { data } = await octokit.request(
+      "PATCH /repos/{owner}/{repo}/issues/{issue_number}",
+      {
+        owner,
+        repo,
+        issue_number: issueNumber,
+        state,
+        headers: {
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      }
+    );
+    return data;
+  } catch (error) {
+    console.error(`Error setting issue state:`, error);
+    throw error;
+  }
+};
+
+/**
+ * Post a comment on an issue or pull request. GitHub models PR comments through
+ * the issues comments endpoint, so this covers both.
+ */
+export const addComment = async (
+  installationId: number,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  body: string
+) => {
+  try {
+    const octokit = await getOctokit(installationId);
+    const { data } = await octokit.request(
+      "POST /repos/{owner}/{repo}/issues/{issue_number}/comments",
+      {
+        owner,
+        repo,
+        issue_number: issueNumber,
+        body,
+        headers: {
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      }
+    );
+    return data;
+  } catch (error) {
+    console.error(`Error adding comment:`, error);
+    throw error;
+  }
+};
+
 export const fetchPullRequests = async (
   installationId: number,
   owner: string,

--- a/connectors/github/src/routes/capabilities.ts
+++ b/connectors/github/src/routes/capabilities.ts
@@ -1,12 +1,13 @@
 import {
   CAPABILITY_INVOKE_PATH,
   CAPABILITY_INVOKE_SECRET_HEADER,
+  capabilityEntityRefSchema,
   invokeEnvelopeSchema,
 } from "@connectors/framework";
 import { formatGitHubId } from "@workspace/schemas/external-issue";
 import Elysia from "elysia";
 import { z } from "zod";
-import { createIssue } from "../lib/github";
+import { addComment, createIssue, setIssueState } from "../lib/github";
 
 /**
  * GitHub's opaque config, interpreted here — the core forwards `configStr`
@@ -23,6 +24,9 @@ const githubConfigSchema = z.object({
   ),
 });
 
+type GithubConfig = z.infer<typeof githubConfigSchema>;
+type GithubRepo = GithubConfig["repos"][number];
+
 /** Opaque sub-resource selector for issue-tracker `create`, GitHub-shaped. */
 const createIssueTargetSchema = z.object({
   owner: z.string().min(1),
@@ -35,10 +39,149 @@ const createIssuePayloadSchema = z.object({
   target: createIssueTargetSchema,
 });
 
+const setStatePayloadSchema = z.object({
+  entity: capabilityEntityRefSchema,
+  state: z.enum(["open", "closed"]),
+});
+
+const linkPayloadSchema = z.object({
+  entity: capabilityEntityRefSchema,
+  thread: z.object({
+    url: z.string(),
+    title: z.string().default(""),
+  }),
+});
+
+/** A handled response: an HTTP status plus the JSON body to return. */
+type HandlerResult = { status: number; body: unknown };
+
+const err = (status: number, error: string): HandlerResult => ({
+  status,
+  body: { error },
+});
+
+/** Resolve a connected repo from its `owner/repo` full name. */
+const findRepo = (
+  config: GithubConfig,
+  repoFullName: string,
+): GithubRepo | undefined =>
+  config.repos.find((r) => r.fullName === repoFullName);
+
+const handleCreateIssue = async (
+  config: GithubConfig,
+  payload: unknown,
+): Promise<HandlerResult> => {
+  const parsed = createIssuePayloadSchema.safeParse(payload);
+  if (!parsed.success) {
+    return err(400, parsed.error.issues[0]?.message ?? "Invalid payload");
+  }
+
+  const { title, body, target } = parsed.data;
+  const repo = config.repos.find(
+    (r) => r.owner === target.owner && r.name === target.repo,
+  );
+  if (!repo) return err(400, "REPOSITORY_NOT_CONNECTED");
+
+  try {
+    const issue = await createIssue(
+      config.installationId,
+      target.owner,
+      target.repo,
+      title,
+      body,
+    );
+    return {
+      status: 201,
+      body: {
+        entity: {
+          id: formatGitHubId(issue.id, target.owner, target.repo),
+          shortId: String(issue.number),
+          title: issue.title,
+          body: issue.body ?? "",
+          state: issue.state,
+          url: issue.html_url,
+          label: `${target.owner}/${target.repo}#${issue.number}`,
+        },
+      },
+    };
+  } catch (error) {
+    console.error("Error creating issue:", error);
+    return err(500, "Failed to create issue");
+  }
+};
+
+const handleSetIssueState = async (
+  config: GithubConfig,
+  payload: unknown,
+): Promise<HandlerResult> => {
+  const parsed = setStatePayloadSchema.safeParse(payload);
+  if (!parsed.success) {
+    return err(400, parsed.error.issues[0]?.message ?? "Invalid payload");
+  }
+
+  const { entity, state } = parsed.data;
+  const repo = findRepo(config, entity.repoFullName);
+  if (!repo) return err(400, "REPOSITORY_NOT_CONNECTED");
+
+  try {
+    await setIssueState(
+      config.installationId,
+      repo.owner,
+      repo.name,
+      entity.number,
+      state,
+    );
+    return { status: 200, body: { ok: true } };
+  } catch (error) {
+    console.error("Error setting issue state:", error);
+    return err(500, "Failed to set issue state");
+  }
+};
+
+const handleLinkPullRequest = async (
+  config: GithubConfig,
+  payload: unknown,
+): Promise<HandlerResult> => {
+  const parsed = linkPayloadSchema.safeParse(payload);
+  if (!parsed.success) {
+    return err(400, parsed.error.issues[0]?.message ?? "Invalid payload");
+  }
+
+  const { entity, thread } = parsed.data;
+  const repo = findRepo(config, entity.repoFullName);
+  if (!repo) return err(400, "REPOSITORY_NOT_CONNECTED");
+
+  const body = `Linked to a FrontDesk support thread. [View the conversation](${thread.url}).`;
+
+  try {
+    await addComment(
+      config.installationId,
+      repo.owner,
+      repo.name,
+      entity.number,
+      body,
+    );
+    return { status: 200, body: { ok: true } };
+  } catch (error) {
+    console.error("Error linking pull request:", error);
+    return err(500, "Failed to link pull request");
+  }
+};
+
+/** Dispatch table keyed by `capability/method`. */
+const handlers: Record<
+  string,
+  (config: GithubConfig, payload: unknown) => Promise<HandlerResult>
+> = {
+  "issue-tracker/create": handleCreateIssue,
+  "issue-tracker/setState": handleSetIssueState,
+  "pr-tracker/link": handleLinkPullRequest,
+};
+
 /**
  * Standardized capability-invocation endpoint. Dispatches on
- * `{ capability, method }`; currently wraps octokit issue creation behind the
- * `issue-tracker` / `create` contract.
+ * `{ capability, method }` to the GitHub-specific handler that fulfils the
+ * declared `issue-tracker` / `pr-tracker` contracts behind octokit.
  */
 export const capabilitiesRoutes = new Elysia().post(
   CAPABILITY_INVOKE_PATH,
@@ -64,7 +207,8 @@ export const capabilitiesRoutes = new Elysia().post(
 
     const { capability, method, config, payload } = envelope.data;
 
-    if (capability !== "issue-tracker" || method !== "create") {
+    const handler = handlers[`${capability}/${method}`];
+    if (!handler) {
       set.status = 404;
       return {
         error: `Unsupported capability/method: ${capability}/${method}`,
@@ -90,50 +234,8 @@ export const capabilitiesRoutes = new Elysia().post(
       return { error: "INVALID_CONFIG" };
     }
 
-    const parsedPayload = createIssuePayloadSchema.safeParse(payload);
-    if (!parsedPayload.success) {
-      set.status = 400;
-      return {
-        error: parsedPayload.error.issues[0]?.message ?? "Invalid payload",
-      };
-    }
-
-    const { installationId, repos } = parsedConfig.data;
-    const { title, body, target } = parsedPayload.data;
-
-    const repo = repos.find(
-      (r) => r.owner === target.owner && r.name === target.repo,
-    );
-    if (!repo) {
-      set.status = 400;
-      return { error: "REPOSITORY_NOT_CONNECTED" };
-    }
-
-    try {
-      const issue = await createIssue(
-        installationId,
-        target.owner,
-        target.repo,
-        title,
-        body,
-      );
-
-      set.status = 201;
-      return {
-        entity: {
-          id: formatGitHubId(issue.id, target.owner, target.repo),
-          shortId: String(issue.number),
-          title: issue.title,
-          body: issue.body ?? "",
-          state: issue.state,
-          url: issue.html_url,
-          label: `${target.owner}/${target.repo}#${issue.number}`,
-        },
-      };
-    } catch (error) {
-      console.error("Error creating issue:", error);
-      set.status = 500;
-      return { error: "Failed to create issue" };
-    }
+    const result = await handler(parsedConfig.data, payload);
+    set.status = result.status;
+    return result.body;
   },
 );

--- a/connectors/github/src/routes/capabilities.ts
+++ b/connectors/github/src/routes/capabilities.ts
@@ -1,8 +1,9 @@
 import {
   CAPABILITY_INVOKE_PATH,
   CAPABILITY_INVOKE_SECRET_HEADER,
-  capabilityEntityRefSchema,
   invokeEnvelopeSchema,
+  issueTrackerSetStatePayloadSchema,
+  prTrackerLinkPayloadSchema,
 } from "@connectors/framework";
 import { formatGitHubId } from "@workspace/schemas/external-issue";
 import Elysia from "elysia";
@@ -39,18 +40,10 @@ const createIssuePayloadSchema = z.object({
   target: createIssueTargetSchema,
 });
 
-const setStatePayloadSchema = z.object({
-  entity: capabilityEntityRefSchema,
-  state: z.enum(["open", "closed"]),
-});
-
-const linkPayloadSchema = z.object({
-  entity: capabilityEntityRefSchema,
-  thread: z.object({
-    url: z.string(),
-    title: z.string().default(""),
-  }),
-});
+// Reuse the framework's exported contracts so the connector can't drift from
+// the schemas the core dispatches against.
+const setStatePayloadSchema = issueTrackerSetStatePayloadSchema;
+const linkPayloadSchema = prTrackerLinkPayloadSchema;
 
 /** A handled response: an HTTP status plus the JSON body to return. */
 type HandlerResult = { status: number; body: unknown };


### PR DESCRIPTION
## Summary

Extends the GitHub connector to declare the second capability (`pr-tracker`) and routes the remaining invoked actions through the same generic capability-dispatch introduced in FRO-192 — proving **routing-by-target**: a core→connector call picks its target integration purely from the linked/mirrored `externalEntity` (matching `entity.provider` to `integration.type`), with no capability-level selection and no provider name in core.

Parent: FRO-190 · Blocked by: FRO-192 (merged, #316)

## Design decisions (confirmed with product)
- **issue-close** → the linked external issue's open/closed state syncs whenever the thread's status crosses the closed boundary (`runSetThreadStatus` choke point). Best-effort — the status change never blocks on a connector failure.
- **link_pr** → the connector posts a back-link comment on the PR (symmetric to the FrontDesk footer on created issues), then core sets `externalPrId`.

## Changes

**Framework (`connectors/framework`)**
- Manifest declares both `issue-tracker` and `pr-tracker`.
- New contracts: `capabilityEntityRef` (provider-neutral mirror reference), `issue-tracker` `setState`, `pr-tracker` `link`.

**GitHub connector (`connectors/github`)**
- Invoke endpoint refactored into a `capability/method` dispatch table (`create` / `setState` / `link`).
- Added `setIssueState` and `addComment` octokit helpers.

**Core (`apps/api`)**
- `lib/capability-dispatch.ts` (new): `resolveEntityCapabilityTarget` (routes by `entity.provider`, no `"github"` literal) + `syncLinkedIssueState`.
- `runSetThreadStatus` syncs a linked issue's state on close/reopen.
- `link_pr` handler resolves the mirrored PR, dispatches `pr-tracker/link`, links it, records a `pr_changed` activity — replacing the `LINK_PR_DEFERRED` throw.

## Acceptance criteria
- [x] GitHub connector provides both `issue-tracker` and `pr-tracker`
- [x] Linking a PR works end-to-end via generic dispatch (no `LINK_PR_DEFERRED`)
- [x] Closing a linked issue works via generic dispatch
- [x] Both resolve their target integration from the linked external entity, not a provider check
- [x] No provider name (`"github"`) in the close/link dispatch path

## Verification
Full monorepo typecheck (11/11) and lint pass. Driving this end-to-end at runtime requires a live GitHub App install, a configured integration, and webhook-mirrored PRs/issues, which isn't reproducible locally — not exercised at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GitHub `pr-tracker` and routes PR link and issue close through generic capability dispatch driven by the mirrored entity. Core no longer checks providers directly, meeting FRO-193.

- **New Features**
  - Link a PR: resolve the mirrored PR by URL, post a back-link comment via `pr-tracker/link`, set `externalPrId`, and record `pr_changed` — idempotent if already linked.
  - Keep linked issues in sync: when a thread crosses the closed boundary, push `open|closed` via `issue-tracker/setState` (statuses ≥ closed count as closed; best‑effort, never blocks).

- **Refactors**
  - Generic dispatch by target: `resolveEntityCapabilityTarget` routes using `entity.provider` to `integration.type` (no `"github"` in core).
  - Framework adds `CapabilityEntityRef` (positive int `number`), `issue-tracker/setState`, and `pr-tracker/link`; GitHub manifest now declares both capabilities.
  - GitHub connector uses a `capability/method` table, reuses framework payload schemas, and adds `setIssueState` and `addComment` helpers.

<sup>Written for commit 96e83d1673e61a719c775912268cd8965074baf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for linking pull requests to threads and recording the associated activity.
  * Thread status changes now synchronize linked GitHub issues between open and closed states.
  * GitHub integrations can now update issue status and add comments.
  * Expanded GitHub capability support for pull request tracking and issue management.
* **Bug Fixes**
  * Deferred pull request linking is now fully processed instead of being rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->