### PR TITLE
feat(api,web): capability-driven gating + per-capability primary (FRO-194)

### DIFF
--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -354,8 +354,12 @@ export const router = createRouter({
             // `capabilityPrimary` is intentionally excluded: it must go through
             // `setCapabilityPrimary`, which validates the capability and that the
             // pinned integration is enabled, configured, and provides it.
+            // `.partial()` so a stripped patch can't materialize schema
+            // defaults (timezone, digest, plan) and silently reset existing
+            // settings — only the keys actually sent are merged.
             settings: organizationSettingsSchema
               .omit({ capabilityPrimary: true })
+              .partial()
               .optional(),
           })
           .refine(

--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -1,4 +1,5 @@
 // TODO refactor with new live-state mental model
+import { isCapability } from "@connectors/framework";
 import { router as createRouter } from "@live-state/sync/server";
 import { InviteUserEmail } from "@workspace/emails/transactional/org-invitation";
 import { organizationSettingsSchema } from "@workspace/schemas/organization";
@@ -14,7 +15,14 @@ import { addDays, addYears } from "date-fns";
 import { ulid } from "ulid";
 import { z } from "zod";
 import { publicKeys } from "../lib/api-key";
-import { authorize, assertInviteRecipient, authorizeSelfOrInternal, getWorkspaceActor, requireInternalApiKey } from "../lib/authorize";
+import {
+  assertInviteRecipient,
+  authorize,
+  authorizeSelfOrInternal,
+  getWorkspaceActor,
+  requireInternalApiKey,
+} from "../lib/authorize";
+import { connectorRegistry } from "../lib/connector-registry";
 import { dodopayments } from "../lib/payment";
 import { resend } from "../lib/resend";
 import { sendWelcomeEmail } from "../trigger/send-welcome-email";
@@ -61,60 +69,269 @@ export const router = createRouter({
   schema,
   routes: {
     organization: publicRoute.withProcedures(({ mutation, query }) => ({
-        /** Single organization by slug — public portal shell. */
-        bySlug: query(z.object({ slug: z.string() })).handler(
-          async ({ db, req }) =>
-            Object.values(
-              await db.find(schema.organization, {
-                where: { slug: req.input.slug.toLowerCase() },
-              }),
-            )[0],
-        ),
-        /** Single organization by id — cli, worker, integration bots. */
-        byId: query(z.object({ id: z.string() })).handler(
-          async ({ db, req }) =>
-            db.organization.one(req.input.id).get(),
-        ),
-        /** All organizations — cli listing and public sitemap generation. */
-        list: query().handler(async ({ db }) =>
-          Object.values(await db.find(schema.organization, {})),
-        ),
-        // Un-executed query returned to integration clients (discord/slack/
-        // github), which load it via `client.load`. The whole-tree read has no
-        // per-resource backstop now (live-state 1.0), so it is gated to internal
-        // bot keys — the only callers — to avoid leaking every org's data.
-        load: query().handler(({ db, req }) => {
-          requireInternalApiKey(req.context);
-          return db.organization.include({
-            threads: {
-              include: {
-                messages: {
-                  include: {
-                    author: {
-                      include: { user: true },
-                    },
+      /** Single organization by slug — public portal shell. */
+      bySlug: query(z.object({ slug: z.string() })).handler(
+        async ({ db, req }) =>
+          Object.values(
+            await db.find(schema.organization, {
+              where: { slug: req.input.slug.toLowerCase() },
+            }),
+          )[0],
+      ),
+      /** Single organization by id — cli, worker, integration bots. */
+      byId: query(z.object({ id: z.string() })).handler(async ({ db, req }) =>
+        db.organization.one(req.input.id).get(),
+      ),
+      /** All organizations — cli listing and public sitemap generation. */
+      list: query().handler(async ({ db }) =>
+        Object.values(await db.find(schema.organization, {})),
+      ),
+      // Un-executed query returned to integration clients (discord/slack/
+      // github), which load it via `client.load`. The whole-tree read has no
+      // per-resource backstop now (live-state 1.0), so it is gated to internal
+      // bot keys — the only callers — to avoid leaking every org's data.
+      load: query().handler(({ db, req }) => {
+        requireInternalApiKey(req.context);
+        return db.organization.include({
+          threads: {
+            include: {
+              messages: {
+                include: {
+                  author: {
+                    include: { user: true },
                   },
                 },
-                updates: {
-                  include: { user: true },
-                },
-                labels: {
-                  include: { label: true },
-                },
-                author: {
-                  include: { user: true },
-                },
+              },
+              updates: {
+                include: { user: true },
+              },
+              labels: {
+                include: { label: true },
+              },
+              author: {
+                include: { user: true },
               },
             },
-            integrations: true,
-            authors: {
-              include: { user: true },
-            },
-          });
+          },
+          integrations: true,
+          authors: {
+            include: { user: true },
+          },
+        });
+      }),
+      create: mutation(
+        z.object({
+          name: z.string(),
+          slug: z
+            .string()
+            .min(4)
+            .refine(
+              (slug) => !RESERVED_ORG_SLUGS.includes(slug.toLowerCase()),
+              {
+                message: "This slug is reserved and cannot be used",
+              },
+            ),
         }),
-        create: mutation(
-          z.object({
-            name: z.string(),
+      ).handler(async ({ req, db }) => {
+        const actor = getWorkspaceActor(req);
+        const userEmail = req.context?.user?.email;
+        const userName = req.context?.user?.name ?? actor.userName ?? undefined;
+        const organizationId = ulid().toLowerCase();
+
+        const dodopaymentsCustomer = await dodopayments?.customers.create({
+          email: userEmail,
+          name: userName,
+        });
+
+        const organization = await db.insert(schema.organization, {
+          id: organizationId,
+          name: req.input!.name,
+          slug: req.input!.slug,
+          createdAt: new Date(),
+          logoUrl: null,
+          socials: null,
+          customInstructions: null,
+          settings: {
+            timezone: "UTC",
+            digest: {
+              pendingReplyThresholdMinutes: 30,
+              time: "09:00",
+              slackChannelId: null,
+              slackChannelName: null,
+              lastDigestSentAt: null,
+            },
+            actionAutonomy: getDefaultActionAutonomy(),
+            plan: "trial",
+            subscriptionStatus: null,
+          },
+        });
+
+        await db.insert(schema.subscription, {
+          id: ulid().toLowerCase(),
+          organizationId,
+          customerId: dodopaymentsCustomer?.customer_id ?? null,
+          subscriptionId: null,
+          plan: "trial",
+          status: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        });
+
+        await db.insert(schema.organizationUser, {
+          id: ulid().toLowerCase(),
+          organizationId,
+          userId: actor.userId,
+          enabled: true,
+          role: "owner",
+        });
+
+        // Send welcome email if this is the user's first organization
+        const userMemberships = Object.values(
+          await db.find(schema.organizationUser, {
+            where: {
+              userId: actor.userId,
+            },
+          }),
+        );
+
+        if (userMemberships.length === 1 && userEmail && userName) {
+          const delayMinutes = Math.floor(Math.random() * 21) + 20;
+
+          sendWelcomeEmail
+            .trigger(
+              {
+                email: userEmail,
+                name: userName,
+              },
+              { delay: `${delayMinutes}m` },
+            )
+            .catch((err) => {
+              console.error("Failed to schedule welcome email", err);
+            });
+        }
+
+        return {
+          success: true,
+          organization,
+        };
+      }),
+      setActionAutonomy: mutation(
+        z.object({
+          organizationId: z.string(),
+          actionKind: actionKindSchema,
+          level: autonomyLevelSchema,
+        }),
+      ).handler(async ({ req, db }) => {
+        authorize(req, {
+          organizationId: req.input.organizationId,
+          role: "owner",
+        });
+
+        if (
+          req.input.level === "auto" &&
+          !REVERSIBLE_ACTIONS.has(req.input.actionKind)
+        ) {
+          throw new Error("ACTION_KIND_LOCKED_FROM_AUTO");
+        }
+
+        const org = await db.organization.one(req.input.organizationId).get();
+        if (!org) throw new Error("ORGANIZATION_NOT_FOUND");
+
+        // Preserve raw settings — only touch actionAutonomy. Avoid
+        // safeParseOrgSettings here because it returns the schema defaults
+        // when the existing settings fail validation, which would silently
+        // overwrite unrelated keys we don't know about yet.
+        const rawSettings =
+          org.settings &&
+          typeof org.settings === "object" &&
+          !Array.isArray(org.settings)
+            ? (org.settings as Record<string, unknown>)
+            : {};
+        const parsedAutonomy = actionAutonomyMapSchema.safeParse(
+          rawSettings.actionAutonomy,
+        );
+        const nextAutonomy: ActionAutonomyMap = {
+          ...getDefaultActionAutonomy(),
+          ...(parsedAutonomy.success ? parsedAutonomy.data : {}),
+          [req.input.actionKind]: req.input.level,
+        };
+
+        return db.organization.update(org.id, {
+          settings: {
+            ...rawSettings,
+            actionAutonomy: nextAutonomy,
+            // biome-ignore lint/suspicious/noExplicitAny: settings JSON shape is open
+          } as any,
+        });
+      }),
+      setCapabilityPrimary: mutation(
+        z.object({
+          organizationId: z.string(),
+          capability: z.string(),
+          integrationId: z.string(),
+        }),
+      ).handler(async ({ req, db }) => {
+        authorize(req, {
+          organizationId: req.input.organizationId,
+          role: "owner",
+        });
+
+        const { capability, integrationId } = req.input;
+        if (!isCapability(capability)) {
+          throw new Error("UNKNOWN_CAPABILITY");
+        }
+
+        // The pinned integration must belong to the org, be enabled, and its
+        // connector must actually provide the capability being pinned.
+        const integration = await db.findOne(schema.integration, integrationId);
+        if (
+          !integration ||
+          integration.organizationId !== req.input.organizationId ||
+          !integration.enabled
+        ) {
+          throw new Error("INTEGRATION_NOT_FOUND");
+        }
+        const entry = connectorRegistry.getByType(integration.type);
+        if (!entry?.manifest.capabilities.includes(capability)) {
+          throw new Error("CAPABILITY_NOT_PROVIDED");
+        }
+
+        const org = await db.organization.one(req.input.organizationId).get();
+        if (!org) throw new Error("ORGANIZATION_NOT_FOUND");
+
+        // Preserve raw settings — only touch capabilityPrimary. Avoid
+        // safeParseOrgSettings here because it returns schema defaults when
+        // the existing settings fail validation, which would silently
+        // overwrite unrelated keys we don't know about yet.
+        const rawSettings =
+          org.settings &&
+          typeof org.settings === "object" &&
+          !Array.isArray(org.settings)
+            ? (org.settings as Record<string, unknown>)
+            : {};
+        const existingPrimary =
+          rawSettings.capabilityPrimary &&
+          typeof rawSettings.capabilityPrimary === "object" &&
+          !Array.isArray(rawSettings.capabilityPrimary)
+            ? (rawSettings.capabilityPrimary as Record<string, string>)
+            : {};
+
+        return db.organization.update(org.id, {
+          settings: {
+            ...rawSettings,
+            capabilityPrimary: {
+              ...existingPrimary,
+              [capability]: integrationId,
+            },
+            // biome-ignore lint/suspicious/noExplicitAny: settings JSON shape is open
+          } as any,
+        });
+      }),
+      updateSettings: mutation(
+        z
+          .object({
+            organizationId: z.string(),
+            name: z.string().optional(),
             slug: z
               .string()
               .min(4)
@@ -123,541 +340,390 @@ export const router = createRouter({
                 {
                   message: "This slug is reserved and cannot be used",
                 },
-              ),
-          }),
-        ).handler(async ({ req, db }) => {
-          const actor = getWorkspaceActor(req);
-          const userEmail = req.context?.user?.email;
-          const userName =
-            req.context?.user?.name ?? actor.userName ?? undefined;
-          const organizationId = ulid().toLowerCase();
-
-          const dodopaymentsCustomer = await dodopayments?.customers.create({
-            email: userEmail,
-            name: userName,
-          });
-
-          const organization = await db.insert(schema.organization, {
-            id: organizationId,
-            name: req.input!.name,
-            slug: req.input!.slug,
-            createdAt: new Date(),
-            logoUrl: null,
-            socials: null,
-            customInstructions: null,
-            settings: {
-              timezone: "UTC",
-              digest: {
-                pendingReplyThresholdMinutes: 30,
-                time: "09:00",
-                slackChannelId: null,
-                slackChannelName: null,
-                lastDigestSentAt: null,
-              },
-              actionAutonomy: getDefaultActionAutonomy(),
-              plan: "trial",
-              subscriptionStatus: null,
-            },
-          });
-
-          await db.insert(schema.subscription, {
-            id: ulid().toLowerCase(),
-            organizationId,
-            customerId: dodopaymentsCustomer?.customer_id ?? null,
-            subscriptionId: null,
-            plan: "trial",
-            status: null,
-            createdAt: new Date(),
-            updatedAt: new Date(),
-          });
-
-          await db.insert(schema.organizationUser, {
-            id: ulid().toLowerCase(),
-            organizationId,
-            userId: actor.userId,
-            enabled: true,
-            role: "owner",
-          });
-
-          // Send welcome email if this is the user's first organization
-          const userMemberships = Object.values(
-            await db.find(schema.organizationUser, {
-              where: {
-                userId: actor.userId,
-              },
-            }),
-          );
-
-          if (userMemberships.length === 1 && userEmail && userName) {
-            const delayMinutes = Math.floor(Math.random() * 21) + 20;
-
-            sendWelcomeEmail
-              .trigger(
-                {
-                  email: userEmail,
-                  name: userName,
-                },
-                { delay: `${delayMinutes}m` },
               )
-              .catch((err) => {
-                console.error("Failed to schedule welcome email", err);
-              });
-          }
+              .optional(),
+            logoUrl: z.string().nullable().optional(),
+            socials: z.string().nullable().optional(),
+            customInstructions: z.string().nullable().optional(),
+            settings: organizationSettingsSchema.optional(),
+          })
+          .refine(
+            (input) => {
+              const { organizationId: _organizationId, ...fields } = input;
+              return Object.values(fields).some((value) => value !== undefined);
+            },
+            { message: "NO_FIELDS_TO_UPDATE" },
+          ),
+      ).handler(async ({ req, db }) => {
+        authorize(req, {
+          organizationId: req.input.organizationId,
+          role: "owner",
+        });
 
-          return {
-            success: true,
-            organization,
-          };
+        const org = await db.organization.one(req.input.organizationId).get();
+        if (!org) throw new Error("ORGANIZATION_NOT_FOUND");
+
+        const {
+          organizationId: _organizationId,
+          name,
+          slug,
+          logoUrl,
+          socials,
+          customInstructions,
+          settings,
+        } = req.input;
+
+        const rawSettings =
+          org.settings &&
+          typeof org.settings === "object" &&
+          !Array.isArray(org.settings)
+            ? (org.settings as Record<string, unknown>)
+            : {};
+
+        return db.organization.update(org.id, {
+          ...(name !== undefined ? { name } : {}),
+          ...(slug !== undefined ? { slug } : {}),
+          ...(logoUrl !== undefined ? { logoUrl } : {}),
+          ...(socials !== undefined ? { socials } : {}),
+          ...(customInstructions !== undefined ? { customInstructions } : {}),
+          ...(settings !== undefined
+            ? {
+                settings: {
+                  ...rawSettings,
+                  ...settings,
+                  // biome-ignore lint/suspicious/noExplicitAny: settings JSON shape is open
+                } as any,
+              }
+            : {}),
+        });
+      }),
+      createPublicApiKey: mutation(
+        z.object({
+          organizationId: z.string(),
+          expiresAt: z.iso.datetime().optional(),
+          name: z.string().optional(),
         }),
-        setActionAutonomy: mutation(
-          z.object({
-            organizationId: z.string(),
-            actionKind: actionKindSchema,
-            level: autonomyLevelSchema,
-          }),
-        ).handler(async ({ req, db }) => {
-          authorize(req, {
-            organizationId: req.input.organizationId,
-            role: "owner",
-          });
+      ).handler(async ({ req, db }) => {
+        const organizationId = req.input.organizationId;
 
-          if (
-            req.input.level === "auto" &&
-            !REVERSIBLE_ACTIONS.has(req.input.actionKind)
-          ) {
-            throw new Error("ACTION_KIND_LOCKED_FROM_AUTO");
-          }
+        authorize(req, { organizationId, role: "owner" });
 
-          const org = await db.organization.one(req.input.organizationId).get();
-          if (!org) throw new Error("ORGANIZATION_NOT_FOUND");
+        const publicApiKey = await publicKeys.create({
+          ownerId: organizationId,
+          tags: ["organization"],
+          expiresAt:
+            req.input.expiresAt ?? addYears(new Date(), 1).toISOString(),
+          name: req.input.name,
+        });
 
-          // Preserve raw settings — only touch actionAutonomy. Avoid
-          // safeParseOrgSettings here because it returns the schema defaults
-          // when the existing settings fail validation, which would silently
-          // overwrite unrelated keys we don't know about yet.
-          const rawSettings =
-            org.settings &&
-            typeof org.settings === "object" &&
-            !Array.isArray(org.settings)
-              ? (org.settings as Record<string, unknown>)
-              : {};
-          const parsedAutonomy = actionAutonomyMapSchema.safeParse(
-            rawSettings.actionAutonomy,
-          );
-          const nextAutonomy: ActionAutonomyMap = {
-            ...getDefaultActionAutonomy(),
-            ...(parsedAutonomy.success ? parsedAutonomy.data : {}),
-            [req.input.actionKind]: req.input.level,
-          };
-
-          return db.organization.update(org.id, {
-            settings: {
-              ...rawSettings,
-              actionAutonomy: nextAutonomy,
-              // biome-ignore lint/suspicious/noExplicitAny: settings JSON shape is open
-            } as any,
-          });
+        return {
+          id: publicApiKey.record.id,
+          key: publicApiKey.key,
+          expiresAt: publicApiKey.record.metadata.expiresAt,
+          name: publicApiKey.record.metadata.name,
+        };
+      }),
+      revokePublicApiKey: mutation(
+        z.object({
+          id: z.string(),
         }),
-        updateSettings: mutation(
-          z
-            .object({
-              organizationId: z.string(),
-              name: z.string().optional(),
-              slug: z
-                .string()
-                .min(4)
-                .refine(
-                  (slug) => !RESERVED_ORG_SLUGS.includes(slug.toLowerCase()),
-                  {
-                    message: "This slug is reserved and cannot be used",
-                  },
-                )
-                .optional(),
-              logoUrl: z.string().nullable().optional(),
-              socials: z.string().nullable().optional(),
-              customInstructions: z.string().nullable().optional(),
-              settings: organizationSettingsSchema.optional(),
-            })
-            .refine(
-              (input) => {
-                const { organizationId: _organizationId, ...fields } = input;
-                return Object.values(fields).some(
-                  (value) => value !== undefined,
-                );
-              },
-              { message: "NO_FIELDS_TO_UPDATE" },
-            ),
-        ).handler(async ({ req, db }) => {
-          authorize(req, {
-            organizationId: req.input.organizationId,
-            role: "owner",
-          });
+      ).handler(async ({ req, db }) => {
+        const publicApiKey = await publicKeys.findById(req.input.id);
 
-          const org = await db.organization.one(req.input.organizationId).get();
-          if (!org) throw new Error("ORGANIZATION_NOT_FOUND");
+        if (!publicApiKey) {
+          throw new Error("PUBLIC_API_KEY_NOT_FOUND");
+        }
 
-          const {
-            organizationId: _organizationId,
-            name,
-            slug,
-            logoUrl,
-            socials,
-            customInstructions,
-            settings,
-          } = req.input;
+        authorize(req, {
+          organizationId: publicApiKey.metadata.ownerId,
+          role: "owner",
+          allowInternalApiKey: false,
+        });
 
-          const rawSettings =
-            org.settings &&
-            typeof org.settings === "object" &&
-            !Array.isArray(org.settings)
-              ? (org.settings as Record<string, unknown>)
-              : {};
+        await publicKeys.revoke(publicApiKey.id).catch((error) => {
+          console.error("Error revoking public API key", error);
+          throw new Error("FAILED_TO_REVOKE_PUBLIC_API_KEY");
+        });
 
-          return db.organization.update(org.id, {
-            ...(name !== undefined ? { name } : {}),
-            ...(slug !== undefined ? { slug } : {}),
-            ...(logoUrl !== undefined ? { logoUrl } : {}),
-            ...(socials !== undefined ? { socials } : {}),
-            ...(customInstructions !== undefined ? { customInstructions } : {}),
-            ...(settings !== undefined
-              ? {
-                  settings: {
-                    ...rawSettings,
-                    ...settings,
-                    // biome-ignore lint/suspicious/noExplicitAny: settings JSON shape is open
-                  } as any,
-                }
-              : {}),
-          });
+        return {
+          success: true,
+        };
+      }),
+      listApiKeys: mutation(
+        z.object({
+          organizationId: z.string(),
         }),
-        createPublicApiKey: mutation(
-          z.object({
-            organizationId: z.string(),
-            expiresAt: z.iso.datetime().optional(),
-            name: z.string().optional(),
-          }),
-        ).handler(async ({ req, db }) => {
-          const organizationId = req.input.organizationId;
+      ).handler(async ({ req, db }) => {
+        const organizationId = req.input.organizationId;
 
-          authorize(req, { organizationId, role: "owner" });
+        authorize(req, { organizationId, role: "owner" });
 
-          const publicApiKey = await publicKeys.create({
-            ownerId: organizationId,
-            tags: ["organization"],
-            expiresAt:
-              req.input.expiresAt ?? addYears(new Date(), 1).toISOString(),
-            name: req.input.name,
-          });
+        const apiKeys = await publicKeys.list(organizationId);
 
-          return {
-            id: publicApiKey.record.id,
-            key: publicApiKey.key,
-            expiresAt: publicApiKey.record.metadata.expiresAt,
-            name: publicApiKey.record.metadata.name,
-          };
-        }),
-        revokePublicApiKey: mutation(
-          z.object({
-            id: z.string(),
-          }),
-        ).handler(async ({ req, db }) => {
-          const publicApiKey = await publicKeys.findById(req.input.id);
-
-          if (!publicApiKey) {
-            throw new Error("PUBLIC_API_KEY_NOT_FOUND");
-          }
-
-          authorize(req, {
-            organizationId: publicApiKey.metadata.ownerId,
-            role: "owner",
-            allowInternalApiKey: false,
-          });
-
-          await publicKeys.revoke(publicApiKey.id).catch((error) => {
-            console.error("Error revoking public API key", error);
-            throw new Error("FAILED_TO_REVOKE_PUBLIC_API_KEY");
-          });
-
-          return {
-            success: true,
-          };
-        }),
-        listApiKeys: mutation(
-          z.object({
-            organizationId: z.string(),
-          }),
-        ).handler(async ({ req, db }) => {
-          const organizationId = req.input.organizationId;
-
-          authorize(req, { organizationId, role: "owner" });
-
-          const apiKeys = await publicKeys.list(organizationId);
-
-          return apiKeys
-            .filter((apiKey) => !apiKey.metadata.revokedAt)
-            .map((apiKey) => ({
-              id: apiKey.id,
-              expiresAt: apiKey.metadata.expiresAt,
-              name: apiKey.metadata.name,
-              type: "public",
-              createdAt: apiKey.metadata.createdAt,
-            }));
-        }),
-      })),
+        return apiKeys
+          .filter((apiKey) => !apiKey.metadata.revokedAt)
+          .map((apiKey) => ({
+            id: apiKey.id,
+            expiresAt: apiKey.metadata.expiresAt,
+            name: apiKey.metadata.name,
+            type: "public",
+            createdAt: apiKey.metadata.createdAt,
+          }));
+      }),
+    })),
     organizationUser: privateRoute.withProcedures(({ mutation, query }) => ({
-        /**
-         * The caller's own org memberships (each with its organization) — SSR
-         * loaders (billing, onboarding, workspace shell). Always scoped to the
-         * session user; `withSubscriptions` includes billing state for the
-         * owner-facing billing screen.
-         */
-        forUser: query(
-          z.object({
-            enabledOnly: z.boolean().optional(),
-            withSubscriptions: z.boolean().optional(),
-          }),
-        ).handler(async ({ req, db }) => {
-          const userId = req.context?.session?.userId;
-          if (!userId) throw new Error("UNAUTHORIZED");
-          return db.organizationUser
-            .where({
-              userId,
-              ...(req.input.enabledOnly ? { enabled: true } : {}),
-              // Subscriptions are owner-only: when requested, restrict to the
-              // caller's owner memberships so billing data never leaks to
-              // non-owner members.
-              ...(req.input.withSubscriptions ? { role: "owner" } : {}),
-            })
-            .include({
-              organization: req.input.withSubscriptions
-                ? { include: { subscriptions: true } }
-                : true,
-            })
-            .get();
+      /**
+       * The caller's own org memberships (each with its organization) — SSR
+       * loaders (billing, onboarding, workspace shell). Always scoped to the
+       * session user; `withSubscriptions` includes billing state for the
+       * owner-facing billing screen.
+       */
+      forUser: query(
+        z.object({
+          enabledOnly: z.boolean().optional(),
+          withSubscriptions: z.boolean().optional(),
         }),
-        // Un-executed query returned to the client, which loads it via
-        // `useLoadData`. Scoped to the session user server-side so the client
-        // never dictates which user's memberships (and org data) to sync.
-        load: query().handler(({ req, db }) =>
-          db.organizationUser
-            .where({ userId: req.context!.session!.userId })
-            .include({
-              organization: {
-                include: {
-                  threads: {
-                    include: {
-                      messages: {
-                        include: { author: true },
-                      },
-                      updates: {
-                        include: { user: true },
-                      },
-                      labels: {
-                        include: { label: true },
-                      },
-                      author: true,
-                      assignedUser: true,
+      ).handler(async ({ req, db }) => {
+        const userId = req.context?.session?.userId;
+        if (!userId) throw new Error("UNAUTHORIZED");
+        return db.organizationUser
+          .where({
+            userId,
+            ...(req.input.enabledOnly ? { enabled: true } : {}),
+            // Subscriptions are owner-only: when requested, restrict to the
+            // caller's owner memberships so billing data never leaks to
+            // non-owner members.
+            ...(req.input.withSubscriptions ? { role: "owner" } : {}),
+          })
+          .include({
+            organization: req.input.withSubscriptions
+              ? { include: { subscriptions: true } }
+              : true,
+          })
+          .get();
+      }),
+      // Un-executed query returned to the client, which loads it via
+      // `useLoadData`. Scoped to the session user server-side so the client
+      // never dictates which user's memberships (and org data) to sync.
+      load: query().handler(({ req, db }) =>
+        db.organizationUser
+          .where({ userId: req.context!.session!.userId })
+          .include({
+            organization: {
+              include: {
+                threads: {
+                  include: {
+                    messages: {
+                      include: { author: true },
                     },
+                    updates: {
+                      include: { user: true },
+                    },
+                    labels: {
+                      include: { label: true },
+                    },
+                    author: true,
+                    assignedUser: true,
                   },
-                  invites: true,
-                  integrations: true,
-                  // `subscriptions` is intentionally NOT synced here: it carries
-                  // billing identifiers and is owner-only (see subscription.forOrg).
-                  // Feature-gating state lives in organization.settings (plan,
-                  // subscriptionStatus), which syncs to every member.
-                  labels: true,
-                  organizationUsers: {
-                    include: { user: true },
-                  },
-                  authors: true,
-                  onboardings: true,
-                  documentationSources: true,
-                  // TODO improve this to load only when needed
-                  agentChats: {
-                    include: { messages: true },
-                  },
-                  autonomousActions: true,
-                  externalEntities: true,
                 },
+                invites: true,
+                integrations: true,
+                // `subscriptions` is intentionally NOT synced here: it carries
+                // billing identifiers and is owner-only (see subscription.forOrg).
+                // Feature-gating state lives in organization.settings (plan,
+                // subscriptionStatus), which syncs to every member.
+                labels: true,
+                organizationUsers: {
+                  include: { user: true },
+                },
+                authors: true,
+                onboardings: true,
+                documentationSources: true,
+                // TODO improve this to load only when needed
+                agentChats: {
+                  include: { messages: true },
+                },
+                autonomousActions: true,
+                externalEntities: true,
               },
-            }),
-        ),
-        inviteUser: mutation(
-          z.object({
-            organizationId: z.string(),
-            email: z.email().array(),
+            },
           }),
-        ).handler(async ({ req, db }) => {
-          const orgId = req.input!.organizationId;
+      ),
+      inviteUser: mutation(
+        z.object({
+          organizationId: z.string(),
+          email: z.email().array(),
+        }),
+      ).handler(async ({ req, db }) => {
+        const orgId = req.input!.organizationId;
 
-          authorize(req, {
-            organizationId: orgId,
-            role: "owner",
-            allowInternalApiKey: false,
-          });
+        authorize(req, {
+          organizationId: orgId,
+          role: "owner",
+          allowInternalApiKey: false,
+        });
 
-          const selfOrgUser = Object.values(
-            await db.find(schema.organizationUser, {
-              where: {
-                organizationId: orgId,
-                userId: req.context!.session!.userId,
+        const selfOrgUser = Object.values(
+          await db.find(schema.organizationUser, {
+            where: {
+              organizationId: orgId,
+              userId: req.context!.session!.userId,
+            },
+            include: {
+              user: true,
+              organization: true,
+            },
+          }),
+        )[0] as any;
+
+        const existingMembers = Object.values(
+          await db.find(schema.organizationUser, {
+            where: {
+              organizationId: orgId,
+            },
+            include: {
+              user: true,
+            },
+          }),
+        );
+
+        const existingInvites = Object.values(
+          await db.find(schema.invite, {
+            where: {
+              organizationId: orgId,
+              active: true,
+              expiresAt: {
+                $gt: new Date(),
               },
-              include: {
-                user: true,
-                organization: true,
-              },
-            }),
-          )[0] as any;
+            },
+          }),
+        );
 
-          const existingMembers = Object.values(
-            await db.find(schema.organizationUser, {
-              where: {
-                organizationId: orgId,
-              },
-              include: {
-                user: true,
-              },
-            }),
-          );
+        // TODO follow https://github.com/pedroscosta/live-state/issues/74
+        const filteredEmails = Array.from(
+          new Set(req.input!.email.map((e) => e.trim().toLowerCase())),
+        ).filter(
+          (email) =>
+            !existingMembers.some(
+              (member) => (member as any).user?.email.toLowerCase() === email,
+            ) &&
+            !existingInvites.some(
+              (invite) => (invite as any).email.toLowerCase() === email,
+            ),
+        );
 
-          const existingInvites = Object.values(
-            await db.find(schema.invite, {
-              where: {
-                organizationId: orgId,
-                active: true,
-                expiresAt: {
-                  $gt: new Date(),
-                },
-              },
-            }),
-          );
+        await Promise.allSettled(
+          filteredEmails.map(async (email) => {
+            const inviteId = ulid().toLowerCase();
+            await db.insert(schema.invite, {
+              id: inviteId,
+              organizationId: req.input!.organizationId,
+              creatorId: req.context.session.userId,
+              email,
+              createdAt: new Date(),
+              expiresAt: addDays(new Date(), 7),
+              active: true,
+            });
 
-          // TODO follow https://github.com/pedroscosta/live-state/issues/74
-          const filteredEmails = Array.from(
-            new Set(req.input!.email.map((e) => e.trim().toLowerCase())),
-          ).filter(
-            (email) =>
-              !existingMembers.some(
-                (member) => (member as any).user?.email.toLowerCase() === email,
-              ) &&
-              !existingInvites.some(
-                (invite) => (invite as any).email.toLowerCase() === email,
-              ),
-          );
-
-          await Promise.allSettled(
-            filteredEmails.map(async (email) => {
-              const inviteId = ulid().toLowerCase();
-              await db.insert(schema.invite, {
-                id: inviteId,
-                organizationId: req.input!.organizationId,
-                creatorId: req.context.session.userId,
-                email,
-                createdAt: new Date(),
-                expiresAt: addDays(new Date(), 7),
-                active: true,
+            await resend.emails
+              .send({
+                from: "FrontDesk <notifications@tryfrontdesk.app>",
+                to: [email],
+                subject: `${selfOrgUser.user.name} invited you to join ${selfOrgUser.organization.name} on FrontDesk`,
+                react: InviteUserEmail({
+                  invitedByName: selfOrgUser.user.name,
+                  organizationName: selfOrgUser.organization.name,
+                  organizationImage: selfOrgUser.organization.logoUrl,
+                  inviteLink: `https://tryfrontdesk.app/app/invitation/${inviteId}`,
+                }),
+              })
+              .catch((error) => {
+                console.error("Error sending email", error);
               });
+          }),
+        );
 
-              await resend.emails
-                .send({
-                  from: "FrontDesk <notifications@tryfrontdesk.app>",
-                  to: [email],
-                  subject: `${selfOrgUser.user.name} invited you to join ${selfOrgUser.organization.name} on FrontDesk`,
-                  react: InviteUserEmail({
-                    invitedByName: selfOrgUser.user.name,
-                    organizationName: selfOrgUser.organization.name,
-                    organizationImage: selfOrgUser.organization.logoUrl,
-                    inviteLink: `https://tryfrontdesk.app/app/invitation/${inviteId}`,
-                  }),
-                })
-                .catch((error) => {
-                  console.error("Error sending email", error);
-                });
-            }),
-          );
+        return {
+          success: true,
+        };
+      }),
+      updateMember: mutation(
+        z
+          .object({
+            organizationUserId: z.string(),
+            role: z.enum(["owner", "user"]).optional(),
+            enabled: z.boolean().optional(),
+          })
+          .refine(
+            (input) => {
+              const { organizationUserId: _organizationUserId, ...fields } =
+                input;
+              return Object.values(fields).some((value) => value !== undefined);
+            },
+            { message: "NO_FIELDS_TO_UPDATE" },
+          ),
+      ).handler(async ({ req, db }) => {
+        const member = await db.organizationUser
+          .one(req.input.organizationUserId)
+          .get();
+        if (!member) throw new Error("ORGANIZATION_USER_NOT_FOUND");
 
-          return {
-            success: true,
-          };
-        }),
-        updateMember: mutation(
-          z
-            .object({
-              organizationUserId: z.string(),
-              role: z.enum(["owner", "user"]).optional(),
-              enabled: z.boolean().optional(),
-            })
-            .refine(
-              (input) => {
-                const { organizationUserId: _organizationUserId, ...fields } =
-                  input;
-                return Object.values(fields).some(
-                  (value) => value !== undefined,
-                );
-              },
-              { message: "NO_FIELDS_TO_UPDATE" },
-            ),
-        ).handler(async ({ req, db }) => {
-          const member = await db.organizationUser
-            .one(req.input.organizationUserId)
-            .get();
-          if (!member) throw new Error("ORGANIZATION_USER_NOT_FOUND");
+        authorize(req, {
+          organizationId: member.organizationId,
+          role: "owner",
+        });
 
-          authorize(req, {
-            organizationId: member.organizationId,
-            role: "owner",
-          });
+        if (
+          member.userId === req.context?.session?.userId &&
+          (req.input.enabled === false ||
+            (req.input.role !== undefined && req.input.role !== member.role))
+        ) {
+          throw new Error("CANNOT_UPDATE_SELF");
+        }
 
-          if (
-            member.userId === req.context?.session?.userId &&
-            (req.input.enabled === false ||
-              (req.input.role !== undefined && req.input.role !== member.role))
-          ) {
-            throw new Error("CANNOT_UPDATE_SELF");
-          }
+        const {
+          organizationUserId: _organizationUserId,
+          role,
+          enabled,
+        } = req.input;
 
-          const { organizationUserId: _organizationUserId, role, enabled } =
-            req.input;
-
-          return db.organizationUser.update(member.id, {
-            ...(role !== undefined ? { role } : {}),
-            ...(enabled !== undefined ? { enabled } : {}),
-          });
-        }),
-      })),
+        return db.organizationUser.update(member.id, {
+          ...(role !== undefined ? { role } : {}),
+          ...(enabled !== undefined ? { enabled } : {}),
+        });
+      }),
+    })),
     user: publicRoute.withProcedures(({ mutation }) => ({
-        updateProfile: mutation(
-          z
-            .object({
-              userId: z.string(),
-              name: z.string().optional(),
-              email: z.string().optional(),
-              image: z.string().nullable().optional(),
-            })
-            .refine(
-              (input) => {
-                const { userId: _userId, ...fields } = input;
-                return Object.values(fields).some(
-                  (value) => value !== undefined,
-                );
-              },
-              { message: "NO_FIELDS_TO_UPDATE" },
-            ),
-        ).handler(async ({ req, db }) => {
-          authorizeSelfOrInternal(req, req.input.userId);
+      updateProfile: mutation(
+        z
+          .object({
+            userId: z.string(),
+            name: z.string().optional(),
+            email: z.string().optional(),
+            image: z.string().nullable().optional(),
+          })
+          .refine(
+            (input) => {
+              const { userId: _userId, ...fields } = input;
+              return Object.values(fields).some((value) => value !== undefined);
+            },
+            { message: "NO_FIELDS_TO_UPDATE" },
+          ),
+      ).handler(async ({ req, db }) => {
+        authorizeSelfOrInternal(req, req.input.userId);
 
-          const existing = await db.user.one(req.input.userId).get();
-          if (!existing) throw new Error("USER_NOT_FOUND");
+        const existing = await db.user.one(req.input.userId).get();
+        if (!existing) throw new Error("USER_NOT_FOUND");
 
-          const { userId: _userId, name, email, image } = req.input;
+        const { userId: _userId, name, email, image } = req.input;
 
-          return db.user.update(existing.id, {
-            ...(name !== undefined ? { name } : {}),
-            ...(email !== undefined ? { email } : {}),
-            ...(image !== undefined ? { image } : {}),
-          });
-        }),
-      })),
+        return db.user.update(existing.id, {
+          ...(name !== undefined ? { name } : {}),
+          ...(email !== undefined ? { email } : {}),
+          ...(image !== undefined ? { image } : {}),
+        });
+      }),
+    })),
     author: publicRoute.withProcedures(({ query }) => ({
       /** Authors by id (batch) — worker message-role resolution. */
       byIds: query(z.object({ ids: z.array(z.string()) })).handler(
@@ -672,91 +738,48 @@ export const router = createRouter({
       ),
     })),
     invite: privateRoute.withProcedures(({ mutation, query }) => ({
-        /** Single invite by id, with org + creator — invitation accept page. */
-        byId: query(z.object({ id: z.string() })).handler(
-          async ({ db, req }) => {
-            const invite = await db.invite
-              .one(req.input.id)
-              .include({ organization: true, creator: true })
-              .get();
-            if (!invite) return undefined;
-            // Only the recipient, an org member, or an internal key may read
-            // the invite (which exposes email, org, and creator).
-            const callerEmail = req.context?.user?.email?.toLowerCase();
-            if (callerEmail !== invite.email.toLowerCase()) {
-              authorize(req, { organizationId: invite.organizationId });
-            }
-            return invite;
-          },
-        ),
-        /** Active, unexpired invites for an email — onboarding join prompt. */
-        forEmail: query(z.object({ email: z.string() })).handler(
-          async ({ db, req }) => {
-            // Invites are stored lowercased; normalize so casing differences
-            // don't hide a valid invite.
-            const email = req.input.email.toLowerCase();
-            // Callers may only look up their own email (internal keys excepted).
-            if (
-              !req.context?.internalApiKey &&
-              req.context?.user?.email?.toLowerCase() !== email
-            ) {
-              throw new Error("UNAUTHORIZED");
-            }
-            return db.invite
-              .where({
-                email,
-                active: true,
-                expiresAt: { $gt: new Date() },
-              })
-              .include({ organization: true })
-              .get();
-          },
-        ),
-        accept: mutation(z.object({ id: z.string() })).handler(
-          async ({ req, db }) => {
-            await db.transaction(async ({ trx }) => {
-              const invite = await trx.findOne(schema.invite, req.input!.id);
-
-              if (!invite) {
-                throw new Error("INVITATION_NOT_FOUND");
-              }
-
-              assertInviteRecipient(req, invite.email);
-
-              const actor = getWorkspaceActor(req);
-
-              await trx.insert(schema.organizationUser, {
-                id: ulid().toLowerCase(),
-                organizationId: invite.organizationId,
-                userId: actor.userId,
-                enabled: true,
-                role: "user",
-              });
-
-              await trx.update(schema.invite, req.input!.id, {
-                active: false,
-              });
-            });
-
-            if (req.context?.user?.email) {
-              try {
-                await db.insert(schema.allowlist, {
-                  id: ulid().toLowerCase(),
-                  email: req.context.user.email.toLowerCase(),
-                });
-              } catch {
-                // Silently ignore errors (e.g., duplicate email)
-              }
-            }
-
-            return {
-              success: true,
-            };
-          },
-        ),
-        decline: mutation(z.object({ id: z.string() })).handler(
-          async ({ req, db }) => {
-            const invite = await db.findOne(schema.invite, req.input!.id);
+      /** Single invite by id, with org + creator — invitation accept page. */
+      byId: query(z.object({ id: z.string() })).handler(async ({ db, req }) => {
+        const invite = await db.invite
+          .one(req.input.id)
+          .include({ organization: true, creator: true })
+          .get();
+        if (!invite) return undefined;
+        // Only the recipient, an org member, or an internal key may read
+        // the invite (which exposes email, org, and creator).
+        const callerEmail = req.context?.user?.email?.toLowerCase();
+        if (callerEmail !== invite.email.toLowerCase()) {
+          authorize(req, { organizationId: invite.organizationId });
+        }
+        return invite;
+      }),
+      /** Active, unexpired invites for an email — onboarding join prompt. */
+      forEmail: query(z.object({ email: z.string() })).handler(
+        async ({ db, req }) => {
+          // Invites are stored lowercased; normalize so casing differences
+          // don't hide a valid invite.
+          const email = req.input.email.toLowerCase();
+          // Callers may only look up their own email (internal keys excepted).
+          if (
+            !req.context?.internalApiKey &&
+            req.context?.user?.email?.toLowerCase() !== email
+          ) {
+            throw new Error("UNAUTHORIZED");
+          }
+          return db.invite
+            .where({
+              email,
+              active: true,
+              expiresAt: { $gt: new Date() },
+            })
+            .include({ organization: true })
+            .get();
+        },
+      ),
+      accept: mutation(z.object({ id: z.string() })).handler(
+        async ({ req, db }) => {
+          await db.transaction(async ({ trx }) => {
+            const invite = await trx.findOne(schema.invite, req.input!.id);
 
             if (!invite) {
               throw new Error("INVITATION_NOT_FOUND");
@@ -764,29 +787,70 @@ export const router = createRouter({
 
             assertInviteRecipient(req, invite.email);
 
-            await db.update(schema.invite, req.input!.id, {
+            const actor = getWorkspaceActor(req);
+
+            await trx.insert(schema.organizationUser, {
+              id: ulid().toLowerCase(),
+              organizationId: invite.organizationId,
+              userId: actor.userId,
+              enabled: true,
+              role: "user",
+            });
+
+            await trx.update(schema.invite, req.input!.id, {
               active: false,
             });
+          });
 
-            return {
-              success: true,
-            };
-          },
-        ),
-        revoke: mutation(z.object({ inviteId: z.string() })).handler(
-          async ({ req, db }) => {
-            const invite = await db.invite.one(req.input.inviteId).get();
-            if (!invite) throw new Error("INVITATION_NOT_FOUND");
+          if (req.context?.user?.email) {
+            try {
+              await db.insert(schema.allowlist, {
+                id: ulid().toLowerCase(),
+                email: req.context.user.email.toLowerCase(),
+              });
+            } catch {
+              // Silently ignore errors (e.g., duplicate email)
+            }
+          }
 
-            authorize(req, {
-              organizationId: invite.organizationId,
-              role: "owner",
-            });
+          return {
+            success: true,
+          };
+        },
+      ),
+      decline: mutation(z.object({ id: z.string() })).handler(
+        async ({ req, db }) => {
+          const invite = await db.findOne(schema.invite, req.input!.id);
 
-            return db.invite.update(invite.id, { active: false });
-          },
-        ),
-      })),
+          if (!invite) {
+            throw new Error("INVITATION_NOT_FOUND");
+          }
+
+          assertInviteRecipient(req, invite.email);
+
+          await db.update(schema.invite, req.input!.id, {
+            active: false,
+          });
+
+          return {
+            success: true,
+          };
+        },
+      ),
+      revoke: mutation(z.object({ inviteId: z.string() })).handler(
+        async ({ req, db }) => {
+          const invite = await db.invite.one(req.input.inviteId).get();
+          if (!invite) throw new Error("INVITATION_NOT_FOUND");
+
+          authorize(req, {
+            organizationId: invite.organizationId,
+            role: "owner",
+          });
+
+          return db.invite.update(invite.id, { active: false });
+        },
+      ),
+    })),
     integration: integrationRoute,
     allowlist: privateRoute.withProcedures(({ query }) => ({
       /** Whether an email is allowlisted — app gate in `beforeLoad`. */

--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -291,6 +291,12 @@ export const router = createRouter({
         ) {
           throw new Error("INTEGRATION_NOT_FOUND");
         }
+        // An integration can be enabled before it's configured; pinning an
+        // unconfigured one would route agent creates to a target that fails at
+        // dispatch, so require a config here too.
+        if (!integration.configStr) {
+          throw new Error("INTEGRATION_NOT_CONFIGURED");
+        }
         const entry = connectorRegistry.getByType(integration.type);
         if (!entry?.manifest.capabilities.includes(capability)) {
           throw new Error("CAPABILITY_NOT_PROVIDED");
@@ -345,7 +351,12 @@ export const router = createRouter({
             logoUrl: z.string().nullable().optional(),
             socials: z.string().nullable().optional(),
             customInstructions: z.string().nullable().optional(),
-            settings: organizationSettingsSchema.optional(),
+            // `capabilityPrimary` is intentionally excluded: it must go through
+            // `setCapabilityPrimary`, which validates the capability and that the
+            // pinned integration is enabled, configured, and provides it.
+            settings: organizationSettingsSchema
+              .omit({ capabilityPrimary: true })
+              .optional(),
           })
           .refine(
             (input) => {

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -1,6 +1,6 @@
 // TODO refactor with new live-state mental model
 import { invokeCapability, type NormalizedIssue } from "@connectors/framework";
-import { safeParseOrgSettings } from "@workspace/schemas/organization";
+import { readCapabilityPrimary } from "@workspace/schemas/organization";
 import { ulid } from "ulid";
 import z from "zod";
 import {
@@ -476,9 +476,10 @@ export default publicRoute.withProcedures(({ mutation, query }) => ({
     // When no target is implied (agent-initiated create, humans pin nothing),
     // fall back to the org's primary issue-tracker before the first provider.
     // Humans can still pin any target freely via `integrationId`.
-    const primaryIssueTrackerId = safeParseOrgSettings(
+    const primaryIssueTrackerId = readCapabilityPrimary(
       enabledIntegrations[0]?.organization?.settings,
-    ).capabilityPrimary?.["issue-tracker"];
+      "issue-tracker",
+    );
 
     const integration = req.input.integrationId
       ? enabledIntegrations.find(

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -1,5 +1,6 @@
 // TODO refactor with new live-state mental model
 import { invokeCapability, type NormalizedIssue } from "@connectors/framework";
+import { safeParseOrgSettings } from "@workspace/schemas/organization";
 import { ulid } from "ulid";
 import z from "zod";
 import {
@@ -472,11 +473,24 @@ export default publicRoute.withProcedures(({ mutation, query }) => ({
         .map((entry) => entry.manifest.type),
     );
 
+    // When no target is implied (agent-initiated create, humans pin nothing),
+    // fall back to the org's primary issue-tracker before the first provider.
+    // Humans can still pin any target freely via `integrationId`.
+    const primaryIssueTrackerId = safeParseOrgSettings(
+      enabledIntegrations[0]?.organization?.settings,
+    ).capabilityPrimary?.["issue-tracker"];
+
     const integration = req.input.integrationId
       ? enabledIntegrations.find(
           (i) => i.id === req.input.integrationId && providerTypes.has(i.type),
         )
-      : enabledIntegrations.find((i) => providerTypes.has(i.type));
+      : ((primaryIssueTrackerId
+          ? enabledIntegrations.find(
+              (i) =>
+                i.id === primaryIssueTrackerId && providerTypes.has(i.type),
+            )
+          : undefined) ??
+        enabledIntegrations.find((i) => providerTypes.has(i.type)));
 
     if (!integration) {
       throw new Error("ISSUE_TRACKER_NOT_CONFIGURED");

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@base-ui/react": "^1.1.0",
     "@bradenmacdonald/s3-lite-client": "npm:@jsr/bradenmacdonald__s3-lite-client@^0.9.3",
+    "@connectors/framework": "workspace:*",
     "@faker-js/faker": "^10.0.0",
     "@fontsource-variable/intel-one-mono": "^5.2.1",
     "@fontsource-variable/inter": "^5.2.6",

--- a/apps/web/src/components/threads/issues.tsx
+++ b/apps/web/src/components/threads/issues.tsx
@@ -46,6 +46,7 @@ import { Github, Loader2, Plus, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { activeOrganizationAtom } from "~/lib/atoms";
+import { useOrgCapability } from "~/lib/hooks/query/use-org-capability";
 import { fetchClient, mutate, query } from "~/lib/live-state";
 import { entityMatchesQuery, type MirrorEntity } from "./external-entities";
 
@@ -83,6 +84,11 @@ export function IssuesSection({
     null,
   );
 
+  // Gate the whole section on the capability, not on a named provider.
+  const hasIssueTracker = useOrgCapability("issue-tracker");
+
+  // Provider-aware config read (repo enumeration) is allowed by design: the
+  // connect/config control plane stays provider-specific. Gating above is not.
   const githubIntegration = useLiveQuery(
     query.integration.first({
       organizationId: currentOrg?.id,
@@ -176,7 +182,11 @@ export function IssuesSection({
         target: { owner, repo },
       });
 
-      if (!result?.issue?.id || !result?.issue?.shortId || !result?.issue?.url) {
+      if (
+        !result?.issue?.id ||
+        !result?.issue?.shortId ||
+        !result?.issue?.url
+      ) {
         throw new Error("Invalid response from GitHub API");
       }
 
@@ -261,7 +271,7 @@ export function IssuesSection({
     });
   };
 
-  if (!githubIntegration || !githubIntegration.enabled) return null;
+  if (!hasIssueTracker) return null;
 
   return (
     <div className="flex flex-col gap-2">

--- a/apps/web/src/components/threads/pull-requests.tsx
+++ b/apps/web/src/components/threads/pull-requests.tsx
@@ -13,6 +13,7 @@ import { useAtomValue } from "jotai/react";
 import { GitPullRequest, X } from "lucide-react";
 import { useState } from "react";
 import { activeOrganizationAtom } from "~/lib/atoms";
+import { useOrgCapability } from "~/lib/hooks/query/use-org-capability";
 import { mutate, query } from "~/lib/live-state";
 import { entityMatchesQuery, type MirrorEntity } from "./external-entities";
 import { LinkedPrSuggestionsSection } from "./linked-pr-suggestions-section";
@@ -36,12 +37,8 @@ export function PullRequestsSection({
   const currentOrg = useAtomValue(activeOrganizationAtom);
   const [search, setSearch] = useState("");
 
-  const githubIntegration = useLiveQuery(
-    query.integration.first({
-      organizationId: currentOrg?.id,
-      type: "github",
-    }),
-  );
+  // Gate the whole section on the capability, not on a named provider.
+  const hasPrTracker = useOrgCapability("pr-tracker");
 
   // Reactive mirror of the org's pull requests, synced via Live-State. Replaces
   // the on-demand `thread.fetchGithubPullRequests` fetch.
@@ -86,7 +83,7 @@ export function PullRequestsSection({
     });
   };
 
-  if (!githubIntegration || !githubIntegration.enabled) return null;
+  if (!hasPrTracker) return null;
 
   return (
     <div className="flex flex-col gap-2">

--- a/apps/web/src/lib/hooks/query/use-org-capability.ts
+++ b/apps/web/src/lib/hooks/query/use-org-capability.ts
@@ -1,0 +1,32 @@
+import { type Capability, typesHaveCapability } from "@connectors/framework";
+import { useLiveQuery } from "@live-state/sync/client";
+import { useAtomValue } from "jotai/react";
+import { activeOrganizationAtom } from "~/lib/atoms";
+import { query } from "~/lib/live-state";
+
+/**
+ * The `type`s of the active org's enabled integrations. Provider-agnostic:
+ * consumers pair this with the connector manifests to reason about capabilities
+ * rather than checking for a named provider.
+ */
+export function useEnabledIntegrationTypes(): string[] {
+  const currentOrg = useAtomValue(activeOrganizationAtom);
+  const integrations = useLiveQuery(
+    query.integration.where({
+      organizationId: currentOrg?.id,
+      enabled: true,
+    }),
+  );
+  return (integrations ?? []).map((integration) => integration.type);
+}
+
+/**
+ * Whether the active org can offer `capability`, resolved from its enabled
+ * integrations via the connector manifests. Client mirror of the API's
+ * `orgHasCapability` — answers "can we show this affordance?"; a specific
+ * invoked call still routes by a concrete target. Replaces `type:"github"`
+ * gating in the UI.
+ */
+export function useOrgCapability(capability: Capability): boolean {
+  return typesHaveCapability(useEnabledIntegrationTypes(), capability);
+}

--- a/apps/web/src/routes/app/_workspace/settings/organization/integration/index.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/integration/index.tsx
@@ -136,14 +136,24 @@ function PrimaryIssueTrackerSection({
   isUserOwner,
 }: {
   organizationId: string;
-  integrations: { id: string; type: string; enabled: boolean }[];
+  integrations: {
+    id: string;
+    type: string;
+    enabled: boolean;
+    configStr: string | null;
+  }[];
   isUserOwner: boolean;
 }) {
   const org = useLiveQuery(query.organization.first({ id: organizationId }));
 
   const providerTypes = new Set(typesProvidingCapability("issue-tracker"));
+  // Only offer configured integrations — an enabled-but-unconfigured tracker
+  // can't actually receive an issue, so pinning it would break agent creates.
   const trackers = integrations.filter(
-    (integration) => integration.enabled && providerTypes.has(integration.type),
+    (integration) =>
+      integration.enabled &&
+      integration.configStr &&
+      providerTypes.has(integration.type),
   );
 
   // Nothing to route through, or nobody's allowed to change it — hide the control.

--- a/apps/web/src/routes/app/_workspace/settings/organization/integration/index.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/integration/index.tsx
@@ -1,12 +1,21 @@
+import { typesProvidingCapability } from "@connectors/framework";
 import { useLiveQuery } from "@live-state/sync/client";
 import { createFileRoute, Link } from "@tanstack/react-router";
+import { safeParseOrgSettings } from "@workspace/schemas/organization";
 import { Badge } from "@workspace/ui/components/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@workspace/ui/components/select";
 import { cn } from "@workspace/ui/lib/utils";
 import { LimitCallout } from "~/components/integration-settings/limit-callout";
 import { useIntegrationWarnings } from "~/lib/hooks/query/use-integration-warnings";
 import { useOrganizationSwitcher } from "~/lib/hooks/query/use-organization-switcher";
 import { usePlanLimits } from "~/lib/hooks/query/use-plan-limits";
-import { query } from "~/lib/live-state";
+import { mutate, query } from "~/lib/live-state";
 import { seo } from "~/utils/seo";
 
 export const Route = createFileRoute(
@@ -113,6 +122,75 @@ To get started, connect your GitHub account and select the repository you want t
   // },
 ];
 
+const integrationLabel = (type: string): string =>
+  integrationOptions.find((option) => option.id === type)?.label ?? type;
+
+/**
+ * Picks the org's primary issue-tracker — the target used when none is implied
+ * (e.g. an agent-initiated issue create). Gated on the capability, not a named
+ * provider, so it lists whichever enabled integrations provide `issue-tracker`.
+ */
+function PrimaryIssueTrackerSection({
+  organizationId,
+  integrations,
+  isUserOwner,
+}: {
+  organizationId: string;
+  integrations: { id: string; type: string; enabled: boolean }[];
+  isUserOwner: boolean;
+}) {
+  const org = useLiveQuery(query.organization.first({ id: organizationId }));
+
+  const providerTypes = new Set(typesProvidingCapability("issue-tracker"));
+  const trackers = integrations.filter(
+    (integration) => integration.enabled && providerTypes.has(integration.type),
+  );
+
+  // Nothing to route through, or nobody's allowed to change it — hide the control.
+  if (!isUserOwner || trackers.length === 0) return null;
+
+  const primaryId = safeParseOrgSettings(org?.settings).capabilityPrimary?.[
+    "issue-tracker"
+  ];
+  // Default the selection to the first tracker when none is pinned yet.
+  const selected =
+    trackers.find((tracker) => tracker.id === primaryId)?.id ?? trackers[0].id;
+
+  return (
+    <div className="p-4 flex flex-col gap-4 w-full">
+      <h2 className="text-base">Issue tracking</h2>
+      <div className="flex flex-col gap-2 rounded-md border bg-muted/30 p-4">
+        <div className="text-sm">Primary issue tracker</div>
+        <div className="text-muted-foreground text-sm">
+          Where the Agent opens issues when a thread doesn't already point at a
+          specific target. You can still pick any target by hand.
+        </div>
+        <Select
+          value={selected}
+          onValueChange={(value) =>
+            mutate.organization.setCapabilityPrimary({
+              organizationId,
+              capability: "issue-tracker",
+              integrationId: value as string,
+            })
+          }
+        >
+          <SelectTrigger className="w-64 mt-1">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {trackers.map((tracker) => (
+              <SelectItem key={tracker.id} value={tracker.id}>
+                {integrationLabel(tracker.type)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}
+
 function RouteComponent() {
   const { activeOrganization } = useOrganizationSwitcher();
   const { integrations: integrationLimits } = usePlanLimits();
@@ -216,6 +294,13 @@ function RouteComponent() {
       {integrationLimits.hasReachedLimit && <LimitCallout className="mb-4" />}
       {renderIntegrationGroup("Active integrations", activeIntegrations)}
       {renderIntegrationGroup("Available integrations", availableIntegrations)}
+      {activeOrganization?.id && (
+        <PrimaryIssueTrackerSection
+          organizationId={activeOrganization.id}
+          integrations={allIntegrations ?? []}
+          isUserOwner={isUserOwner}
+        />
+      )}
     </>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -110,6 +110,7 @@
       "dependencies": {
         "@base-ui/react": "^1.1.0",
         "@bradenmacdonald/s3-lite-client": "npm:@jsr/bradenmacdonald__s3-lite-client@^0.9.3",
+        "@connectors/framework": "workspace:*",
         "@faker-js/faker": "^10.0.0",
         "@fontsource-variable/intel-one-mono": "^5.2.1",
         "@fontsource-variable/inter": "^5.2.6",

--- a/connectors/framework/src/index.ts
+++ b/connectors/framework/src/index.ts
@@ -25,6 +25,8 @@ export {
   type ConnectorManifest,
   githubManifest,
   manifests,
+  typesHaveCapability,
+  typesProvidingCapability,
 } from "./manifest";
 export {
   buildRegistry,

--- a/connectors/framework/src/manifest.ts
+++ b/connectors/framework/src/manifest.ts
@@ -30,3 +30,35 @@ export const githubManifest: ConnectorManifest = {
 
 /** All known connector manifests. */
 export const manifests: ConnectorManifest[] = [githubManifest];
+
+/**
+ * The integration `type`s whose manifest declares `capability`. Pure and
+ * env-free (unlike the boot-time {@link ConnectorRegistry}, which resolves host
+ * URLs from `process.env`), so it is safe to call from the browser: the web
+ * client uses it to answer "which providers can offer this?" for gating.
+ */
+export function typesProvidingCapability(
+  capability: Capability,
+  manifestList: ConnectorManifest[] = manifests,
+): string[] {
+  return manifestList
+    .filter((manifest) => manifest.capabilities.includes(capability))
+    .map((manifest) => manifest.type);
+}
+
+/**
+ * Whether any of `enabledTypes` provides `capability`. Env-free, client-safe
+ * mirror of {@link ConnectorRegistry.hasCapability} — answers "can we offer
+ * this?"; a specific invoked call still routes by a concrete target.
+ */
+export function typesHaveCapability(
+  enabledTypes: Iterable<string>,
+  capability: Capability,
+  manifestList: ConnectorManifest[] = manifests,
+): boolean {
+  const providers = new Set(typesProvidingCapability(capability, manifestList));
+  for (const type of enabledTypes) {
+    if (providers.has(type)) return true;
+  }
+  return false;
+}

--- a/packages/schemas/src/organization.ts
+++ b/packages/schemas/src/organization.ts
@@ -56,3 +56,24 @@ export const safeParseOrgSettings = (
     return organizationSettingsSchema.parse({});
   }
 };
+
+/**
+ * Reads a capability's pinned primary integration id directly from raw settings,
+ * without validating the rest of the object. Mirrors the write path, which
+ * preserves unknown/invalid sibling keys — an unrelated bad field must not cause
+ * a validly pinned primary to be silently dropped.
+ */
+export const readCapabilityPrimary = (
+  settings: unknown,
+  capability: string,
+): string | undefined => {
+  if (!settings || typeof settings !== "object" || Array.isArray(settings)) {
+    return undefined;
+  }
+  const primary = (settings as Record<string, unknown>).capabilityPrimary;
+  if (!primary || typeof primary !== "object" || Array.isArray(primary)) {
+    return undefined;
+  }
+  const value = (primary as Record<string, unknown>)[capability];
+  return typeof value === "string" ? value : undefined;
+};

--- a/packages/schemas/src/organization.ts
+++ b/packages/schemas/src/organization.ts
@@ -35,6 +35,12 @@ export const organizationSettingsSchema = z.object({
     .catch("trial")
     .default("trial"),
   subscriptionStatus: z.string().nullable().default(null),
+  // Per-capability primary integration: a `capability → integrationId` map used
+  // where target-routing doesn't apply (e.g. agent-initiated entity creation
+  // with no implied target). Keys are connector capabilities (`issue-tracker`,
+  // …); kept as an open string map so schemas stays free of a framework
+  // dependency. The API validates the capability and integration on write.
+  capabilityPrimary: z.record(z.string(), z.string()).optional(),
 });
 
 export type OrganizationSettings = z.infer<typeof organizationSettingsSchema>;


### PR DESCRIPTION
## What & why

Implements [FRO-194](https://linear.app/front-desk/issue/FRO-194) — makes the core and UI provider-agnostic and adds the primary-integration mechanism the connector/capability design (FRO-190) calls for when target-routing doesn't apply. Builds on the generic capability-dispatch from FRO-192/193.

## Changes

- **schemas** — add `organization.settings.capabilityPrimary`, an open `capability → integrationId` map (kept string-typed so `@workspace/schemas` stays free of a framework dependency; the API validates on write).
- **framework** — `typesProvidingCapability` / `typesHaveCapability`: pure, env-free helpers mirroring the registry's `hasCapability`. The boot-time registry reads `process.env`, so these let the browser reason about capabilities safely.
- **api**
  - `organization.setCapabilityPrimary` mutation — owner-only; validates the capability is known, the integration is enabled + belongs to the org, and its connector actually provides the capability; merges into settings preserving unknown keys.
  - `thread.createIssue` — resolution is now *pinned `integrationId` → org primary issue-tracker → first enabled provider*, so agent-initiated creates (no implied target) fall back to the primary while humans still pin any target freely.
- **web**
  - `useOrgCapability` hook (client mirror of the API's `orgHasCapability`).
  - `issues.tsx` / `pull-requests.tsx` gate on `hasCapability("issue-tracker")` / `("pr-tracker")` instead of `type:"github"`. Provider-aware repo enumeration read stays (control plane is provider-specific by design).
  - Primary issue-tracker picker added to the existing integrations settings page.

## Acceptance criteria

- [x] `capabilityPrimary` persists a `capability → integrationId` map
- [x] Settings UI picks the primary issue-tracker
- [x] Web UI gates on `hasCapability`, not `type:"github"`
- [x] Agent-initiated create resolves via the primary when none implied
- [x] Repo/sub-resource enumeration still works (provider-aware read allowed)

## Verification

`api`, `web`, `schemas`, and `framework` typecheck clean; biome lint passes on all touched files. Not yet driven end-to-end in a running stack (needs Postgres/Redis/connector hosts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provider-agnostic capability gating with a per-capability primary integration, so agent-initiated creates fall back to the org’s chosen provider when no target is implied. Delivers FRO-194.

- **New Features**
  - Schemas: add `organization.settings.capabilityPrimary` (capability → integrationId).
  - API: `organization.setCapabilityPrimary` (owner-only) validates capability, org ownership, enabled state, and that the connector provides it; merges without touching unknown keys.
  - Framework: add `typesProvidingCapability` and `typesHaveCapability` to `@connectors/framework` for client-safe capability checks.
  - Threads: `thread.createIssue` resolves target as pinned `integrationId` → org primary issue-tracker → first enabled provider.
  - Web: add `useOrgCapability` and gate Issues/PR sections on capabilities; add a primary issue-tracker picker in org integration settings.
  - Dependencies: add `@connectors/framework` to `apps/web`.

- **Bug Fixes**
  - API: make `organization.updateSettings.settings` a partial patch and omit `capabilityPrimary`, so defaults don’t clobber existing settings and writes go through validated `setCapabilityPrimary`; reject pinning an enabled-but-unconfigured tracker.
  - Threads: read the primary via `readCapabilityPrimary` so unrelated invalid settings no longer drop a valid primary.
  - Web: only list configured trackers when choosing a primary.

<sup>Written for commit 57d1f613ca8d321f5c12018e1cd0290692fab02e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization owners can select a primary issue tracker from enabled integrations.
  * Issue and pull request sections now appear when the organization supports the relevant capability, regardless of a specific provider.
  * New capability-based integration support improves organization configuration and tracker selection.

* **Bug Fixes**
  * Issue creation now respects the organization’s selected primary tracker and falls back appropriately when unavailable.
  * Capability settings are validated before being saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->