### PR TITLE
feat(connectors,api): support-entry-point ingest contract + Discord tracer bullet (FRO-197)

### DIFF
--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -31,6 +31,7 @@ import { agentChatRoute } from "./router/agent-chat";
 import autonomousActionRoute from "./router/autonomous-action";
 import documentationSourcesRoute from "./router/documentation-sources";
 import externalEntityRoute from "./router/external-entity";
+import { ingestRoute } from "./router/ingest";
 import integrationRoute from "./router/integration";
 import labelsRoute from "./router/labels";
 import messageRoute from "./router/message";
@@ -908,6 +909,8 @@ export const router = createRouter({
     // Mirror of external issues/PRs. Default mutators are disabled; writes go
     // through the route's custom `upsert` / `softDelete` procedures.
     externalEntity: externalEntityRoute,
+    // Emitting-side (`support-entry-point`) ingest — connector → core.
+    ingest: ingestRoute,
     thread: threadsRoute,
     update: updateRoute,
     message: messageRoute,

--- a/apps/api/src/live-state/router/ingest.ts
+++ b/apps/api/src/live-state/router/ingest.ts
@@ -64,9 +64,15 @@ export const ingestRoute = publicRoute.withProcedures(({ mutation }) => ({
           });
         }
 
-        // Locate the thread for this external thread within the org.
+        // Locate the thread for this external thread within the org. Scope by
+        // provider too: two providers can mint the same raw external id, and
+        // conflating them would append messages to the wrong conversation.
         const existingThread = await trx.thread
-          .first({ organizationId, externalId: externalThreadId })
+          .first({
+            organizationId,
+            externalId: externalThreadId,
+            externalOrigin: provider,
+          })
           .get();
 
         // Append path.

--- a/apps/api/src/live-state/router/ingest.ts
+++ b/apps/api/src/live-state/router/ingest.ts
@@ -1,0 +1,146 @@
+// TODO refactor with new live-state mental model
+import { supportEntryPointIngestSchema } from "@connectors/framework";
+import { ulid } from "ulid";
+import { requireInternalApiKey } from "../../lib/authorize";
+import { nextThreadShortId } from "../../lib/thread-short-id";
+import { serializeMessageContent } from "../../lib/tiptap-content";
+import { publicRoute } from "../factories";
+import { schema } from "../schema";
+
+/**
+ * The emitting-side (`support-entry-point`) ingest procedure — connector → core.
+ *
+ * A connector translates a provider event into the neutral `ingest` payload; the
+ * core owns all normalization here so connectors stay thin:
+ *
+ * - **Idempotent** on `(organizationId, externalThreadId, externalMessageId)`.
+ * - **Create-vs-append** by whether a thread already exists for the external
+ *   thread — not by any connector-side "is this the first message?" guess.
+ * - **Hard-errors** when a message targets an unknown external thread with no
+ *   `thread` descriptor, rather than create a silent titleless thread.
+ * - **Author** find-or-create/dedup on `(organizationId, metaId)` with the
+ *   `provider:` prefixing convention.
+ *
+ * `isBackfill` is written onto the message rows and only influences downstream
+ * pipeline triggers (via the message `afterInsert` hook); it does not change
+ * normalization. Inbound status changes stay a separate generic mutation.
+ *
+ * See `docs/adr/0009-emitting-side-connector-retrofit.md`.
+ */
+export const ingestRoute = publicRoute.withProcedures(({ mutation }) => ({
+  ingest: mutation(supportEntryPointIngestSchema).handler(
+    async ({ req, db }) => {
+      // Ingest is connector → core; only the internal bot keys may call it.
+      requireInternalApiKey(req.context);
+
+      const {
+        organizationId,
+        provider,
+        externalThreadId,
+        thread: threadDescriptor,
+        message,
+        author,
+        isBackfill,
+      } = req.input;
+
+      const metaId = `${provider}:${author.externalId}`;
+      const content = serializeMessageContent(message.body);
+
+      return db.transaction(async ({ trx }) => {
+        // Author find-or-create/dedup, keyed on (organizationId, metaId).
+        const existingAuthor = await trx.author
+          .first({ metaId, organizationId })
+          .get();
+
+        let authorId = existingAuthor?.id;
+        if (!authorId) {
+          authorId = ulid().toLowerCase();
+          await trx.author.insert({
+            id: authorId,
+            name: author.name,
+            organizationId,
+            metaId,
+            userId: null,
+          });
+        }
+
+        // Locate the thread for this external thread within the org.
+        const existingThread = await trx.thread
+          .first({ organizationId, externalId: externalThreadId })
+          .get();
+
+        // Append path.
+        if (existingThread) {
+          // Idempotent: a message we've already ingested is a no-op.
+          const existingMessage = await trx.message
+            .first({
+              externalMessageId: message.externalMessageId,
+              threadId: existingThread.id,
+            })
+            .get();
+
+          if (!existingMessage) {
+            await trx.message.insert({
+              id: ulid().toLowerCase(),
+              authorId,
+              content,
+              threadId: existingThread.id,
+              createdAt: message.createdAt,
+              origin: provider,
+              externalMessageId: message.externalMessageId,
+              isBackfill,
+            });
+          }
+
+          return { thread: existingThread, created: false };
+        }
+
+        // Create path — refuse to create a titleless thread.
+        if (!threadDescriptor) {
+          throw new Error("INGEST_UNKNOWN_THREAD_WITHOUT_DESCRIPTOR");
+        }
+
+        const threadId = ulid().toLowerCase();
+        const shortId = await nextThreadShortId(trx, organizationId);
+
+        await trx.thread.insert({
+          id: threadId,
+          name: threadDescriptor.title,
+          organizationId,
+          authorId,
+          status: 0,
+          priority: 0,
+          assignedUserId: null,
+          createdAt: message.createdAt,
+          deletedAt: null,
+          // Provider-neutral: the deprecated discord-specific column is left
+          // unset; outbound delivery reads `externalId`/`externalOrigin`.
+          discordChannelId: null,
+          externalIssueId: null,
+          externalPrId: null,
+          externalId: externalThreadId,
+          externalOrigin: provider,
+          externalMetadataStr: threadDescriptor.externalMetadata
+            ? JSON.stringify(threadDescriptor.externalMetadata)
+            : null,
+          shortId,
+        });
+
+        await trx.message.insert({
+          id: ulid().toLowerCase(),
+          authorId,
+          content,
+          threadId,
+          createdAt: message.createdAt,
+          origin: provider,
+          externalMessageId: message.externalMessageId,
+          isBackfill,
+        });
+
+        const thread = await trx.findOne(schema.thread, threadId);
+
+        return { thread, created: true };
+      });
+    },
+  ),
+}));

--- a/connectors/discord/src/index.ts
+++ b/connectors/discord/src/index.ts
@@ -11,17 +11,16 @@ import {
   type TextChannel,
   type ThreadChannel,
 } from "discord.js";
-import { ulid } from "ulid";
 import "./env";
 import { reflagClient } from "./lib/feature-flag";
 import { fetchClient, store } from "./lib/live-state";
+import type { BackfillChannelResult } from "./lib/queue";
 import {
   addChannelBackfillJob,
   addThreadBackfillJob,
   closeBackfillQueue,
   initializeBackfillWorker,
 } from "./lib/queue";
-import type { BackfillChannelResult } from "./lib/queue";
 import {
   getBackfillLimit,
   parseContentAsMarkdown,
@@ -33,7 +32,8 @@ import {
 } from "./lib/utils";
 import { getOrCreateWebhook } from "./utils";
 
-const THREAD_CREATION_THRESHOLD_MS = 1000;
+/** Integration `type` / `support-entry-point` provider key for this connector. */
+const DISCORD_PROVIDER = "discord";
 
 const ensureThreadTitle = (title: string) =>
   title.length >= 3 ? title : title.padEnd(3, ".");
@@ -62,7 +62,6 @@ const buildPortalThreadUrl = (
   const port = baseUrlObj.port ? `:${baseUrlObj.port}` : "";
   return `${baseUrlObj.protocol}//${organizationSlug}.${baseUrlObj.hostname}${port}/threads/${threadId}`;
 };
-
 
 // TODO(signals-overhaul): related-threads polling used the dropped `suggestion`
 // table. Rebuild on top of the new pipeline (issue 06 synthesis or a fresh
@@ -114,13 +113,39 @@ const client = new Client({
   ],
 });
 
-const resolveDiscordAuthor = (
-  discordUserId: string,
-  displayName: string,
-): { id: string; name: string } => ({
-  id: `discord:${discordUserId}`,
-  name: displayName,
-});
+/**
+ * Translate a Discord message into a `support-entry-point` ingest call. The core
+ * owns create-vs-append, dedup, author identity and `provider:` prefixing; the
+ * connector only supplies neutral shapes plus the thread descriptor (Discord
+ * cheaply knows the channel title, so it is attached on every call and the core
+ * ignores it once the thread exists). Author display-name resolution stays here.
+ */
+const ingestDiscordMessage = (args: {
+  organizationId: string;
+  externalThreadId: string;
+  title: string;
+  message: Message;
+  isBackfill?: boolean;
+}) =>
+  fetchClient.mutate.ingest.ingest({
+    organizationId: args.organizationId,
+    provider: DISCORD_PROVIDER,
+    externalThreadId: args.externalThreadId,
+    thread: {
+      title: ensureThreadTitle(args.title),
+      externalMetadata: { channelId: args.externalThreadId },
+    },
+    message: {
+      externalMessageId: args.message.id,
+      body: parse(parseContentAsMarkdown(args.message)),
+      createdAt: args.message.createdAt,
+    },
+    author: {
+      externalId: args.message.author.id,
+      name: args.message.author.displayName,
+    },
+    isBackfill: args.isBackfill ?? false,
+  });
 
 /**
  * Backfill threads from a specific Discord channel (page-based)
@@ -156,7 +181,9 @@ const backfillChannel = async (
 
     // Check budget and queue thread jobs (all inside lock so total stays accurate if enqueue fails)
     const budgetExhausted = await withBackfillLock(integrationId, async () => {
-      const integration = await fetchClient.query.integration.byId({ id: integrationId });
+      const integration = await fetchClient.query.integration.byId({
+        id: integrationId,
+      });
       const currentSettings = safeParseIntegrationSettings(
         integration?.configStr ?? null,
       );
@@ -179,12 +206,16 @@ const backfillChannel = async (
       }
 
       const newTotal = currentTotal + threadsToQueue.length;
-      await updateBackfillStatus(integrationId, integration?.configStr ?? null, {
-        processed: existingBackfill?.processed ?? 0,
-        total: newTotal,
-        limit: existingBackfill?.limit ?? null,
-        channelsDiscovering: existingBackfill?.channelsDiscovering ?? 0,
-      });
+      await updateBackfillStatus(
+        integrationId,
+        integration?.configStr ?? null,
+        {
+          processed: existingBackfill?.processed ?? 0,
+          total: newTotal,
+          limit: existingBackfill?.limit ?? null,
+          channelsDiscovering: existingBackfill?.channelsDiscovering ?? 0,
+        },
+      );
 
       return limit !== null && newTotal >= limit;
     });
@@ -194,7 +225,9 @@ const backfillChannel = async (
     if (!hasMoreArchived || budgetExhausted) {
       // This channel is done discovering — decrement channelsDiscovering
       await withBackfillLock(integrationId, async () => {
-        const integration = await fetchClient.query.integration.byId({ id: integrationId });
+        const integration = await fetchClient.query.integration.byId({
+          id: integrationId,
+        });
         const settings = safeParseIntegrationSettings(
           integration?.configStr ?? null,
         );
@@ -242,7 +275,9 @@ const backfillChannel = async (
     console.error(`    Error fetching threads from #${channel.name}:`, error);
     // Decrement channelsDiscovering on error so backfill can complete
     await withBackfillLock(integrationId, async () => {
-      const integration = await fetchClient.query.integration.byId({ id: integrationId });
+      const integration = await fetchClient.query.integration.byId({
+        id: integrationId,
+      });
       const settings = safeParseIntegrationSettings(
         integration?.configStr ?? null,
       );
@@ -300,7 +335,9 @@ const handleIntegrationChanges = async (
       // Migration: if syncedChannels is undefined, initialize from current selectedChannels
       // This prevents false trigger on first deploy with new code
       if (settings.syncedChannels === undefined) {
-        const latestIntegration = await fetchClient.query.integration.byId({ id: integration.id });
+        const latestIntegration = await fetchClient.query.integration.byId({
+          id: integration.id,
+        });
         await updateSyncedChannels(
           integration.id,
           latestIntegration?.configStr ?? integration.configStr,
@@ -327,7 +364,9 @@ const handleIntegrationChanges = async (
       if (addedChannels.length === 0) {
         // Persist cleanup only (no new channels to add)
         if (hadCleanup) {
-          const latestIntegration = await fetchClient.query.integration.byId({ id: integration.id });
+          const latestIntegration = await fetchClient.query.integration.byId({
+            id: integration.id,
+          });
           await updateSyncedChannels(
             integration.id,
             latestIntegration?.configStr ?? null,
@@ -339,7 +378,9 @@ const handleIntegrationChanges = async (
 
       // Consolidate cleanup + add into a single update; use fresh config to avoid overwriting concurrent changes
       const finalSynced = [...syncedChannels, ...addedChannels];
-      const latestIntegration = await fetchClient.query.integration.byId({ id: integration.id });
+      const latestIntegration = await fetchClient.query.integration.byId({
+        id: integration.id,
+      });
       const freshConfigStr = latestIntegration?.configStr ?? null;
 
       // Check if backfill feature is enabled for this organization
@@ -351,11 +392,7 @@ const handleIntegrationChanges = async (
           `[Discord] Backfill disabled via feature flag, skipping ${addedChannels.length} channel(s)`,
         );
         // Still mark as synced so we don't re-check on restart
-        await updateSyncedChannels(
-          integration.id,
-          freshConfigStr,
-          finalSynced,
-        );
+        await updateSyncedChannels(integration.id, freshConfigStr, finalSynced);
         continue;
       }
 
@@ -374,21 +411,22 @@ const handleIntegrationChanges = async (
 
       // Add new channels to syncedChannels immediately (at backfill START)
       // BullMQ handles retries for in-progress jobs
-      await updateSyncedChannels(
-        integration.id,
-        freshConfigStr,
-        finalSynced,
-      );
+      await updateSyncedChannels(integration.id, freshConfigStr, finalSynced);
 
       // Initialize/accumulate backfill status
       await withBackfillLock(integration.id, async () => {
-        const latestIntegration = await fetchClient.query.integration.byId({ id: integration.id });
+        const latestIntegration = await fetchClient.query.integration.byId({
+          id: integration.id,
+        });
         const latestSettings = safeParseIntegrationSettings(
           latestIntegration?.configStr ?? null,
         );
         const existingBackfill = latestSettings?.backfill;
 
-        const channelsToQueue: { channel: TextChannel | ForumChannel; name: string }[] = [];
+        const channelsToQueue: {
+          channel: TextChannel | ForumChannel;
+          name: string;
+        }[] = [];
         for (const channelName of addedChannels) {
           const channel = guild.channels.cache.find(
             (c): c is TextChannel | ForumChannel =>
@@ -435,23 +473,16 @@ const handleIntegrationChanges = async (
 };
 
 /**
- * Backfill a single thread and its messages
+ * Backfill a single thread and its messages through `mutate.ingest`. The ingest
+ * procedure is idempotent (create-vs-append + `externalMessageId` dedup owned by
+ * the core), so this one path covers both a first-time thread and a re-added
+ * channel — no connector-side `byExternalId` checks. Status (Discord archived →
+ * FrontDesk Closed) stays a separate generic `thread.setStatus` mutation.
  */
 const backfillThread = async (
   thread: ThreadChannel,
   organizationId: string,
 ) => {
-  // Check if thread already exists in the database using externalId
-  const existingThread = await fetchClient.query.thread.byExternalId({ externalId: thread.id, organizationId });
-
-  if (existingThread) {
-    // Thread exists (re-added channel), sync status and backfill missing messages
-    await backfillMessages(thread, existingThread, organizationId);
-    return;
-  }
-
-  console.log(`      Creating thread: ${thread.name}`);
-
   // Fetch all messages with pagination
   const allMessages: Message[] = [];
   let lastMessageId: string | undefined;
@@ -468,166 +499,57 @@ const backfillThread = async (
       lastMessageId = batch.last()?.id;
     }
   }
-  const sortedMessages = allMessages.sort(
-    (a, b) => a.createdTimestamp - b.createdTimestamp,
-  );
+  const sortedMessages = allMessages
+    .filter((m) => !m.author.bot)
+    .sort((a, b) => a.createdTimestamp - b.createdTimestamp);
 
   if (sortedMessages.length === 0) {
     console.log(`      Skipping thread with no messages: ${thread.name}`);
     return;
   }
 
-  // Get the first non-bot message author as the thread author
-  const firstMessage =
-    sortedMessages.find((m) => !m.author.bot) ?? sortedMessages[0];
-  const author = resolveDiscordAuthor(
-    firstMessage.author.id,
-    firstMessage.author.displayName,
-  );
-
-  const threadId = ulid().toLowerCase();
-  const firstContent = parseContentAsMarkdown(firstMessage);
-
-  await fetchClient.mutate.thread.create({
-    id: threadId,
-    organizationId,
-    title: ensureThreadTitle(thread.name),
-    message: parse(firstContent),
-    author,
-    createdAt: thread.createdAt ?? new Date(),
-    status: thread.archived ? 3 : 0,
-    discordChannelId: thread.id,
-    externalId: thread.id,
-    externalOrigin: "discord",
-    externalMetadataStr: JSON.stringify({ channelId: thread.id }),
-    firstMessage: {
-      createdAt: firstMessage.createdAt,
-      origin: "discord",
-      isBackfill: true,
-      externalMessageId: firstMessage.id,
-    },
-  });
-
+  // Ingest in chronological order: the first call creates the thread (with the
+  // first non-bot message as its root author), the rest append. The core dedups
+  // any already-ingested message, so re-added channels only add what's missing.
+  let frontdeskThreadId: string | null = null;
+  let currentStatus = 0;
   for (const message of sortedMessages) {
-    if (message.id === firstMessage.id) continue;
-    if (message.author.bot) continue;
-
-    await backfillMessage(message, threadId, organizationId);
+    const { thread: fdThread } = await ingestDiscordMessage({
+      organizationId,
+      externalThreadId: thread.id,
+      title: thread.name,
+      message,
+      isBackfill: true,
+    });
+    if (fdThread) {
+      frontdeskThreadId = fdThread.id;
+      currentStatus = fdThread.status;
+    }
   }
 
-  console.log(
-    `      Synced ${sortedMessages.filter((m) => !m.author.bot).length} messages`,
-  );
-};
-
-/**
- * Backfill messages for an existing thread (check for missing messages)
- * Also syncs thread status between Discord and FrontDesk
- * Used when a channel is re-added to an integration
- */
-const backfillMessages = async (
-  thread: ThreadChannel,
-  existingThread: { id: string; status: number },
-  organizationId: string,
-) => {
-  // Sync thread status: Discord archived = FrontDesk Closed (3), active = Open (0)
+  // Sync status only between Open (0) and Closed (3); preserve In Progress (1)
+  // and Resolved (2). `currentStatus` reflects the thread's state before this
+  // backfill's inserts (0 for a freshly created thread).
   const expectedStatus = thread.archived ? 3 : 0;
-  const currentStatus = existingThread.status;
-
-  // Only sync between Open (0) and Closed (3), preserve other statuses like In Progress (1) or Resolved (2)
   if (
-    (currentStatus === 0 && expectedStatus === 3) ||
-    (currentStatus === 3 && expectedStatus === 0)
+    frontdeskThreadId &&
+    ((currentStatus === 0 && expectedStatus === 3) ||
+      (currentStatus === 3 && expectedStatus === 0))
   ) {
-    console.log(
-      `      Updating thread status: ${thread.name} (${currentStatus} → ${expectedStatus})`,
-    );
     await fetchClient.mutate.thread.setStatus({
-      threadId: existingThread.id,
+      threadId: frontdeskThreadId,
       organizationId,
       status: expectedStatus,
       source: "discord",
     });
   }
 
-  // Fetch all messages with pagination
-  const allMessages: Message[] = [];
-  let lastMsgId: string | undefined;
-  let hasMoreMsgs = true;
-  while (hasMoreMsgs) {
-    const batch = await thread.messages.fetch({
-      limit: 100,
-      ...(lastMsgId ? { before: lastMsgId } : {}),
-    });
-    if (batch.size === 0) {
-      hasMoreMsgs = false;
-    } else {
-      allMessages.push(...batch.values());
-      lastMsgId = batch.last()?.id;
-    }
-  }
-  const sortedMessages = allMessages.sort(
-    (a, b) => a.createdTimestamp - b.createdTimestamp,
-  );
-
-  let syncedCount = 0;
-  for (const message of sortedMessages) {
-    if (message.author.bot) continue;
-
-    // Check if message already exists in the database
-    const existingMessage = await fetchClient.query.message.byExternalId({ externalMessageId: message.id });
-
-    if (!existingMessage) {
-      await backfillMessage(message, existingThread.id, organizationId);
-      syncedCount++;
-    }
-  }
-
-  if (syncedCount > 0) {
-    console.log(
-      `      Synced ${syncedCount} missing messages for thread: ${thread.name}`,
-    );
-  }
-};
-
-/**
- * Backfill a single message
- */
-const backfillMessage = async (
-  message: Message,
-  threadId: string,
-  organizationId: string,
-) => {
-  const author = resolveDiscordAuthor(
-    message.author.id,
-    message.author.displayName,
-  );
-  const contentWithMentions = parseContentAsMarkdown(message);
-
-  await fetchClient.mutate.message.create({
-    id: ulid().toLowerCase(),
-    threadId,
-    organizationId,
-    author,
-    content: parse(contentWithMentions),
-    createdAt: message.createdAt,
-    origin: "discord",
-    isBackfill: true,
-    externalMessageId: message.id,
-  });
+  console.log(`      Synced ${sortedMessages.length} messages`);
 };
 
 client.on("messageCreate", async (message) => {
   if (!message.channel.isThread() || message.author.bot || !message.guild?.id)
     return;
-
-  const isFirstMessage =
-    Math.abs(
-      (message.channel.createdTimestamp ?? 0) - (message.createdTimestamp ?? 0),
-    ) < THREAD_CREATION_THRESHOLD_MS;
-
-  let threadId: string | null = null;
-  let portalMessageOrgSlug: string | null = null;
 
   const integration = (
     await fetchClient.query.integration.listByType({ type: "discord" })
@@ -649,37 +571,25 @@ client.on("messageCreate", async (message) => {
   )
     return;
 
-  // TODO do this in a transaction
+  // One idempotent ingest call: the core creates the thread on the first message
+  // for this channel and appends thereafter (no timing heuristic, no dedup here).
+  const { thread, created } = await ingestDiscordMessage({
+    organizationId: integration.organizationId,
+    externalThreadId: message.channel.id,
+    title: message.channel.name,
+    message,
+  });
 
-  const author = resolveDiscordAuthor(
-    message.author.id,
-    message.author.displayName,
-  );
+  if (!thread) return;
+  const threadId = thread.id;
 
-  if (isFirstMessage) {
-    threadId = ulid().toLowerCase();
-    const contentWithMentions = parseContentAsMarkdown(message);
-
-    await fetchClient.mutate.thread.create({
-      id: threadId,
-      organizationId: integration.organizationId,
-      title: ensureThreadTitle(message.channel.name),
-      message: parse(contentWithMentions),
-      author,
-      createdAt: new Date(),
-      discordChannelId: message.channel.id,
-      externalId: message.channel.id,
-      externalOrigin: "discord",
-      externalMetadataStr: JSON.stringify({ channelId: message.channel.id }),
-      firstMessage: {
-        createdAt: message.createdAt,
-        origin: "discord",
-        externalMessageId: message.id,
-      },
-    });
-
+  // The portal-link embed is posted once, when the thread is first created.
+  let portalMessageOrgSlug: string | null = null;
+  if (created) {
     try {
-      const organization = await fetchClient.query.organization.byId({ id: integration.organizationId });
+      const organization = await fetchClient.query.organization.byId({
+        id: integration.organizationId,
+      });
 
       if (organization?.slug) {
         const showPortalMessage =
@@ -694,35 +604,9 @@ client.on("messageCreate", async (message) => {
     } catch (error) {
       console.error("Error sending portal link message:", error);
     }
-  } else {
-    const thread = store.query.thread
-      .first({
-        discordChannelId: message.channel.id,
-        organizationId: integration.organizationId,
-      })
-      .get();
-
-    if (!thread) return;
-    threadId = thread.id;
   }
 
-  if (!threadId) return;
-
-  if (!isFirstMessage) {
-    const contentWithMentions = parseContentAsMarkdown(message);
-
-    store.mutate.message.create({
-      threadId,
-      organizationId: integration.organizationId,
-      author,
-      content: parse(contentWithMentions),
-      createdAt: message.createdAt,
-      origin: "discord",
-      externalMessageId: message.id,
-    });
-  }
-
-  if (isFirstMessage && portalMessageOrgSlug) {
+  if (portalMessageOrgSlug) {
     const baseUrl = process.env.BASE_URL ?? "https://tryfrontdesk.app";
     const portalUrl = buildPortalThreadUrl(
       baseUrl,
@@ -780,7 +664,10 @@ const handleMessages = async (
     // TODO this is not consistent, either we make this part of the include or we wait until the store is bootstrapped. Remove the timeout when this is fixed.
     const organizationId = message.thread?.organizationId;
     if (!organizationId) continue;
-    const integration = await fetchClient.query.integration.forOrg({ organizationId, type: "discord" });
+    const integration = await fetchClient.query.integration.forOrg({
+      organizationId,
+      type: "discord",
+    });
 
     if (!integration || !integration.configStr) continue;
 
@@ -792,7 +679,13 @@ const handleMessages = async (
 
     if (!guildId) continue;
 
-    const channelId = message.thread.discordChannelId;
+    // The Discord channel id lives on `externalId` (guarded by `externalOrigin`),
+    // no longer on the deprecated `discordChannelId` column that ingest stopped
+    // writing.
+    const channelId =
+      message.thread.externalOrigin === "discord"
+        ? message.thread.externalId
+        : null;
 
     if (!channelId) continue;
 
@@ -885,7 +778,10 @@ const handleUpdates = async (
       // TODO this is not consistent, either we make this part of the include or we wait until the store is bootstrapped. Remove the timeout when this is fixed.
       const organizationId = update.thread?.organizationId;
       if (!organizationId) continue;
-      const integration = await fetchClient.query.integration.forOrg({ organizationId, type: "discord" });
+      const integration = await fetchClient.query.integration.forOrg({
+        organizationId,
+        type: "discord",
+      });
 
       if (!integration || !integration.configStr) continue;
 
@@ -897,7 +793,10 @@ const handleUpdates = async (
 
       if (!guildId) continue;
 
-      const channelId = update.thread.discordChannelId;
+      const channelId =
+        update.thread.externalOrigin === "discord"
+          ? update.thread.externalId
+          : null;
 
       if (!channelId) continue;
 
@@ -981,7 +880,9 @@ client.once("ready", async () => {
     processThread: backfillThread,
     onThreadBackfillComplete: async (integrationId: string) => {
       await withBackfillLock(integrationId, async () => {
-        const integration = await fetchClient.query.integration.byId({ id: integrationId });
+        const integration = await fetchClient.query.integration.byId({
+          id: integrationId,
+        });
         const settings = safeParseIntegrationSettings(
           integration?.configStr ?? null,
         );
@@ -1021,7 +922,8 @@ setTimeout(async () => {
       .where({
         externalMessageId: null,
         thread: {
-          discordChannelId: { $not: null },
+          externalOrigin: "discord",
+          externalId: { $not: null },
         },
       })
       .include({ thread: true, author: { include: { user: true } } })
@@ -1031,7 +933,8 @@ setTimeout(async () => {
     .where({
       externalMessageId: null,
       thread: {
-        discordChannelId: { $not: null },
+        externalOrigin: "discord",
+        externalId: { $not: null },
       },
     })
     .include({ thread: true, author: { include: { user: true } } })
@@ -1041,7 +944,8 @@ setTimeout(async () => {
   const updates = await store.query.update
     .where({
       thread: {
-        discordChannelId: { $not: null },
+        externalOrigin: "discord",
+        externalId: { $not: null },
       },
     })
     .include({ thread: true, user: true })
@@ -1051,7 +955,8 @@ setTimeout(async () => {
   store.query.update
     .where({
       thread: {
-        discordChannelId: { $not: null },
+        externalOrigin: "discord",
+        externalId: { $not: null },
       },
     })
     .include({ thread: true, user: true })

--- a/connectors/framework/src/capabilities.ts
+++ b/connectors/framework/src/capabilities.ts
@@ -24,6 +24,82 @@ export const isCapability = (value: string): value is Capability =>
   (CAPABILITIES as readonly string[]).includes(value);
 
 /**
+ * `support-entry-point` capability — the emitting leg (connector → core).
+ *
+ * A connector translates a provider event into these neutral shapes and calls
+ * the core's `mutate.ingest` procedure. The core owns normalization: idempotent
+ * create-vs-append keyed on `(organizationId, externalThreadId,
+ * externalMessageId)`, author find-or-create, and the `provider:` prefixing
+ * convention. The connector keeps only the un-liftable provider work — event
+ * translation and resolving a raw user id → display name.
+ *
+ * See `docs/adr/0009-emitting-side-connector-retrofit.md`.
+ */
+
+/** Neutral author identity. `externalId` is the raw provider user id (the core
+ * prefixes it with `provider:` to form the author `metaId`); the connector
+ * resolves `name` from the provider. */
+export const supportEntryPointAuthorSchema = z.object({
+  externalId: z.string().min(1),
+  name: z.string().min(1),
+  avatarUrl: z.string().optional(),
+});
+
+export type SupportEntryPointAuthor = z.infer<
+  typeof supportEntryPointAuthorSchema
+>;
+
+/**
+ * Creation-only thread descriptor. Optional: the core decides create-vs-append
+ * by whether a thread already exists for `externalThreadId`, so on an append the
+ * descriptor is ignored. It is required (its `title`) the first time an external
+ * thread is seen — the core hard-errors on an unknown external thread with no
+ * descriptor rather than create a titleless thread.
+ */
+export const supportEntryPointThreadSchema = z.object({
+  title: z.string().min(1),
+  externalMetadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type SupportEntryPointThread = z.infer<
+  typeof supportEntryPointThreadSchema
+>;
+
+/** A single inbound message. `body` is TipTap JSON or a plain string; the core
+ * serializes it for storage. */
+export const supportEntryPointMessageSchema = z.object({
+  externalMessageId: z.string().min(1),
+  body: z.union([z.string(), z.any()]),
+  createdAt: z.coerce.date(),
+});
+
+export type SupportEntryPointMessage = z.infer<
+  typeof supportEntryPointMessageSchema
+>;
+
+/**
+ * The full `ingest` payload. `externalThreadId` is always present — it is both
+ * the append target and part of the idempotency key — while the richer `thread`
+ * descriptor is attached only for creation. `isBackfill` suppresses downstream
+ * pipeline triggers only; it does not change normalization.
+ */
+export const supportEntryPointIngestSchema = z.object({
+  organizationId: z.string().min(1),
+  /** Integration `type` of the emitting connector, e.g. `"discord"`. Becomes
+   * the thread's `externalOrigin` and the author `metaId` prefix. */
+  provider: z.string().min(1),
+  externalThreadId: z.string().min(1),
+  thread: supportEntryPointThreadSchema.optional(),
+  message: supportEntryPointMessageSchema,
+  author: supportEntryPointAuthorSchema,
+  isBackfill: z.boolean().default(false),
+});
+
+export type SupportEntryPointIngestPayload = z.infer<
+  typeof supportEntryPointIngestSchema
+>;
+
+/**
  * `issue-tracker` capability — invoked method contracts.
  *
  * `create`: open a new issue on a target sub-resource. The `target` is an

--- a/connectors/framework/src/capabilities.ts
+++ b/connectors/framework/src/capabilities.ts
@@ -69,8 +69,14 @@ export type SupportEntryPointThread = z.infer<
  * serializes it for storage. */
 export const supportEntryPointMessageSchema = z.object({
   externalMessageId: z.string().min(1),
-  body: z.union([z.string(), z.any()]),
-  createdAt: z.coerce.date(),
+  // Plain string or TipTap JSON; require it to be present so a malformed event
+  // is rejected instead of persisted as the literal string "undefined".
+  body: z.unknown().refine((value) => value !== undefined, {
+    message: "body is required",
+  }),
+  // Accept a Date (in-process) or string (over the wire); reject null so a
+  // malformed event is not coerced to the Unix epoch and misordered.
+  createdAt: z.union([z.date(), z.string()]).pipe(z.coerce.date()),
 });
 
 export type SupportEntryPointMessage = z.infer<

--- a/connectors/framework/src/index.ts
+++ b/connectors/framework/src/index.ts
@@ -12,6 +12,14 @@ export {
   type NormalizedIssue,
   type PrTrackerLinkPayload,
   prTrackerLinkPayloadSchema,
+  type SupportEntryPointAuthor,
+  type SupportEntryPointIngestPayload,
+  type SupportEntryPointMessage,
+  type SupportEntryPointThread,
+  supportEntryPointAuthorSchema,
+  supportEntryPointIngestSchema,
+  supportEntryPointMessageSchema,
+  supportEntryPointThreadSchema,
 } from "./capabilities";
 export {
   CAPABILITY_INVOKE_PATH,
@@ -23,6 +31,7 @@ export {
 } from "./invoke";
 export {
   type ConnectorManifest,
+  discordManifest,
   githubManifest,
   manifests,
   typesHaveCapability,

--- a/connectors/framework/src/manifest.ts
+++ b/connectors/framework/src/manifest.ts
@@ -28,8 +28,22 @@ export const githubManifest: ConnectorManifest = {
   defaultBaseUrl: "http://localhost:3334",
 };
 
+/**
+ * Discord connector manifest. Declares the emitting `support-entry-point`
+ * capability. Discord is emitting-only (it runs as a gateway bot and delivers
+ * outbound via pull-based replication, per ADR-0009), so it exposes no invoke
+ * HTTP endpoint; `baseUrlEnv`/`defaultBaseUrl` are unused for it and kept only
+ * to satisfy the shared manifest shape.
+ */
+export const discordManifest: ConnectorManifest = {
+  type: "discord",
+  capabilities: ["support-entry-point"],
+  baseUrlEnv: "BASE_DISCORD_SERVER_URL",
+  defaultBaseUrl: "http://localhost:3335",
+};
+
 /** All known connector manifests. */
-export const manifests: ConnectorManifest[] = [githubManifest];
+export const manifests: ConnectorManifest[] = [githubManifest, discordManifest];
 
 /**
  * The integration `type`s whose manifest declares `capability`. Pure and

--- a/docs/adr/0009-emitting-side-connector-retrofit.md
+++ b/docs/adr/0009-emitting-side-connector-retrofit.md
@@ -1,0 +1,33 @@
+# Emitting-side connector retrofit (support-entry-point ingest)
+
+Builds on [ADR-0008](./0008-connector-capability-framework.md), which proved the **invoked** leg (core → connector, HTTP) by retrofitting GitHub. This ADR records the decisions for the **emitting** leg — retrofitting Discord and Slack onto the `support-entry-point` capability — which 0008 deliberately deferred as "a later follow-up, once the ingest contract is proven against real code."
+
+Tracked as a sibling mini-project to FRO-190 (not more children of it): FRO-190 stays "GitHub-first, invoked side, done"; this work depends on it.
+
+## Status
+
+accepted
+
+## Decisions
+
+- **Ingest is a live-state custom mutation procedure, not HTTP.** The two capability legs are genuinely asymmetric: the invoked leg is HTTP because it is core → connector, but ingest is connector → core, where the connectors are already live-state clients. A typed `mutate.ingest(...)` procedure gives the API server-side ownership of normalization while preserving real-time sync and the typed client. Forcing HTTP symmetry on the inbound leg buys nothing real and would stand up a second inbound transport + auth surface.
+
+- **One idempotent `ingest` call; the framework owns create-vs-append.** The connector no longer branches on "is this the first message" (killing the fragile `THREAD_CREATION_THRESHOLD_MS` timing heuristic) and no longer does its own `byExternalId` dedup. `ingest({ thread?, message, author, isBackfill })` is idempotent on `(organizationId, externalThreadId, externalMessageId)`: if no thread exists for the external thread → create using the `thread` descriptor + this message as first; else → append, deduped on `externalMessageId`.
+
+- **The `thread` descriptor is optional; the connector decides when to attach it; the framework hard-errors on a missing thread for an unknown external thread.** Provider-specific "is this a thread root?" logic (Discord thread-name resolution, Slack root detection) stays in the connector. If a message arrives for an external thread the framework doesn't know *and* carries no thread descriptor, ingest fails loudly rather than silently creating a titleless thread — surfacing connector bugs instead of corrupting data.
+
+- **The framework owns author identity.** Ingest takes a neutral `author: { externalId, name, avatarUrl? }`; the API owns author-row find-or-create/dedup on `(organizationId, metaId)` and the `provider:` prefixing convention. Only the un-liftable provider call — resolving a raw user id → display name (Slack's async API lookup, Discord's `displayName`) — stays in the connector.
+
+- **The deliver leg (outbound) stays pull-based replication, deviating from 0008.** ADR-0008 phrased the outbound mirror as "a normalized `deliver` interface the framework *calls on* the origin connector" (push). We keep the existing pull model instead: the connector holds a live-state subscription, watches for un-replicated outbound messages/updates, delivers them, and round-trips the external message id. The framework provides a normalized outbound-subscription helper so connectors don't each re-implement the polling. Consequence: `support-entry-point` has two permanent outbound mechanisms relative to the invoked capabilities, and FRO-195's durable dispatch does **not** cover replies. This is a deliberate trade to avoid rewriting the load-bearing `update`/`markReplicated` path and to avoid forcing an invoke HTTP endpoint onto the standalone gateway/bolt apps. **Supersedes the push-deliver implication of ADR-0008 for `support-entry-point`.**
+
+- **Shared connector runtime lifts into a node-only subpath of `@connectors/framework`.** `@connectors/framework` stays dependency-free and browser-safe (the web client imports its manifest for gating, per FRO-194). Node-only runtime scaffolding — live-state client bootstrap, redis/BullMQ queue factory, feature-flag client, backfill orchestration, portal-URL builder, integration-settings parsing, and the outbound-subscription helper — lifts into a `@connectors/framework/runtime` subpath export. Browser safety is preserved by the export map (browser imports only `.`); a whole separate package would add ceremony for no gain.
+
+- **`notification-center` is out of scope.** It is a different theme (a brand-new invoked capability, the first invoke HTTP endpoint on a standalone connector, and formalizing the digest path) and is deferred to its own follow-up — same discipline that kept FRO-190 GitHub-first.
+
+## Consequences
+
+- Discord and Slack shrink to "translate provider event ↔ normalized ingest args"; the ingest/dedup/identity logic centralizes in the API.
+- The deprecated `thread.discordChannelId` column is dropped: ingest stops writing it, and the pull-deliver path migrates its channel-lookup reads to `externalId` (guarded by `externalOrigin`).
+- Backfill jobs stay in the connectors (integration apps own their jobs) but route through the same `mutate.ingest(..., isBackfill: true)`; `isBackfill` only suppresses downstream pipeline triggers.
+- Inbound status (Discord archived → thread closed) stays a plain generic `thread.setStatus({ source })` mutation — already provider-neutral, not folded into ingest.
+- Rollout: (1) ingest contract + Discord tracer bullet, (2) Slack onto ingest, (3) runtime scaffolding lift, (4) drop `discordChannelId`.


### PR DESCRIPTION
## What & why

The tracer bullet for the emitting-side connector retrofit ([ADR-0009](../blob/main/docs/adr/0009-emitting-side-connector-retrofit.md)). Introduces the `support-entry-point` ingest contract and cuts the inbound-heavy connector (Discord) onto it, proving normalization end-to-end. Closes FRO-197.

## Changes

**`@connectors/framework`** (root, browser-safe)
- Added the `support-entry-point` ingest schemas: neutral `author { externalId, name, avatarUrl? }`, optional creation-only `thread { title, externalMetadata? }`, `message { externalMessageId, body, createdAt }`, and the top-level `ingest` payload.
- Added `discordManifest` declaring `support-entry-point`, registered in `manifests` (so web capability gating now recognizes Discord).

**API — `mutate.ingest`**
- New internal-key-gated custom mutation procedure. In one transaction it owns: **idempotent** upsert on `(organizationId, externalThreadId, externalMessageId)`; **create-vs-append** by existing-thread lookup (no connector-side "is this the first message?" guess); a **hard-error** on an unknown external thread with no descriptor (no silent titleless threads); author find-or-create/dedup on `(organizationId, metaId)` with `provider:` prefixing. `isBackfill` is written onto message rows only — it influences downstream pipeline triggers via the existing message hook, not normalization. Returns `{ thread, created }`.

**Discord connector**
- Live `messageCreate` and backfill both route through a single `ingestDiscordMessage` → `mutate.ingest`. Author display-name resolution stays local.
- Deleted the `THREAD_CREATION_THRESHOLD_MS` timing heuristic, connector-side `byExternalId` dedup, and the separate `backfillMessages`/`backfillMessage` paths.
- Migrated the pull-deliver (outbound) reads off the now-unwritten `discordChannelId` onto `externalId` guarded by `externalOrigin: "discord"`, so ingest-created threads still receive outbound replies/updates.

## Design note / deviation

The issue phrased the descriptor as `{ externalThreadId, title, externalMetadata? }`. In the implementation `externalThreadId` sits at the **top level** of the payload rather than inside the optional descriptor — it is both the append target and part of the idempotency key, so it must be present even when no descriptor is attached. The optional `thread` descriptor carries only the creation-only `title`/`externalMetadata`. Documented inline.

## Done-when check

Creating and replying in a Discord thread produces threads/messages via `mutate.ingest` with **zero** `thread.create`/`message.create` calls in the connector; backfill uses the same path. ✅ verified by grep.

## Verification

`typecheck` + `biome` clean across `@connectors/framework`, `api`, `discord`, and `web`. Not yet driven against a live Discord thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce the emitting-side `support-entry-point` ingest flow and switch the Discord connector to it, centralizing normalization in the API. Adds provider-scoped lookup and stricter message validation; proves end-to-end ingest for FRO-197.

- **New Features**
  - `@connectors/framework`: add neutral ingest schemas (`author`, `thread`, `message`) and `discordManifest` declaring `support-entry-point`.
  - API: new internal-key-gated `mutate.ingest` with idempotent upsert on `(organizationId, externalThreadId, externalMessageId)`; owns create-vs-append, author dedup; returns `{ thread, created }`.
  - Discord: live `messageCreate` and backfill route through `mutate.ingest`; portal link posts once on first creation; status sync remains via `thread.setStatus`.

- **Refactors**
  - Scoped ingest thread lookup by `provider` to prevent cross-connector id collisions; hardened message schema to require `body` and a valid `createdAt`.
  - Removed `THREAD_CREATION_THRESHOLD_MS`, connector-side `byExternalId` dedup, and split backfill paths.
  - Outbound delivery reads now use `externalId` guarded by `externalOrigin: "discord"`; stop writing `discordChannelId`.
  - Added ADR-0009 documenting the emitting-side retrofit.

<sup>Written for commit 9c236000e733ae65e5e06dd907db82b6f0799a6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standardized connector-to-support ingestion flow for creating and updating conversations via an ingest endpoint.
  * Discord messages can now automatically create or append to support threads with author details and channel context.
  * Added Discord connector discovery and capability support (including typed ingestion payload definitions).
* **Bug Fixes**
  * Prevented duplicate threads and messages by making ingestion idempotent across live ingestion and backfills.
  * Improved Discord ↔ support thread status synchronization and streamlined downstream event delivery.
* **Documentation**
  * Documented the connector ingestion and synchronization architecture in a new ADR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->