### PR TITLE
feat(connectors): lift shared runtime scaffolding into @connectors/framework/runtime (FRO-199)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -202,6 +202,7 @@
       "name": "discord",
       "version": "0.0.0",
       "dependencies": {
+        "@connectors/framework": "workspace:*",
         "@live-state/sync": "catalog:",
         "@reflag/node-sdk": "^1.1.0",
         "@workspace/schemas": "workspace:*",
@@ -223,12 +224,22 @@
       "name": "@connectors/framework",
       "version": "0.0.0",
       "dependencies": {
+        "@live-state/sync": "catalog:",
+        "@reflag/node-sdk": "^1.1.0",
+        "bullmq": "^5.67.1",
+        "ioredis": "^5.3.2",
         "zod": "catalog:",
       },
       "devDependencies": {
         "@types/node": "^22.15.2",
         "typescript": "^5.7.0",
       },
+      "peerDependencies": {
+        "api": "workspace:*",
+      },
+      "optionalPeers": [
+        "api",
+      ],
     },
     "connectors/github": {
       "name": "github",
@@ -259,6 +270,7 @@
       "name": "slack",
       "version": "0.0.0",
       "dependencies": {
+        "@connectors/framework": "workspace:*",
         "@live-state/sync": "catalog:",
         "@reflag/node-sdk": "^1.1.0",
         "@slack/bolt": "^4.6.0",
@@ -3797,7 +3809,7 @@
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
 
-    "uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "valibot": ["valibot@1.0.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-1Hc0ihzWxBar6NGeZv7fPLY0QuxFMyxwYR2sF1Blu7Wq7EnremwY2W02tit2ij2VJT8HcSkHAQqmFfl77f73Yw=="],
 
@@ -4619,6 +4631,8 @@
 
     "@smithy/middleware-retry/@smithy/util-middleware": ["@smithy/util-middleware@2.2.0", "", { "dependencies": { "@smithy/types": "^2.12.0", "tslib": "^2.6.2" } }, "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw=="],
 
+    "@smithy/middleware-retry/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
     "@smithy/node-http-handler/@smithy/protocol-http": ["@smithy/protocol-http@3.3.0", "", { "dependencies": { "@smithy/types": "^2.12.0", "tslib": "^2.6.2" } }, "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ=="],
 
     "@smithy/signature-v4/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
@@ -4683,6 +4697,8 @@
 
     "@trigger.dev/sdk/ulid": ["ulid@2.4.0", "", { "bin": { "ulid": "bin/cli.js" } }, "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg=="],
 
+    "@trigger.dev/sdk/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
     "@types/body-parser/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
 
     "@types/connect/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
@@ -4730,8 +4746,6 @@
     "body-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "body-parser/raw-body": ["raw-body@2.5.3", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "unpipe": "~1.0.0" } }, "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA=="],
-
-    "bullmq/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "bun-types/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
 
@@ -4830,8 +4844,6 @@
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
-
-    "mermaid/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "miniflare/acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
 

--- a/connectors/discord/package.json
+++ b/connectors/discord/package.json
@@ -26,6 +26,7 @@
     "node": ">=20.18.0"
   },
   "dependencies": {
+    "@connectors/framework": "workspace:*",
     "@reflag/node-sdk": "^1.1.0",
     "@live-state/sync": "catalog:",
     "api": "workspace:*",

--- a/connectors/discord/src/index.ts
+++ b/connectors/discord/src/index.ts
@@ -1,7 +1,11 @@
-import type { InferLiveObject } from "@live-state/sync";
+import {
+  buildPortalThreadUrl,
+  type OutboundMessage,
+  type OutboundUpdate,
+  startOutboundReplication,
+} from "@connectors/framework/runtime";
 import { parse } from "@workspace/utils/md-tiptap";
 import { stringify } from "@workspace/utils/tiptap-md";
-import type { schema } from "api/schema";
 import {
   ChannelType,
   Client,
@@ -52,16 +56,6 @@ const sleep = (ms: number) =>
   new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
-
-const buildPortalThreadUrl = (
-  baseUrl: string,
-  organizationSlug: string,
-  threadId: string,
-) => {
-  const baseUrlObj = new URL(baseUrl);
-  const port = baseUrlObj.port ? `:${baseUrlObj.port}` : "";
-  return `${baseUrlObj.protocol}//${organizationSlug}.${baseUrlObj.hostname}${port}/threads/${threadId}`;
-};
 
 // TODO(signals-overhaul): related-threads polling used the dropped `suggestion`
 // table. Rebuild on top of the new pipeline (issue 06 synthesis or a fresh
@@ -335,14 +329,7 @@ const handleIntegrationChanges = async (
       // Migration: if syncedChannels is undefined, initialize from current selectedChannels
       // This prevents false trigger on first deploy with new code
       if (settings.syncedChannels === undefined) {
-        const latestIntegration = await fetchClient.query.integration.byId({
-          id: integration.id,
-        });
-        await updateSyncedChannels(
-          integration.id,
-          latestIntegration?.configStr ?? integration.configStr,
-          [...currentChannels],
-        );
+        await updateSyncedChannels(integration.id, [...currentChannels]);
         continue;
       }
 
@@ -364,24 +351,13 @@ const handleIntegrationChanges = async (
       if (addedChannels.length === 0) {
         // Persist cleanup only (no new channels to add)
         if (hadCleanup) {
-          const latestIntegration = await fetchClient.query.integration.byId({
-            id: integration.id,
-          });
-          await updateSyncedChannels(
-            integration.id,
-            latestIntegration?.configStr ?? null,
-            [...syncedChannels],
-          );
+          await updateSyncedChannels(integration.id, [...syncedChannels]);
         }
         continue;
       }
 
-      // Consolidate cleanup + add into a single update; use fresh config to avoid overwriting concurrent changes
+      // Consolidate cleanup + add into a single update
       const finalSynced = [...syncedChannels, ...addedChannels];
-      const latestIntegration = await fetchClient.query.integration.byId({
-        id: integration.id,
-      });
-      const freshConfigStr = latestIntegration?.configStr ?? null;
 
       // Check if backfill feature is enabled for this organization
       const { isEnabled: isBackfillEnabled } = reflagClient
@@ -392,7 +368,7 @@ const handleIntegrationChanges = async (
           `[Discord] Backfill disabled via feature flag, skipping ${addedChannels.length} channel(s)`,
         );
         // Still mark as synced so we don't re-check on restart
-        await updateSyncedChannels(integration.id, freshConfigStr, finalSynced);
+        await updateSyncedChannels(integration.id, finalSynced);
         continue;
       }
 
@@ -411,7 +387,7 @@ const handleIntegrationChanges = async (
 
       // Add new channels to syncedChannels immediately (at backfill START)
       // BullMQ handles retries for in-progress jobs
-      await updateSyncedChannels(integration.id, freshConfigStr, finalSynced);
+      await updateSyncedChannels(integration.id, finalSynced);
 
       // Initialize/accumulate backfill status
       await withBackfillLock(integration.id, async () => {
@@ -654,76 +630,69 @@ client.on("messageCreate", async (message) => {
   }
 });
 
-const handleMessages = async (
-  messages: InferLiveObject<
-    (typeof schema)["message"],
-    { thread: true; author: { include: { user: true } } }
-  >[],
-) => {
-  for (const message of messages) {
-    // TODO this is not consistent, either we make this part of the include or we wait until the store is bootstrapped. Remove the timeout when this is fixed.
-    const organizationId = message.thread?.organizationId;
-    if (!organizationId) continue;
-    const integration = await fetchClient.query.integration.forOrg({
-      organizationId,
-      type: "discord",
+/**
+ * Resolve the Discord channel a normalized thread maps to, or `null` if this
+ * connector can't currently deliver to it (no matching guild in cache, etc.).
+ * The channel id lives on `thread.externalId` (guarded by `externalOrigin`),
+ * no longer on the deprecated `discordChannelId` column ingest stopped writing.
+ */
+const resolveDiscordChannel = async (thread: {
+  organizationId?: string;
+  externalOrigin?: string | null;
+  externalId?: string | null;
+}) => {
+  const organizationId = thread?.organizationId;
+  if (!organizationId) return null;
+
+  const integration = await fetchClient.query.integration.forOrg({
+    organizationId,
+    type: "discord",
+  });
+  if (!integration || !integration.configStr) return null;
+
+  const parsedConfig = safeParseIntegrationSettings(integration.configStr);
+  const guildId = parsedConfig?.guildId;
+  if (!guildId) return null;
+
+  const channelId =
+    thread.externalOrigin === "discord" ? thread.externalId : null;
+  if (!channelId) return null;
+
+  const guild = client.guilds.cache.get(guildId);
+  if (!guild) return null;
+
+  return guild.channels.cache.get(channelId) ?? null;
+};
+
+/**
+ * Deliver one outbound reply to Discord via the channel webhook. Returns the
+ * webhook message id to round-trip, or `null` to leave it for the next pass.
+ */
+const deliverDiscordMessage = async (
+  message: OutboundMessage,
+): Promise<string | null> => {
+  const channel = await resolveDiscordChannel(message.thread);
+  if (!channel) return null;
+
+  try {
+    const webhookClient = await getOrCreateWebhook(channel as TextChannel);
+    const webhookMessage = await webhookClient.send({
+      content: stringify(safeParseJSON(message.content), {
+        heading: true,
+        horizontalRule: true,
+      }),
+      threadId: channel.id,
+      username: message.author.name,
+      avatarURL: message.author?.user?.image ?? undefined,
     });
-
-    if (!integration || !integration.configStr) continue;
-
-    const parsedConfig = safeParseIntegrationSettings(integration.configStr);
-
-    if (!parsedConfig) continue;
-
-    const guildId = parsedConfig.guildId;
-
-    if (!guildId) continue;
-
-    // The Discord channel id lives on `externalId` (guarded by `externalOrigin`),
-    // no longer on the deprecated `discordChannelId` column that ingest stopped
-    // writing.
-    const channelId =
-      message.thread.externalOrigin === "discord"
-        ? message.thread.externalId
-        : null;
-
-    if (!channelId) continue;
-
-    const guild = client.guilds.cache.get(guildId);
-
-    if (!guild) continue;
-
-    const channel = guild.channels.cache.get(channelId);
-
-    if (!channel) continue;
-
-    try {
-      const webhookClient = await getOrCreateWebhook(channel as TextChannel);
-      const webhookMessage = await webhookClient.send({
-        content: stringify(safeParseJSON(message.content), {
-          heading: true,
-          horizontalRule: true,
-        }),
-        threadId: channel.id,
-        username: message.author.name,
-        avatarURL: message.author?.user?.image ?? undefined,
-      });
-      store.mutate.message.setExternalMessageId({
-        messageId: message.id,
-        externalMessageId: webhookMessage.id,
-      });
-    } catch (error) {
-      console.error("Error sending webhook message:", error);
-    }
+    return webhookMessage.id;
+  } catch (error) {
+    console.error("Error sending webhook message:", error);
+    return null;
   }
 };
 
-const formatUpdateMessage = (
-  update: InferLiveObject<
-    (typeof schema)["update"],
-    { thread: true; user: true }
-  >,
-): string => {
+const formatUpdateMessage = (update: OutboundUpdate): string => {
   let metadata: any = null;
   if (update.metadataStr) {
     try {
@@ -756,75 +725,21 @@ const formatUpdateMessage = (
   return `**${userName}** updated the thread`;
 };
 
-const handlingUpdates = new Set<string>();
+/**
+ * Deliver one outbound thread update to Discord as a bot message. Returns the
+ * message id to round-trip, or `null` to leave it un-replicated. The framework's
+ * outbound helper owns the replicated-check and in-flight dedup.
+ */
+const deliverDiscordUpdate = async (
+  update: OutboundUpdate,
+): Promise<string | null> => {
+  const channel = await resolveDiscordChannel(update.thread);
+  if (!channel) return null;
 
-const handleUpdates = async (
-  updates: InferLiveObject<
-    (typeof schema)["update"],
-    { thread: true; user: true }
-  >[],
-) => {
-  for (const update of updates) {
-    const replicated = update.replicatedStr
-      ? JSON.parse(update.replicatedStr)
-      : {};
-    if (replicated.discord) continue;
-
-    if (handlingUpdates.has(update.id)) continue;
-
-    handlingUpdates.add(update.id);
-
-    try {
-      // TODO this is not consistent, either we make this part of the include or we wait until the store is bootstrapped. Remove the timeout when this is fixed.
-      const organizationId = update.thread?.organizationId;
-      if (!organizationId) continue;
-      const integration = await fetchClient.query.integration.forOrg({
-        organizationId,
-        type: "discord",
-      });
-
-      if (!integration || !integration.configStr) continue;
-
-      const parsedConfig = safeParseIntegrationSettings(integration.configStr);
-
-      if (!parsedConfig) continue;
-
-      const guildId = parsedConfig.guildId;
-
-      if (!guildId) continue;
-
-      const channelId =
-        update.thread.externalOrigin === "discord"
-          ? update.thread.externalId
-          : null;
-
-      if (!channelId) continue;
-
-      const guild = client.guilds.cache.get(guildId);
-
-      if (!guild) continue;
-
-      const channel = guild.channels.cache.get(channelId);
-
-      if (!channel) continue;
-
-      const updateMessage = formatUpdateMessage(update);
-      const botMessage = await (channel as TextChannel).send({
-        content: updateMessage,
-      });
-      await fetchClient.mutate.update.markReplicated({
-        updateId: update.id,
-        replicatedStr: JSON.stringify({
-          ...replicated,
-          discord: botMessage.id,
-        }),
-      });
-    } catch (error) {
-      console.error("Error sending update bot message:", error);
-    } finally {
-      handlingUpdates.delete(update.id);
-    }
-  }
+  const botMessage = await (channel as TextChannel).send({
+    content: formatUpdateMessage(update),
+  });
+  return botMessage.id;
 };
 
 client.on("error", (error) => {
@@ -916,51 +831,15 @@ client.once("ready", async () => {
 });
 
 setTimeout(async () => {
-  // TODO Subscribe callback is not being triggered with current values - track https://github.com/pedroscosta/live-state/issues/82
-  await handleMessages(
-    await store.query.message
-      .where({
-        externalMessageId: null,
-        thread: {
-          externalOrigin: "discord",
-          externalId: { $not: null },
-        },
-      })
-      .include({ thread: true, author: { include: { user: true } } })
-      .get(),
-  );
-  store.query.message
-    .where({
-      externalMessageId: null,
-      thread: {
-        externalOrigin: "discord",
-        externalId: { $not: null },
-      },
-    })
-    .include({ thread: true, author: { include: { user: true } } })
-    .subscribe(handleMessages);
-
-  // Handle updates for threads linked to Discord
-  const updates = await store.query.update
-    .where({
-      thread: {
-        externalOrigin: "discord",
-        externalId: { $not: null },
-      },
-    })
-    .include({ thread: true, user: true })
-    .get();
-
-  await handleUpdates(updates);
-  store.query.update
-    .where({
-      thread: {
-        externalOrigin: "discord",
-        externalId: { $not: null },
-      },
-    })
-    .include({ thread: true, user: true })
-    .subscribe(handleUpdates);
+  // Watch un-replicated outbound messages/updates for Discord threads and
+  // deliver them; the framework owns the round-trip of external message ids.
+  await startOutboundReplication({
+    store,
+    fetchClient,
+    provider: DISCORD_PROVIDER,
+    deliverMessage: deliverDiscordMessage,
+    deliverUpdate: deliverDiscordUpdate,
+  });
 
   // Subscribe to Discord integrations to trigger backfill when channels are added
   store.query.integration

--- a/connectors/discord/src/lib/feature-flag.ts
+++ b/connectors/discord/src/lib/feature-flag.ts
@@ -1,6 +1,4 @@
-import { ReflagClient } from "@reflag/node-sdk";
+import { createReflagClient } from "@connectors/framework/runtime";
 
-// Create a singleton instance of the Reflag client
-export const reflagClient = new ReflagClient({
-  secretKey: process.env.REFLAG_SECRET_KEY,
-});
+// Singleton Reflag client for feature flags.
+export const reflagClient = createReflagClient();

--- a/connectors/discord/src/lib/live-state.ts
+++ b/connectors/discord/src/lib/live-state.ts
@@ -1,35 +1,6 @@
-import { createClient } from "@live-state/sync/client";
-import { createClient as createFetchClient } from "@live-state/sync/client/fetch";
-import type { Router } from "api/router";
-import { schema } from "api/schema";
+import { createLiveStateClient } from "@connectors/framework/runtime";
 
-export const { client, store } = createClient<Router>({
-  url: process.env.LIVE_STATE_WS_URL || "ws://localhost:3333/api/ls/ws",
-  schema,
-  credentials: async () => ({
-    discordBotKey: process.env.DISCORD_BOT_KEY ?? "",
-  }),
-  storage: false,
-});
-
-client.ws.addEventListener("open", () => {
-  console.info("Live State connected");
-});
-
-client.ws.addEventListener("close", () => {
-  console.info("Live State disconnected");
-});
-
-client.ws.addEventListener("error", (error) => {
-  console.error("Live State error: ", error, error.error);
-});
-
-client.load(store.query.organization.load().buildQueryRequest());
-
-export const fetchClient = createFetchClient<Router>({
-  url: process.env.LIVE_STATE_API_URL || "http://localhost:3333/api/ls",
-  schema,
-  credentials: async () => ({
-    "x-discord-bot-key": process.env.DISCORD_BOT_KEY ?? "",
-  }),
+export const { client, store, fetchClient } = createLiveStateClient({
+  botKey: process.env.DISCORD_BOT_KEY ?? "",
+  label: "Discord",
 });

--- a/connectors/discord/src/lib/queue.ts
+++ b/connectors/discord/src/lib/queue.ts
@@ -1,4 +1,9 @@
-import { type Job, Queue, Worker } from "bullmq";
+import {
+  createQueue,
+  createWorker,
+  type Job,
+  type Worker,
+} from "@connectors/framework/runtime";
 import type {
   Client,
   ForumChannel,
@@ -6,22 +11,6 @@ import type {
   ThreadChannel,
 } from "discord.js";
 import "../env";
-
-// Redis connection configuration
-const getRedisConnection = () => {
-  if (process.env.REDIS_URL) {
-    return { url: process.env.REDIS_URL };
-  }
-
-  return {
-    host: process.env.REDIS_HOST ?? "localhost",
-    port: process.env.REDIS_PORT
-      ? Number.parseInt(process.env.REDIS_PORT, 10)
-      : 6379,
-    password: process.env.REDIS_PASSWORD,
-    db: process.env.REDIS_DB ? Number.parseInt(process.env.REDIS_DB, 10) : 0,
-  };
-};
 
 // Job data types
 export type BackfillChannelJobData = {
@@ -51,8 +40,7 @@ export type BackfillChannelResult = {
 };
 
 // Queue instance
-export const backfillQueue = new Queue<BackfillJobData>("discord-backfill", {
-  connection: getRedisConnection(),
+export const backfillQueue = createQueue<BackfillJobData>("discord-backfill", {
   defaultJobOptions: {
     attempts: 3,
     backoff: {
@@ -94,7 +82,7 @@ export const initializeBackfillWorker = (
     return backfillWorker;
   }
 
-  backfillWorker = new Worker<BackfillJobData>(
+  backfillWorker = createWorker<BackfillJobData>(
     "discord-backfill",
     async (job: Job<BackfillJobData>) => {
       const { data } = job;
@@ -153,7 +141,6 @@ export const initializeBackfillWorker = (
       }
     },
     {
-      connection: getRedisConnection(),
       concurrency: 2, // Process 2 jobs at a time
       limiter: {
         max: 10, // Max 10 jobs

--- a/connectors/discord/src/lib/utils.ts
+++ b/connectors/discord/src/lib/utils.ts
@@ -1,104 +1,23 @@
+import {
+  createBackfillHelpers,
+  createSettingsParser,
+} from "@connectors/framework/runtime";
 import { discordIntegrationSchema } from "@workspace/schemas/integration/discord";
 import type { Message } from "discord.js";
-import type z from "zod";
 import { fetchClient } from "./live-state";
 
-export const safeParseIntegrationSettings = (
-  configStr: string | null,
-): z.infer<typeof discordIntegrationSchema> | undefined => {
-  if (!configStr) return undefined;
-  try {
-    return discordIntegrationSchema.parse(JSON.parse(configStr));
-  } catch {
-    return undefined;
-  }
-};
+export { safeParseJSON } from "@connectors/framework/runtime";
 
-export const updateBackfillStatus = async (
-  integrationId: string,
-  configStr: string | null,
-  backfill: {
-    processed: number;
-    total: number;
-    limit: number | null;
-    channelsDiscovering: number;
-  } | null,
-) => {
-  const current = safeParseIntegrationSettings(configStr) ?? {};
-  await fetchClient.mutate.integration.updateInstallation({
-    integrationId,
-    configStr: JSON.stringify({ ...current, backfill }),
-  });
-};
+export const { safeParseIntegrationSettings } = createSettingsParser(
+  discordIntegrationSchema,
+);
 
-export const updateSyncedChannels = async (
-  integrationId: string,
-  configStr: string | null,
-  syncedChannels: string[],
-) => {
-  const current = safeParseIntegrationSettings(configStr) ?? {};
-  await fetchClient.mutate.integration.updateInstallation({
-    integrationId,
-    configStr: JSON.stringify({ ...current, syncedChannels }),
-  });
-};
-
-export const getBackfillLimit = async (
-  organizationId: string,
-): Promise<number | null> => {
-  const subscription = await fetchClient.query.subscription.forOrg({
-    organizationId,
-  });
-  if (!subscription || subscription.plan === "trial") {
-    return 100;
-  }
-  return null;
-};
-
-// Per-integration async mutex to serialize backfill status read-modify-write operations
-const backfillLocks = new Map<string, Promise<void>>();
-
-export const withBackfillLock = async <T>(
-  integrationId: string,
-  fn: () => Promise<T>,
-): Promise<T> => {
-  const existing = backfillLocks.get(integrationId) ?? Promise.resolve();
-  let resolve: () => void;
-  const next = new Promise<void>((r) => {
-    resolve = r;
-  });
-  backfillLocks.set(integrationId, next);
-
-  try {
-    await existing;
-    return await fn();
-  } finally {
-    resolve!();
-    if (backfillLocks.get(integrationId) === next) {
-      backfillLocks.delete(integrationId);
-    }
-  }
-};
-
-export const safeParseJSON = (raw: string) => {
-  try {
-    const parsed = JSON.parse(raw);
-    // Accept common shapes produced by our editor:
-    if (Array.isArray(parsed)) return parsed;
-    if (parsed && typeof parsed === "object" && "content" in parsed) {
-      // e.g. a full doc { type: 'doc', content: [...] }
-      // Normalize to content[] to match our usage.
-      return (parsed as any).content ?? [];
-    }
-  } catch {}
-  // Fallback: wrap plain text in a single paragraph node.
-  return [
-    {
-      type: "paragraph",
-      content: [{ type: "text", text: String(raw) }],
-    },
-  ];
-};
+export const {
+  withBackfillLock,
+  updateBackfillStatus,
+  updateSyncedChannels,
+  getBackfillLimit,
+} = createBackfillHelpers(fetchClient);
 
 export const parseContentAsMarkdown = (message: Message): string => {
   let content = message.content;

--- a/connectors/framework/package.json
+++ b/connectors/framework/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "author": "front-desk",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./runtime": "./src/runtime/index.ts"
   },
   "scripts": {
     "lint": "biome lint .",
@@ -14,7 +15,19 @@
     "format": "bun biome format ./src --fix"
   },
   "dependencies": {
+    "@live-state/sync": "catalog:",
+    "@reflag/node-sdk": "^1.1.0",
+    "bullmq": "^5.67.1",
+    "ioredis": "^5.3.2",
     "zod": "catalog:"
+  },
+  "peerDependencies": {
+    "api": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "api": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/node": "^22.15.2",

--- a/connectors/framework/src/runtime/backfill.ts
+++ b/connectors/framework/src/runtime/backfill.ts
@@ -1,0 +1,111 @@
+import type { LiveStateFetchClient } from "./live-state";
+
+export type BackfillStatus = {
+  processed: number;
+  total: number;
+  limit: number | null;
+  channelsDiscovering: number;
+};
+
+/**
+ * Parse an opaque `integration.configStr` into a plain object for a generic
+ * read-modify-write. Backfill orchestration only merges a couple of keys, so it
+ * deliberately does not go through the connector's typed settings schema.
+ */
+const parseSettingsRecord = (
+  configStr: string | null,
+): Record<string, unknown> => {
+  if (!configStr) return {};
+  try {
+    const parsed = JSON.parse(configStr);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+};
+
+/**
+ * Backfill orchestration helpers bound to a connector's `fetchClient`. These are
+ * generic writes to `integration.settings` (via `updateInstallation`) plus the
+ * plan-based backfill cap — identical across discord/slack, lifted here.
+ *
+ * `withBackfillLock` closes over a per-process, per-integration mutex so the
+ * status read-modify-write stays serialized within a single connector.
+ */
+export const createBackfillHelpers = (fetchClient: LiveStateFetchClient) => {
+  const backfillLocks = new Map<string, Promise<void>>();
+
+  /** Serialize backfill status read-modify-write operations per integration. */
+  const withBackfillLock = async <T>(
+    integrationId: string,
+    fn: () => Promise<T>,
+  ): Promise<T> => {
+    const existing = backfillLocks.get(integrationId) ?? Promise.resolve();
+    let resolve!: () => void;
+    const next = new Promise<void>((r) => {
+      resolve = r;
+    });
+    backfillLocks.set(integrationId, next);
+
+    try {
+      await existing;
+      return await fn();
+    } finally {
+      resolve();
+      if (backfillLocks.get(integrationId) === next) {
+        backfillLocks.delete(integrationId);
+      }
+    }
+  };
+
+  /** Merge the backfill-progress blob into the integration settings. */
+  const updateBackfillStatus = async (
+    integrationId: string,
+    configStr: string | null,
+    backfill: BackfillStatus | null,
+  ) => {
+    const current = parseSettingsRecord(configStr);
+    await fetchClient.mutate.integration.updateInstallation({
+      integrationId,
+      configStr: JSON.stringify({ ...current, backfill }),
+    });
+  };
+
+  /**
+   * Merge the synced-channel list into the integration settings. Always re-reads
+   * the latest `configStr` first so concurrent status writes are not clobbered.
+   */
+  const updateSyncedChannels = async (
+    integrationId: string,
+    syncedChannels: string[],
+  ) => {
+    const latest = await fetchClient.query.integration.byId({
+      id: integrationId,
+    });
+    const current = parseSettingsRecord(latest?.configStr ?? null);
+    await fetchClient.mutate.integration.updateInstallation({
+      integrationId,
+      configStr: JSON.stringify({ ...current, syncedChannels }),
+    });
+  };
+
+  /** Trial/free orgs cap backfill at 100 threads; paid orgs are uncapped. */
+  const getBackfillLimit = async (
+    organizationId: string,
+  ): Promise<number | null> => {
+    const subscription = await fetchClient.query.subscription.forOrg({
+      organizationId,
+    });
+    if (!subscription || subscription.plan === "trial") {
+      return 100;
+    }
+    return null;
+  };
+
+  return {
+    withBackfillLock,
+    updateBackfillStatus,
+    updateSyncedChannels,
+    getBackfillLimit,
+  };
+};

--- a/connectors/framework/src/runtime/backfill.ts
+++ b/connectors/framework/src/runtime/backfill.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import type { LiveStateFetchClient } from "./live-state";
 
 export type BackfillStatus = {
@@ -7,21 +8,21 @@ export type BackfillStatus = {
   channelsDiscovering: number;
 };
 
+const settingsRecordSchema = z.record(z.string(), z.unknown());
+
 /**
  * Parse an opaque `integration.configStr` into a plain object for a generic
  * read-modify-write. Backfill orchestration only merges a couple of keys, so it
- * deliberately does not go through the connector's typed settings schema.
+ * deliberately does not go through the connector's typed settings schema — but
+ * it still validates the value is a plain record and throws otherwise, so a
+ * malformed blob or JSON array aborts the write instead of clobbering the
+ * settings with only the merged key.
  */
 const parseSettingsRecord = (
   configStr: string | null,
 ): Record<string, unknown> => {
   if (!configStr) return {};
-  try {
-    const parsed = JSON.parse(configStr);
-    return parsed && typeof parsed === "object" ? parsed : {};
-  } catch {
-    return {};
-  }
+  return settingsRecordSchema.parse(JSON.parse(configStr));
 };
 
 /**

--- a/connectors/framework/src/runtime/backfill.ts
+++ b/connectors/framework/src/runtime/backfill.ts
@@ -89,17 +89,17 @@ export const createBackfillHelpers = (fetchClient: LiveStateFetchClient) => {
     });
   };
 
-  /** Trial/free orgs cap backfill at 100 threads; paid orgs are uncapped. */
+  /**
+   * Trial/free orgs cap backfill at 100 threads; only the paid `pro` plan is
+   * uncapped. `starter` and `beta-feedback` are free plans, so they stay capped.
+   */
   const getBackfillLimit = async (
     organizationId: string,
   ): Promise<number | null> => {
     const subscription = await fetchClient.query.subscription.forOrg({
       organizationId,
     });
-    if (!subscription || subscription.plan === "trial") {
-      return 100;
-    }
-    return null;
+    return subscription?.plan === "pro" ? null : 100;
   };
 
   return {

--- a/connectors/framework/src/runtime/feature-flag.ts
+++ b/connectors/framework/src/runtime/feature-flag.ts
@@ -1,0 +1,10 @@
+import { ReflagClient } from "@reflag/node-sdk";
+
+/**
+ * Create the connector's singleton Reflag (feature-flag) client. Identical setup
+ * across discord/slack today; lifted so the `REFLAG_SECRET_KEY` wiring lives once.
+ */
+export const createReflagClient = (): ReflagClient =>
+  new ReflagClient({ secretKey: process.env.REFLAG_SECRET_KEY });
+
+export type { ReflagClient };

--- a/connectors/framework/src/runtime/index.ts
+++ b/connectors/framework/src/runtime/index.ts
@@ -21,10 +21,8 @@ export {
   createQueue,
   createRedisConnection,
   createWorker,
-  getRedisConnection,
   type Job,
   type Queue,
-  type RedisConnection,
   type Worker,
 } from "./redis";
 export {

--- a/connectors/framework/src/runtime/index.ts
+++ b/connectors/framework/src/runtime/index.ts
@@ -1,0 +1,33 @@
+export {
+  type BackfillStatus,
+  createBackfillHelpers,
+} from "./backfill";
+export { createReflagClient, type ReflagClient } from "./feature-flag";
+export {
+  type CreateLiveStateClientOptions,
+  createLiveStateClient,
+  type LiveStateClient,
+  type LiveStateFetchClient,
+  type LiveStateStore,
+} from "./live-state";
+export {
+  type OutboundMessage,
+  type OutboundReplicationOptions,
+  type OutboundUpdate,
+  startOutboundReplication,
+} from "./outbound";
+export { buildPortalThreadUrl } from "./portal";
+export {
+  createQueue,
+  createRedisConnection,
+  createWorker,
+  getRedisConnection,
+  type Job,
+  type Queue,
+  type RedisConnection,
+  type Worker,
+} from "./redis";
+export {
+  createSettingsParser,
+  safeParseJSON,
+} from "./settings";

--- a/connectors/framework/src/runtime/live-state.ts
+++ b/connectors/framework/src/runtime/live-state.ts
@@ -1,0 +1,84 @@
+import { createClient } from "@live-state/sync/client";
+import { createClient as createFetchClient } from "@live-state/sync/client/fetch";
+import type { Router } from "api/router";
+import { schema } from "api/schema";
+
+export type CreateLiveStateClientOptions = {
+  /**
+   * Value of the connector bot key (all connectors authenticate against the
+   * shared `DISCORD_BOT_KEY` today — pass `process.env.DISCORD_BOT_KEY ?? ""`).
+   */
+  botKey: string;
+  /**
+   * Credential field the WS client sends. The API only accepts `discordBotKey`
+   * today (see `apps/api/src/index.ts`); parameterized so a per-connector key
+   * can be introduced without touching this factory.
+   */
+  credentialName?: string;
+  /** HTTP header the fetch client sends. Mirrors {@link credentialName}. */
+  credentialHeader?: string;
+  /** Override the WS url (defaults to `LIVE_STATE_WS_URL` / localhost). */
+  wsUrl?: string;
+  /** Override the fetch url (defaults to `LIVE_STATE_API_URL` / localhost). */
+  apiUrl?: string;
+  /** Label used in reconnect logging, e.g. `"Discord"`. */
+  label?: string;
+};
+
+/**
+ * Node-only live-state client bootstrap shared by every connector: the reactive
+ * `client`/`store`, the one-shot `fetchClient`, reconnect logging, and the
+ * initial organization load. The only thing that differs per connector is the
+ * bot-key credential, which is parameterized.
+ */
+export const createLiveStateClient = (
+  options: CreateLiveStateClientOptions,
+) => {
+  const {
+    botKey,
+    credentialName = "discordBotKey",
+    credentialHeader = "x-discord-bot-key",
+    label,
+  } = options;
+
+  const prefix = label ? `[${label}] ` : "";
+
+  const { client, store } = createClient<Router>({
+    url:
+      options.wsUrl ??
+      process.env.LIVE_STATE_WS_URL ??
+      "ws://localhost:3333/api/ls/ws",
+    schema,
+    credentials: async () => ({ [credentialName]: botKey }),
+    storage: false,
+  });
+
+  client.ws.addEventListener("open", () => {
+    console.info(`${prefix}Live State connected`);
+  });
+
+  client.ws.addEventListener("close", () => {
+    console.info(`${prefix}Live State disconnected`);
+  });
+
+  client.ws.addEventListener("error", (error) => {
+    console.error(`${prefix}Live State error: `, error, error.error);
+  });
+
+  client.load(store.query.organization.load().buildQueryRequest());
+
+  const fetchClient = createFetchClient<Router>({
+    url:
+      options.apiUrl ??
+      process.env.LIVE_STATE_API_URL ??
+      "http://localhost:3333/api/ls",
+    schema,
+    credentials: async () => ({ [credentialHeader]: botKey }),
+  });
+
+  return { client, store, fetchClient };
+};
+
+export type LiveStateClient = ReturnType<typeof createLiveStateClient>;
+export type LiveStateStore = LiveStateClient["store"];
+export type LiveStateFetchClient = LiveStateClient["fetchClient"];

--- a/connectors/framework/src/runtime/outbound.ts
+++ b/connectors/framework/src/runtime/outbound.ts
@@ -1,0 +1,129 @@
+import type { InferLiveObject } from "@live-state/sync";
+import type { schema } from "api/schema";
+import type { LiveStateFetchClient, LiveStateStore } from "./live-state";
+
+/** Outbound message row, with the includes every connector needs to deliver it. */
+export type OutboundMessage = InferLiveObject<
+  (typeof schema)["message"],
+  { thread: true; author: { include: { user: true } } }
+>;
+
+/** Outbound thread-update row, with the includes needed to format it. */
+export type OutboundUpdate = InferLiveObject<
+  (typeof schema)["update"],
+  { thread: true; user: true }
+>;
+
+/**
+ * Deliver an outbound row to the external provider. Return the external message
+ * id to round-trip (marks the row replicated); return `null`/`undefined` to
+ * leave it un-replicated so it is retried on the next emission. All the
+ * provider-specific resolution (integration lookup, channel/webhook, formatting)
+ * lives inside this callback — the framework owns only the replication plumbing.
+ */
+type Deliver<T> = (row: T) => Promise<string | null | undefined>;
+
+export type OutboundReplicationOptions = {
+  store: LiveStateStore;
+  fetchClient: LiveStateFetchClient;
+  /**
+   * `externalOrigin` / `replicatedStr` key for this connector (e.g. `"discord"`).
+   * Matches the thread's origin and namespaces the replicated marker.
+   */
+  provider: string;
+  /**
+   * Extra constraints merged into the `thread` sub-filter of both queries (e.g.
+   * slack also requires `externalMetadataStr: { $not: null }`).
+   */
+  threadFilter?: Record<string, unknown>;
+  deliverMessage: Deliver<OutboundMessage>;
+  deliverUpdate: Deliver<OutboundUpdate>;
+};
+
+/**
+ * Normalized outbound-subscription helper: the pull-deliver loop that every
+ * support-entry-point connector runs. It watches un-replicated outbound messages
+ * and thread updates for this provider, hands each to the connector's deliver
+ * callback, and round-trips the external id (`message.setExternalMessageId` /
+ * `update.markReplicated`) so connectors stop re-implementing the plumbing.
+ *
+ * Runs an initial `.get()` pass, then subscribes for live updates.
+ */
+export const startOutboundReplication = async ({
+  store,
+  fetchClient,
+  provider,
+  threadFilter = {},
+  deliverMessage,
+  deliverUpdate,
+}: OutboundReplicationOptions) => {
+  const threadWhere = {
+    externalOrigin: provider,
+    externalId: { $not: null },
+    ...threadFilter,
+  };
+
+  const handleMessages = async (messages: OutboundMessage[]) => {
+    for (const message of messages) {
+      try {
+        const externalMessageId = await deliverMessage(message);
+        if (externalMessageId) {
+          store.mutate.message.setExternalMessageId({
+            messageId: message.id,
+            externalMessageId,
+          });
+        }
+      } catch (error) {
+        console.error("[outbound] message delivery failed:", error);
+      }
+    }
+  };
+
+  // In-flight guard: a delivery can outlive the next emission of the same row,
+  // and updates are marked replicated via the async fetch client, so dedup here.
+  const handlingUpdates = new Set<string>();
+
+  const handleUpdates = async (updates: OutboundUpdate[]) => {
+    for (const update of updates) {
+      const replicated = update.replicatedStr
+        ? JSON.parse(update.replicatedStr)
+        : {};
+      if (replicated[provider]) continue;
+      if (handlingUpdates.has(update.id)) continue;
+
+      handlingUpdates.add(update.id);
+      try {
+        const externalMessageId = await deliverUpdate(update);
+        if (externalMessageId) {
+          await fetchClient.mutate.update.markReplicated({
+            updateId: update.id,
+            replicatedStr: JSON.stringify({
+              ...replicated,
+              [provider]: externalMessageId,
+            }),
+          });
+        }
+      } catch (error) {
+        console.error("[outbound] update delivery failed:", error);
+      } finally {
+        handlingUpdates.delete(update.id);
+      }
+    }
+  };
+
+  const messageQuery = store.query.message
+    .where({ externalMessageId: null, thread: threadWhere })
+    .include({ thread: true, author: { include: { user: true } } });
+
+  // TODO Subscribe callback is not being triggered with current values - track
+  // https://github.com/pedroscosta/live-state/issues/82
+  await handleMessages(await messageQuery.get());
+  messageQuery.subscribe(handleMessages);
+
+  const updateQuery = store.query.update
+    .where({ thread: threadWhere })
+    .include({ thread: true, user: true });
+
+  await handleUpdates(await updateQuery.get());
+  updateQuery.subscribe(handleUpdates);
+};

--- a/connectors/framework/src/runtime/outbound.ts
+++ b/connectors/framework/src/runtime/outbound.ts
@@ -1,6 +1,10 @@
 import type { InferLiveObject } from "@live-state/sync";
 import type { schema } from "api/schema";
+import { z } from "zod";
 import type { LiveStateFetchClient, LiveStateStore } from "./live-state";
+
+/** The per-provider replicated-marker map stored on `update.replicatedStr`. */
+const replicatedSchema = z.record(z.string(), z.unknown());
 
 /** Outbound message row, with the includes every connector needs to deliver it. */
 export type OutboundMessage = InferLiveObject<
@@ -93,9 +97,16 @@ export const startOutboundReplication = async ({
 
   const handleUpdates = async (updates: OutboundUpdate[]) => {
     for (const update of updates) {
-      const replicated = update.replicatedStr
-        ? JSON.parse(update.replicatedStr)
-        : {};
+      let replicated: Record<string, unknown> = {};
+      if (update.replicatedStr) {
+        try {
+          replicated = replicatedSchema.parse(JSON.parse(update.replicatedStr));
+        } catch (error) {
+          // A malformed row must not reject the whole pass — skip it.
+          console.error("[outbound] invalid replicatedStr, skipping:", error);
+          continue;
+        }
+      }
       if (replicated[provider]) continue;
       if (handlingUpdates.has(update.id)) continue;
 

--- a/connectors/framework/src/runtime/outbound.ts
+++ b/connectors/framework/src/runtime/outbound.ts
@@ -57,14 +57,24 @@ export const startOutboundReplication = async ({
   deliverMessage,
   deliverUpdate,
 }: OutboundReplicationOptions) => {
+  // Provider invariants are spread last so a caller-supplied `threadFilter`
+  // cannot override `externalOrigin`/`externalId` and pull another provider's rows.
   const threadWhere = {
+    ...threadFilter,
     externalOrigin: provider,
     externalId: { $not: null },
-    ...threadFilter,
   };
+
+  // In-flight guards: a delivery can outlive the next emission of the same row,
+  // and rows are marked replicated via the async fetch client, so dedup here.
+  const handlingMessages = new Set<string>();
+  const handlingUpdates = new Set<string>();
 
   const handleMessages = async (messages: OutboundMessage[]) => {
     for (const message of messages) {
+      if (handlingMessages.has(message.id)) continue;
+
+      handlingMessages.add(message.id);
       try {
         const externalMessageId = await deliverMessage(message);
         if (externalMessageId) {
@@ -75,13 +85,11 @@ export const startOutboundReplication = async ({
         }
       } catch (error) {
         console.error("[outbound] message delivery failed:", error);
+      } finally {
+        handlingMessages.delete(message.id);
       }
     }
   };
-
-  // In-flight guard: a delivery can outlive the next emission of the same row,
-  // and updates are marked replicated via the async fetch client, so dedup here.
-  const handlingUpdates = new Set<string>();
 
   const handleUpdates = async (updates: OutboundUpdate[]) => {
     for (const update of updates) {

--- a/connectors/framework/src/runtime/portal.ts
+++ b/connectors/framework/src/runtime/portal.ts
@@ -1,0 +1,14 @@
+/**
+ * Build a customer-portal URL for a thread on the org's subdomain. FrontDesk
+ * rewrites `{org}.tryfrontdesk.app` to the internal support path, so the portal
+ * link is the base url with the org slug prepended as a subdomain.
+ */
+export const buildPortalThreadUrl = (
+  baseUrl: string,
+  organizationSlug: string,
+  threadId: string,
+): string => {
+  const baseUrlObj = new URL(baseUrl);
+  const port = baseUrlObj.port ? `:${baseUrlObj.port}` : "";
+  return `${baseUrlObj.protocol}//${organizationSlug}.${baseUrlObj.hostname}${port}/threads/${threadId}`;
+};

--- a/connectors/framework/src/runtime/redis.ts
+++ b/connectors/framework/src/runtime/redis.ts
@@ -9,46 +9,72 @@ import Redis, { type RedisOptions } from "ioredis";
 
 export type { Job, Queue, Worker } from "bullmq";
 
-/**
- * Create an owned ioredis instance configured for BullMQ
- * (`maxRetriesPerRequest: null` is required when passing an instance, rather
- * than a descriptor, to a Queue/Worker). Replaces github's `createRedisConnection`.
- */
-export const createRedisConnection = (): Redis => {
-  if (process.env.REDIS_URL) {
-    return new Redis(process.env.REDIS_URL, { maxRetriesPerRequest: null });
-  }
+/** Map a `redis(s)://` URL onto the ioredis options BullMQ understands. */
+const parseRedisUrl = (url: string): RedisOptions => {
+  const parsed = new URL(url);
+  const options: RedisOptions = { host: parsed.hostname };
 
-  const options: RedisOptions & { maxRetriesPerRequest: null } = {
-    host: process.env.REDIS_HOST ?? "localhost",
-    maxRetriesPerRequest: null,
-  };
+  if (parsed.port) options.port = Number.parseInt(parsed.port, 10);
+  if (parsed.username) options.username = decodeURIComponent(parsed.username);
+  if (parsed.password) options.password = decodeURIComponent(parsed.password);
 
-  if (process.env.REDIS_PORT) {
-    options.port = Number.parseInt(process.env.REDIS_PORT, 10);
-  }
-  if (process.env.REDIS_PASSWORD) {
-    options.password = process.env.REDIS_PASSWORD;
-  }
-  if (process.env.REDIS_DB) {
-    options.db = Number.parseInt(process.env.REDIS_DB, 10);
-  }
+  const db = parsed.pathname.replace(/^\//, "");
+  if (db) options.db = Number.parseInt(db, 10);
+  if (parsed.protocol === "rediss:") options.tls = {};
 
-  return new Redis(options);
+  return options;
 };
 
 /**
- * Create a BullMQ Queue wired to the shared connection. Connector-specific job
+ * Resolve BullMQ connection options from the environment: prefer `REDIS_URL`
+ * (parsed into ioredis options — BullMQ does not honour a bare `{ url }`), fall
+ * back to discrete host/port/password/db env vars. `maxRetriesPerRequest: null`
+ * is required by Workers and harmless for Queues. Returning a descriptor (not a
+ * pre-built instance) lets BullMQ own the connection and close its socket on
+ * `Queue`/`Worker` `.close()`.
+ */
+export const getRedisConnectionOptions = (): RedisOptions & {
+  maxRetriesPerRequest: null;
+} => {
+  const base: RedisOptions = process.env.REDIS_URL
+    ? parseRedisUrl(process.env.REDIS_URL)
+    : {
+        host: process.env.REDIS_HOST ?? "localhost",
+        ...(process.env.REDIS_PORT
+          ? { port: Number.parseInt(process.env.REDIS_PORT, 10) }
+          : {}),
+        ...(process.env.REDIS_PASSWORD
+          ? { password: process.env.REDIS_PASSWORD }
+          : {}),
+        ...(process.env.REDIS_DB
+          ? { db: Number.parseInt(process.env.REDIS_DB, 10) }
+          : {}),
+      };
+
+  return { ...base, maxRetriesPerRequest: null };
+};
+
+/**
+ * Create an owned ioredis instance for callers that wire their own Queue/Worker
+ * and manage its lifecycle. Replaces github's `createRedisConnection`.
+ */
+export const createRedisConnection = (): Redis =>
+  new Redis(getRedisConnectionOptions());
+
+/**
+ * Create a BullMQ Queue. BullMQ constructs and owns the connection from the
+ * descriptor, so it closes the socket on `queue.close()`. Connector-specific job
  * data and default options are passed through.
  */
 export const createQueue = <T>(
   name: string,
   options?: Omit<QueueOptions, "connection">,
 ): Queue<T> =>
-  new Queue<T>(name, { connection: createRedisConnection(), ...options });
+  new Queue<T>(name, { connection: getRedisConnectionOptions(), ...options });
 
 /**
- * Create a BullMQ Worker wired to the shared connection. The processor and any
+ * Create a BullMQ Worker. BullMQ constructs and owns the connection from the
+ * descriptor, so it closes the socket on `worker.close()`. The processor and any
  * connector-specific concurrency/limiter options are passed through.
  */
 export const createWorker = <T, R = unknown>(
@@ -57,6 +83,6 @@ export const createWorker = <T, R = unknown>(
   options?: Omit<WorkerOptions, "connection">,
 ): Worker<T, R> =>
   new Worker<T, R>(name, processor, {
-    connection: createRedisConnection(),
+    connection: getRedisConnectionOptions(),
     ...options,
   });

--- a/connectors/framework/src/runtime/redis.ts
+++ b/connectors/framework/src/runtime/redis.ts
@@ -1,0 +1,90 @@
+import {
+  type Processor,
+  Queue,
+  type QueueOptions,
+  Worker,
+  type WorkerOptions,
+} from "bullmq";
+import Redis, { type RedisOptions } from "ioredis";
+
+export type { Job, Queue, Worker } from "bullmq";
+
+/**
+ * BullMQ connection descriptor: prefer `REDIS_URL`, fall back to discrete
+ * host/port/password/db env vars. Passed as `connection` to a Queue/Worker,
+ * where BullMQ builds and manages the underlying ioredis instance itself.
+ */
+export type RedisConnection =
+  | { url: string }
+  | { host: string; port?: number; password?: string; db?: number };
+
+/**
+ * Resolve the shared connection descriptor from the environment. Replaces the
+ * per-connector `getRedisConnection` copies (discord/slack).
+ */
+export const getRedisConnection = (): RedisConnection => {
+  if (process.env.REDIS_URL) {
+    return { url: process.env.REDIS_URL };
+  }
+
+  return {
+    host: process.env.REDIS_HOST ?? "localhost",
+    port: process.env.REDIS_PORT
+      ? Number.parseInt(process.env.REDIS_PORT, 10)
+      : 6379,
+    password: process.env.REDIS_PASSWORD,
+    db: process.env.REDIS_DB ? Number.parseInt(process.env.REDIS_DB, 10) : 0,
+  };
+};
+
+/**
+ * Create an owned ioredis instance configured for BullMQ
+ * (`maxRetriesPerRequest: null` is required when passing an instance, rather
+ * than a descriptor, to a Queue/Worker). Replaces github's `createRedisConnection`.
+ */
+export const createRedisConnection = (): Redis => {
+  if (process.env.REDIS_URL) {
+    return new Redis(process.env.REDIS_URL, { maxRetriesPerRequest: null });
+  }
+
+  const options: RedisOptions & { maxRetriesPerRequest: null } = {
+    host: process.env.REDIS_HOST ?? "localhost",
+    maxRetriesPerRequest: null,
+  };
+
+  if (process.env.REDIS_PORT) {
+    options.port = Number.parseInt(process.env.REDIS_PORT, 10);
+  }
+  if (process.env.REDIS_PASSWORD) {
+    options.password = process.env.REDIS_PASSWORD;
+  }
+  if (process.env.REDIS_DB) {
+    options.db = Number.parseInt(process.env.REDIS_DB, 10);
+  }
+
+  return new Redis(options);
+};
+
+/**
+ * Create a BullMQ Queue wired to the shared connection. Connector-specific job
+ * data and default options are passed through.
+ */
+export const createQueue = <T>(
+  name: string,
+  options?: Omit<QueueOptions, "connection">,
+): Queue<T> =>
+  new Queue<T>(name, { connection: getRedisConnection(), ...options });
+
+/**
+ * Create a BullMQ Worker wired to the shared connection. The processor and any
+ * connector-specific concurrency/limiter options are passed through.
+ */
+export const createWorker = <T, R = unknown>(
+  name: string,
+  processor: Processor<T, R>,
+  options?: Omit<WorkerOptions, "connection">,
+): Worker<T, R> =>
+  new Worker<T, R>(name, processor, {
+    connection: getRedisConnection(),
+    ...options,
+  });

--- a/connectors/framework/src/runtime/redis.ts
+++ b/connectors/framework/src/runtime/redis.ts
@@ -22,6 +22,16 @@ const parseRedisUrl = (url: string): RedisOptions => {
   if (db) options.db = Number.parseInt(db, 10);
   if (parsed.protocol === "rediss:") options.tls = {};
 
+  // Carry query options through (e.g. `?family=6` for IPv6), matching ioredis's
+  // own URL parsing which copies search params onto the connection options.
+  // Numeric-looking values are coerced so `family`/`connectTimeout`/etc. arrive
+  // as numbers rather than strings.
+  for (const [key, value] of parsed.searchParams) {
+    (options as Record<string, unknown>)[key] = /^\d+$/.test(value)
+      ? Number.parseInt(value, 10)
+      : value;
+  }
+
   return options;
 };
 

--- a/connectors/framework/src/runtime/redis.ts
+++ b/connectors/framework/src/runtime/redis.ts
@@ -10,34 +10,6 @@ import Redis, { type RedisOptions } from "ioredis";
 export type { Job, Queue, Worker } from "bullmq";
 
 /**
- * BullMQ connection descriptor: prefer `REDIS_URL`, fall back to discrete
- * host/port/password/db env vars. Passed as `connection` to a Queue/Worker,
- * where BullMQ builds and manages the underlying ioredis instance itself.
- */
-export type RedisConnection =
-  | { url: string }
-  | { host: string; port?: number; password?: string; db?: number };
-
-/**
- * Resolve the shared connection descriptor from the environment. Replaces the
- * per-connector `getRedisConnection` copies (discord/slack).
- */
-export const getRedisConnection = (): RedisConnection => {
-  if (process.env.REDIS_URL) {
-    return { url: process.env.REDIS_URL };
-  }
-
-  return {
-    host: process.env.REDIS_HOST ?? "localhost",
-    port: process.env.REDIS_PORT
-      ? Number.parseInt(process.env.REDIS_PORT, 10)
-      : 6379,
-    password: process.env.REDIS_PASSWORD,
-    db: process.env.REDIS_DB ? Number.parseInt(process.env.REDIS_DB, 10) : 0,
-  };
-};
-
-/**
  * Create an owned ioredis instance configured for BullMQ
  * (`maxRetriesPerRequest: null` is required when passing an instance, rather
  * than a descriptor, to a Queue/Worker). Replaces github's `createRedisConnection`.
@@ -73,7 +45,7 @@ export const createQueue = <T>(
   name: string,
   options?: Omit<QueueOptions, "connection">,
 ): Queue<T> =>
-  new Queue<T>(name, { connection: getRedisConnection(), ...options });
+  new Queue<T>(name, { connection: createRedisConnection(), ...options });
 
 /**
  * Create a BullMQ Worker wired to the shared connection. The processor and any
@@ -85,6 +57,6 @@ export const createWorker = <T, R = unknown>(
   options?: Omit<WorkerOptions, "connection">,
 ): Worker<T, R> =>
   new Worker<T, R>(name, processor, {
-    connection: getRedisConnection(),
+    connection: createRedisConnection(),
     ...options,
   });

--- a/connectors/framework/src/runtime/settings.ts
+++ b/connectors/framework/src/runtime/settings.ts
@@ -1,0 +1,47 @@
+import type { z } from "zod";
+
+/**
+ * Build a schema-bound integration-settings parser. Each connector has its own
+ * settings schema (discord/slack), so the schema is injected once and the
+ * returned `safeParseIntegrationSettings` keeps the connector's call sites
+ * argument-compatible with the old per-connector helper.
+ */
+export const createSettingsParser = <S extends z.ZodTypeAny>(schema: S) => {
+  const safeParseIntegrationSettings = (
+    configStr: string | null,
+  ): z.infer<S> | undefined => {
+    if (!configStr) return undefined;
+    try {
+      return schema.parse(JSON.parse(configStr));
+    } catch {
+      return undefined;
+    }
+  };
+
+  return { safeParseIntegrationSettings };
+};
+
+/**
+ * Parse a Tiptap message body from its stored JSON string into the `content[]`
+ * array our editor produces, tolerating the common shapes and falling back to a
+ * single plain-text paragraph.
+ */
+export const safeParseJSON = (raw: string) => {
+  try {
+    const parsed = JSON.parse(raw);
+    // Accept common shapes produced by our editor:
+    if (Array.isArray(parsed)) return parsed;
+    if (parsed && typeof parsed === "object" && "content" in parsed) {
+      // e.g. a full doc { type: 'doc', content: [...] }
+      // Normalize to content[] to match our usage.
+      return (parsed as { content?: unknown }).content ?? [];
+    }
+  } catch {}
+  // Fallback: wrap plain text in a single paragraph node.
+  return [
+    {
+      type: "paragraph",
+      content: [{ type: "text", text: String(raw) }],
+    },
+  ];
+};

--- a/connectors/framework/tsconfig.json
+++ b/connectors/framework/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "esModuleInterop": true,
     "isolatedModules": true,
+    "jsx": "react-jsx",
     "lib": ["es2022"],
     "module": "preserve",
     "moduleDetection": "force",

--- a/connectors/github/src/lib/live-state.ts
+++ b/connectors/github/src/lib/live-state.ts
@@ -1,35 +1,6 @@
-import { createClient } from "@live-state/sync/client";
-import { createClient as createFetchClient } from "@live-state/sync/client/fetch";
-import type { Router } from "api/router";
-import { schema } from "api/schema";
+import { createLiveStateClient } from "@connectors/framework/runtime";
 
-export const { client, store } = createClient<Router>({
-  url: process.env.LIVE_STATE_WS_URL || "ws://localhost:3333/api/ls/ws",
-  schema,
-  credentials: async () => ({
-    discordBotKey: process.env.DISCORD_BOT_KEY ?? "",
-  }),
-  storage: false,
-});
-
-client.ws.addEventListener("open", () => {
-  console.info("Live State connected");
-});
-
-client.ws.addEventListener("close", () => {
-  console.info("Live State disconnected");
-});
-
-client.ws.addEventListener("error", (error) => {
-  console.error("Live State error: ", error, error.error);
-});
-
-client.load(store.query.organization.load().buildQueryRequest());
-
-export const fetchClient = createFetchClient<Router>({
-  url: process.env.LIVE_STATE_API_URL || "http://localhost:3333/api/ls",
-  schema,
-  credentials: async () => ({
-    "x-discord-bot-key": process.env.DISCORD_BOT_KEY ?? "",
-  }),
+export const { client, store, fetchClient } = createLiveStateClient({
+  botKey: process.env.DISCORD_BOT_KEY ?? "",
+  label: "GitHub",
 });

--- a/connectors/github/src/lib/queue.ts
+++ b/connectors/github/src/lib/queue.ts
@@ -1,5 +1,7 @@
+import { createRedisConnection } from "@connectors/framework/runtime";
 import { Queue } from "bullmq";
-import Redis from "ioredis";
+
+export { createRedisConnection } from "@connectors/framework/runtime";
 
 /**
  * Queue + connection for the github app's own BullMQ jobs. Integration apps own
@@ -43,42 +45,6 @@ export type BackfillJobData = {
  * auth + paging inputs); kept as a distinct type for intent.
  */
 export type ReconcileRepoJobData = BackfillJobData;
-
-/**
- * Create a Redis connection configured for BullMQ (`maxRetriesPerRequest: null`
- * is required by both Queue and Worker). Mirrors the worker app's connection
- * resolution: prefer `REDIS_URL`, fall back to discrete host/port/etc.
- */
-export const createRedisConnection = (): Redis => {
-  if (process.env.REDIS_URL) {
-    return new Redis(process.env.REDIS_URL, { maxRetriesPerRequest: null });
-  }
-
-  const redisConfig: {
-    host: string;
-    port?: number;
-    password?: string;
-    db?: number;
-    maxRetriesPerRequest: null;
-  } = {
-    host: process.env.REDIS_HOST ?? "localhost",
-    maxRetriesPerRequest: null,
-  };
-
-  if (process.env.REDIS_PORT) {
-    redisConfig.port = Number.parseInt(process.env.REDIS_PORT, 10);
-  }
-
-  if (process.env.REDIS_PASSWORD) {
-    redisConfig.password = process.env.REDIS_PASSWORD;
-  }
-
-  if (process.env.REDIS_DB) {
-    redisConfig.db = Number.parseInt(process.env.REDIS_DB, 10);
-  }
-
-  return new Redis(redisConfig);
-};
 
 let queue: Queue<BackfillJobData> | null = null;
 
@@ -141,7 +107,7 @@ export const ensureReconcileScheduler = async () => {
         removeOnComplete: { count: 20, age: 7 * 24 * 3600 },
         removeOnFail: { count: 50 },
       },
-    }
+    },
   );
 };
 

--- a/connectors/slack/package.json
+++ b/connectors/slack/package.json
@@ -8,6 +8,7 @@
     "dev": "bun run --watch src/index.ts"
   },
   "dependencies": {
+    "@connectors/framework": "workspace:*",
     "@reflag/node-sdk": "^1.1.0",
     "@live-state/sync": "catalog:",
     "@slack/bolt": "^4.6.0",

--- a/connectors/slack/src/index.ts
+++ b/connectors/slack/src/index.ts
@@ -17,6 +17,7 @@ import { WebClient } from "@slack/web-api";
 import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsHistoryResponse";
 import { parse } from "@workspace/utils/md-tiptap";
 import { stringify } from "@workspace/utils/tiptap-md";
+import { z } from "zod";
 import { closeDigestWorker, initializeDigestWorker } from "./lib/digest-queue";
 import { reflagClient } from "./lib/feature-flag";
 import { installationStore } from "./lib/installation-store";
@@ -35,6 +36,9 @@ import {
   updateSyncedChannels,
   withBackfillLock,
 } from "./lib/utils";
+
+/** Thread `externalMetadataStr` shape — a non-empty Slack channel id. */
+const externalMetadataSchema = z.object({ channelId: z.string().min(1) });
 
 const app = new App({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
@@ -891,10 +895,10 @@ const resolveSlackTarget = async (thread: {
   let channelId: string | null = null;
   if (thread.externalMetadataStr) {
     try {
-      const metadata = JSON.parse(thread.externalMetadataStr) as {
-        channelId?: string;
-      };
-      channelId = metadata.channelId ?? null;
+      const metadata = externalMetadataSchema.parse(
+        JSON.parse(thread.externalMetadataStr),
+      );
+      channelId = metadata.channelId;
     } catch (error) {
       console.error("Error parsing externalMetadataStr:", error);
     }

--- a/connectors/slack/src/index.ts
+++ b/connectors/slack/src/index.ts
@@ -1,6 +1,12 @@
 import "./env";
 
-import type { InferLiveObject } from "@live-state/sync";
+import {
+  buildPortalThreadUrl,
+  type OutboundMessage,
+  type OutboundUpdate,
+  safeParseJSON,
+  startOutboundReplication,
+} from "@connectors/framework/runtime";
 import type {
   AllMiddlewareArgs,
   AuthorizeResult,
@@ -11,7 +17,6 @@ import { WebClient } from "@slack/web-api";
 import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsHistoryResponse";
 import { parse } from "@workspace/utils/md-tiptap";
 import { stringify } from "@workspace/utils/tiptap-md";
-import type { schema } from "api/schema";
 import { closeDigestWorker, initializeDigestWorker } from "./lib/digest-queue";
 import { reflagClient } from "./lib/feature-flag";
 import { installationStore } from "./lib/installation-store";
@@ -148,22 +153,6 @@ const app = new App({
   },
 });
 
-const safeParseJSON = (raw: string) => {
-  try {
-    const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) return parsed;
-    if (parsed && typeof parsed === "object" && "content" in parsed) {
-      return (parsed as { content?: unknown }).content ?? [];
-    }
-  } catch {}
-  return [
-    {
-      type: "paragraph",
-      content: [{ type: "text", text: String(raw) }],
-    },
-  ];
-};
-
 type RelatedThreadLink = {
   threadId: string;
   name: string | null;
@@ -176,16 +165,6 @@ const sleep = (ms: number) =>
   new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
-
-const buildPortalThreadUrl = (
-  baseUrl: string,
-  organizationSlug: string,
-  threadId: string,
-) => {
-  const baseUrlObj = new URL(baseUrl);
-  const port = baseUrlObj.port ? `:${baseUrlObj.port}` : "";
-  return `${baseUrlObj.protocol}//${organizationSlug}.${baseUrlObj.hostname}${port}/threads/${threadId}`;
-};
 
 // TODO(signals-overhaul): related-threads polling used the dropped `suggestion`
 // table. Rebuild on the new pipeline before re-enabling the related-threads
@@ -477,7 +456,9 @@ const backfillChannel = async (
     // Check budget and queue thread jobs (all inside lock so total stays accurate if enqueue fails)
     let queuedCount = 0;
     await withBackfillLock(integrationId, async () => {
-      const integration = await fetchClient.query.integration.byId({ id: integrationId });
+      const integration = await fetchClient.query.integration.byId({
+        id: integrationId,
+      });
       const currentSettings = safeParseIntegrationSettings(
         integration?.configStr ?? null,
       );
@@ -529,7 +510,9 @@ const backfillChannel = async (
 
     // Determine if there are more pages
     const budgetExhausted = await (async () => {
-      const integration = await fetchClient.query.integration.byId({ id: integrationId });
+      const integration = await fetchClient.query.integration.byId({
+        id: integrationId,
+      });
       const settings = safeParseIntegrationSettings(
         integration?.configStr ?? null,
       );
@@ -544,7 +527,9 @@ const backfillChannel = async (
     if (!hasMorePages || budgetExhausted) {
       // This channel is done discovering — decrement channelsDiscovering
       await withBackfillLock(integrationId, async () => {
-        const integration = await fetchClient.query.integration.byId({ id: integrationId });
+        const integration = await fetchClient.query.integration.byId({
+          id: integrationId,
+        });
         const settings = safeParseIntegrationSettings(
           integration?.configStr ?? null,
         );
@@ -669,7 +654,9 @@ const handleIntegrationChanges = async (
 
       // Initialize/accumulate backfill status
       await withBackfillLock(integration.id, async () => {
-        const latestIntegration = await fetchClient.query.integration.byId({ id: integration.id });
+        const latestIntegration = await fetchClient.query.integration.byId({
+          id: integration.id,
+        });
         const latestSettings = safeParseIntegrationSettings(
           latestIntegration?.configStr ?? null,
         );
@@ -874,82 +861,82 @@ app.message(
   },
 );
 
-const handleMessages = async (
-  messages: InferLiveObject<
-    (typeof schema)["message"],
-    { thread: true; author: { include: { user: true } } }
-  >[],
-) => {
-  for (const message of messages) {
-    // TODO this is not consistent, either we make this part of the include or we wait until the store is bootstrapped. Remove the timeout when this is fixed.
-    const integration = store.query.integration
-      .first({
-        organizationId: message.thread?.organizationId,
-        type: "slack",
-      })
-      .get();
+/**
+ * Resolve the Slack workspace client + channel/thread a normalized thread maps
+ * to, or `null` if this connector can't currently deliver to it. The parent
+ * channel id lives in the thread's `externalMetadataStr`; the thread ts on
+ * `externalId`.
+ */
+const resolveSlackTarget = async (thread: {
+  organizationId?: string;
+  externalId?: string | null;
+  externalMetadataStr?: string | null;
+}): Promise<{
+  client: WebClient;
+  channelId: string;
+  threadTs: string;
+} | null> => {
+  const integration = store.query.integration
+    .first({ organizationId: thread?.organizationId, type: "slack" })
+    .get();
+  if (!integration || !integration.configStr) return null;
 
-    if (!integration || !integration.configStr) continue;
+  const parsedConfig = safeParseIntegrationSettings(integration.configStr);
+  const teamId = parsedConfig?.teamId;
+  if (!teamId) return null;
 
-    const parsedConfig = safeParseIntegrationSettings(integration.configStr);
+  const threadTs = thread.externalId;
+  if (!threadTs) return null;
 
-    if (!parsedConfig) continue;
-
-    const teamId = parsedConfig.teamId;
-
-    if (!teamId) continue;
-
-    const threadTs = message.thread.externalId;
-
-    if (!threadTs) continue;
-
-    let channelId: string | null = null;
-    if (message.thread.externalMetadataStr) {
-      try {
-        const metadata = JSON.parse(message.thread.externalMetadataStr) as {
-          channelId?: string;
-        };
-        channelId = metadata.channelId ?? null;
-      } catch (error) {
-        console.error("Error parsing externalMetadataStr:", error);
-      }
-    }
-
-    if (!channelId) continue;
-
+  let channelId: string | null = null;
+  if (thread.externalMetadataStr) {
     try {
-      const client = await getClientForTeam(teamId);
-      if (!client) continue;
-
-      const result = await client.chat.postMessage({
-        channel: channelId,
-        text: stringify(safeParseJSON(message.content), {
-          heading: true,
-          horizontalRule: true,
-        }),
-        thread_ts: threadTs,
-        username: message.author.name,
-        icon_url: message.author?.user?.image ?? undefined,
-      });
-
-      if (result.ok && result.ts) {
-        store.mutate.message.setExternalMessageId({
-          messageId: message.id,
-          externalMessageId: result.ts,
-        });
-      }
+      const metadata = JSON.parse(thread.externalMetadataStr) as {
+        channelId?: string;
+      };
+      channelId = metadata.channelId ?? null;
     } catch (error) {
-      console.error("Error sending Slack message:", error);
+      console.error("Error parsing externalMetadataStr:", error);
     }
+  }
+  if (!channelId) return null;
+
+  const client = await getClientForTeam(teamId);
+  if (!client) return null;
+
+  return { client, channelId, threadTs };
+};
+
+/**
+ * Deliver one outbound reply to Slack. Returns the message `ts` to round-trip,
+ * or `null` to leave it for the next pass.
+ */
+const deliverSlackMessage = async (
+  message: OutboundMessage,
+): Promise<string | null> => {
+  const target = await resolveSlackTarget(message.thread);
+  if (!target) return null;
+
+  try {
+    const result = await target.client.chat.postMessage({
+      channel: target.channelId,
+      text: stringify(safeParseJSON(message.content), {
+        heading: true,
+        horizontalRule: true,
+      }),
+      thread_ts: target.threadTs,
+      username: message.author.name,
+      icon_url: message.author?.user?.image ?? undefined,
+    });
+
+    return result.ok && result.ts ? result.ts : null;
+  } catch (error) {
+    console.error("Error sending Slack message:", error);
+    return null;
   }
 };
 
-const formatUpdateMessage = (
-  update: InferLiveObject<
-    (typeof schema)["update"],
-    { thread: true; user: true }
-  >,
-): string => {
+const formatUpdateMessage = (update: OutboundUpdate): string => {
   let metadata: Record<string, unknown> | null = null;
   if (update.metadataStr) {
     try {
@@ -982,89 +969,24 @@ const formatUpdateMessage = (
   return `*${userName}* updated the thread`;
 };
 
-const handlingUpdates = new Set<string>();
+/**
+ * Deliver one outbound thread update to Slack as a threaded message. Returns the
+ * message `ts` to round-trip, or `null` to leave it un-replicated. The
+ * framework's outbound helper owns the replicated-check and in-flight dedup.
+ */
+const deliverSlackUpdate = async (
+  update: OutboundUpdate,
+): Promise<string | null> => {
+  const target = await resolveSlackTarget(update.thread);
+  if (!target) return null;
 
-const handleUpdates = async (
-  updates: InferLiveObject<
-    (typeof schema)["update"],
-    { thread: true; user: true }
-  >[],
-) => {
-  for (const update of updates) {
-    const replicated = update.replicatedStr
-      ? JSON.parse(update.replicatedStr)
-      : {};
-    if (replicated.slack) continue;
+  const result = await target.client.chat.postMessage({
+    channel: target.channelId,
+    text: formatUpdateMessage(update),
+    thread_ts: target.threadTs,
+  });
 
-    if (handlingUpdates.has(update.id)) continue;
-
-    // TODO this is not consistent, either we make this part of the include or we wait until the store is bootstrapped. Remove the timeout when this is fixed.
-    const integration = store.query.integration
-      .first({
-        organizationId: update.thread?.organizationId,
-        type: "slack",
-      })
-      .get();
-
-    if (!integration || !integration.configStr) continue;
-
-    const parsedConfig = safeParseIntegrationSettings(integration.configStr);
-
-    if (!parsedConfig) continue;
-
-    const teamId = parsedConfig.teamId;
-
-    if (!teamId) continue;
-
-    const threadTs = update.thread.externalId;
-
-    if (!threadTs) continue;
-
-    let channelId: string | null = null;
-    if (update.thread.externalMetadataStr) {
-      try {
-        const metadata = JSON.parse(update.thread.externalMetadataStr) as {
-          channelId?: string;
-        };
-        channelId = metadata.channelId ?? null;
-      } catch (error) {
-        console.error("Error parsing externalMetadataStr:", error);
-      }
-    }
-
-    if (!channelId) continue;
-
-    handlingUpdates.add(update.id);
-
-    try {
-      const client = await getClientForTeam(teamId);
-      if (!client) {
-        handlingUpdates.delete(update.id);
-        continue;
-      }
-
-      const updateMessage = formatUpdateMessage(update);
-      const result = await client.chat.postMessage({
-        channel: channelId,
-        text: updateMessage,
-        thread_ts: threadTs,
-      });
-
-      if (result.ok && result.ts) {
-        await fetchClient.mutate.update.markReplicated({
-          updateId: update.id,
-          replicatedStr: JSON.stringify({
-            ...replicated,
-            slack: result.ts,
-          }),
-        });
-      }
-    } catch (error) {
-      console.error("Error sending update bot message:", error);
-    } finally {
-      handlingUpdates.delete(update.id);
-    }
-  }
+  return result.ok && result.ts ? result.ts : null;
 };
 
 (async () => {
@@ -1084,7 +1006,9 @@ const handleUpdates = async (
     processThread: backfillThread,
     onThreadBackfillComplete: async (integrationId: string) => {
       await withBackfillLock(integrationId, async () => {
-        const integration = await fetchClient.query.integration.byId({ id: integrationId });
+        const integration = await fetchClient.query.integration.byId({
+          id: integrationId,
+        });
         const settings = safeParseIntegrationSettings(
           integration?.configStr ?? null,
         );
@@ -1120,54 +1044,17 @@ const handleUpdates = async (
   initializeDigestWorker(getClientForTeam);
 
   setTimeout(async () => {
-    // TODO Subscribe callback is not being triggered with current values - track https://github.com/pedroscosta/live-state/issues/82
-    await handleMessages(
-      await store.query.message
-        .where({
-          externalMessageId: null,
-          thread: {
-            externalOrigin: "slack",
-            externalId: { $not: null },
-            externalMetadataStr: { $not: null },
-          },
-        })
-        .include({ thread: true, author: { include: { user: true } } })
-        .get(),
-    );
-    store.query.message
-      .where({
-        externalMessageId: null,
-        thread: {
-          externalOrigin: "slack",
-          externalId: { $not: null },
-          externalMetadataStr: { $not: null },
-        },
-      })
-      .include({ thread: true, author: { include: { user: true } } })
-      .subscribe(handleMessages);
-
-    const updates = await store.query.update
-      .where({
-        thread: {
-          externalOrigin: "slack",
-          externalId: { $not: null },
-          externalMetadataStr: { $not: null },
-        },
-      })
-      .include({ thread: true, user: true })
-      .get();
-
-    await handleUpdates(updates);
-    store.query.update
-      .where({
-        thread: {
-          externalOrigin: "slack",
-          externalId: { $not: null },
-          externalMetadataStr: { $not: null },
-        },
-      })
-      .include({ thread: true, user: true })
-      .subscribe(handleUpdates);
+    // Watch un-replicated outbound messages/updates for Slack threads and
+    // deliver them; the framework owns the round-trip of external message ids.
+    // Slack additionally requires the parent channel id in externalMetadataStr.
+    await startOutboundReplication({
+      store,
+      fetchClient,
+      provider: "slack",
+      threadFilter: { externalMetadataStr: { $not: null } },
+      deliverMessage: deliverSlackMessage,
+      deliverUpdate: deliverSlackUpdate,
+    });
 
     // Subscribe to Slack integrations to trigger backfill when channels are added
     store.query.integration

--- a/connectors/slack/src/lib/digest-queue.ts
+++ b/connectors/slack/src/lib/digest-queue.ts
@@ -1,43 +1,25 @@
+import {
+  createWorker,
+  type Job,
+  type Worker,
+} from "@connectors/framework/runtime";
 import type { KnownBlock, WebClient } from "@slack/web-api";
 import {
   type DigestNotifyJobData,
   digestNotifyJobDataSchema,
 } from "@workspace/schemas/digest";
 import { formatRelativeTime } from "@workspace/utils/format";
-import { type Job, Worker } from "bullmq";
-import Redis, { type RedisOptions } from "ioredis";
 import "../env";
 
 const DIGEST_NOTIFY_QUEUE = "digest-notify";
 const MAX_ITEMS_PER_SECTION = 5;
 
 function escapeMrkdwn(text: string): string {
-  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
-
-const getRedisConnection = (): Redis => {
-  if (process.env.REDIS_URL) {
-    return new Redis(process.env.REDIS_URL, { maxRetriesPerRequest: null });
-  }
-
-  const redisConfig: RedisOptions = {
-    host: process.env.REDIS_HOST ?? "localhost",
-    port: process.env.REDIS_PORT
-      ? Number.parseInt(process.env.REDIS_PORT, 10)
-      : 6379,
-    maxRetriesPerRequest: null,
-  };
-
-  if (process.env.REDIS_PASSWORD) {
-    redisConfig.password = process.env.REDIS_PASSWORD;
-  }
-
-  if (process.env.REDIS_DB) {
-    redisConfig.db = Number.parseInt(process.env.REDIS_DB, 10);
-  }
-
-  return new Redis(redisConfig);
-};
 
 let digestWorker: Worker<DigestNotifyJobData> | null = null;
 
@@ -49,7 +31,7 @@ export const initializeDigestWorker = (
     return digestWorker;
   }
 
-  digestWorker = new Worker<DigestNotifyJobData>(
+  digestWorker = createWorker<DigestNotifyJobData>(
     DIGEST_NOTIFY_QUEUE,
     async (job: Job<DigestNotifyJobData>) => {
       const parsed = digestNotifyJobDataSchema.safeParse(job.data);
@@ -100,7 +82,6 @@ export const initializeDigestWorker = (
       }
     },
     {
-      connection: getRedisConnection(),
       concurrency: 1,
     },
   );

--- a/connectors/slack/src/lib/feature-flag.ts
+++ b/connectors/slack/src/lib/feature-flag.ts
@@ -1,6 +1,4 @@
-import { ReflagClient } from "@reflag/node-sdk";
+import { createReflagClient } from "@connectors/framework/runtime";
 
-// Create a singleton instance of the Reflag client
-export const reflagClient = new ReflagClient({
-  secretKey: process.env.REFLAG_SECRET_KEY,
-});
+// Singleton Reflag client for feature flags.
+export const reflagClient = createReflagClient();

--- a/connectors/slack/src/lib/live-state.ts
+++ b/connectors/slack/src/lib/live-state.ts
@@ -1,35 +1,6 @@
-import { createClient } from "@live-state/sync/client";
-import { createClient as createFetchClient } from "@live-state/sync/client/fetch";
-import type { Router } from "api/router";
-import { schema } from "api/schema";
+import { createLiveStateClient } from "@connectors/framework/runtime";
 
-export const { client, store } = createClient<Router>({
-  url: process.env.LIVE_STATE_WS_URL ?? "ws://localhost:3333/api/ls/ws",
-  schema,
-  credentials: async () => ({
-    discordBotKey: process.env.DISCORD_BOT_KEY ?? "",
-  }),
-  storage: false,
-});
-
-client.ws.addEventListener("open", () => {
-  console.info("Live State connected");
-});
-
-client.ws.addEventListener("close", () => {
-  console.info("Live State disconnected");
-});
-
-client.ws.addEventListener("error", (error) => {
-  console.error("Live State error: ", error, error.error);
-});
-
-client.load(store.query.organization.load().buildQueryRequest());
-
-export const fetchClient = createFetchClient<Router>({
-  url: process.env.LIVE_STATE_API_URL ?? "http://localhost:3333/api/ls",
-  schema,
-  credentials: async () => ({
-    "x-discord-bot-key": process.env.DISCORD_BOT_KEY ?? "",
-  }),
+export const { client, store, fetchClient } = createLiveStateClient({
+  botKey: process.env.DISCORD_BOT_KEY ?? "",
+  label: "Slack",
 });

--- a/connectors/slack/src/lib/queue.ts
+++ b/connectors/slack/src/lib/queue.ts
@@ -1,22 +1,11 @@
+import {
+  createQueue,
+  createWorker,
+  type Job,
+  type Worker,
+} from "@connectors/framework/runtime";
 import type { WebClient } from "@slack/web-api";
-import { type Job, Queue, Worker } from "bullmq";
 import "../env";
-
-// Redis connection configuration
-const getRedisConnection = () => {
-  if (process.env.REDIS_URL) {
-    return { url: process.env.REDIS_URL };
-  }
-
-  return {
-    host: process.env.REDIS_HOST ?? "localhost",
-    port: process.env.REDIS_PORT
-      ? Number.parseInt(process.env.REDIS_PORT, 10)
-      : 6379,
-    password: process.env.REDIS_PASSWORD,
-    db: process.env.REDIS_DB ? Number.parseInt(process.env.REDIS_DB, 10) : 0,
-  };
-};
 
 // Job data types adapted for Slack
 export type BackfillChannelJobData = {
@@ -46,8 +35,7 @@ export type BackfillChannelResult = {
 };
 
 // Queue instance
-export const backfillQueue = new Queue<BackfillJobData>("slack-backfill", {
-  connection: getRedisConnection(),
+export const backfillQueue = createQueue<BackfillJobData>("slack-backfill", {
   defaultJobOptions: {
     attempts: 3,
     backoff: {
@@ -94,7 +82,7 @@ export const initializeBackfillWorker = (
     return backfillWorker;
   }
 
-  backfillWorker = new Worker<BackfillJobData>(
+  backfillWorker = createWorker<BackfillJobData>(
     "slack-backfill",
     async (job: Job<BackfillJobData>) => {
       const { data } = job;
@@ -143,7 +131,6 @@ export const initializeBackfillWorker = (
       }
     },
     {
-      connection: getRedisConnection(),
       concurrency: 1, // Process 1 job at a time (more conservative for Slack)
       limiter: {
         max: 5, // Max 5 jobs

--- a/connectors/slack/src/lib/utils.ts
+++ b/connectors/slack/src/lib/utils.ts
@@ -1,80 +1,17 @@
+import {
+  createBackfillHelpers,
+  createSettingsParser,
+} from "@connectors/framework/runtime";
 import { slackIntegrationSchema } from "@workspace/schemas/integration/slack";
-import type z from "zod";
 import { fetchClient } from "./live-state";
 
-export const updateBackfillStatus = async (
-  integrationId: string,
-  configStr: string | null,
-  backfill: {
-    processed: number;
-    total: number;
-    limit: number | null;
-    channelsDiscovering: number;
-  } | null,
-) => {
-  const current = safeParseIntegrationSettings(configStr) ?? {};
-  await fetchClient.mutate.integration.updateInstallation({
-    integrationId,
-    configStr: JSON.stringify({ ...current, backfill }),
-  });
-};
+export const { safeParseIntegrationSettings } = createSettingsParser(
+  slackIntegrationSchema,
+);
 
-export const updateSyncedChannels = async (
-  integrationId: string,
-  syncedChannels: string[],
-) => {
-  const latestIntegration = await fetchClient.query.integration.byId({ id: integrationId });
-  const current = safeParseIntegrationSettings(
-    latestIntegration?.configStr ?? null,
-  ) ?? {};
-  await fetchClient.mutate.integration.updateInstallation({
-    integrationId,
-    configStr: JSON.stringify({ ...current, syncedChannels }),
-  });
-};
-
-export const getBackfillLimit = async (
-  organizationId: string,
-): Promise<number | null> => {
-  const subscription = await fetchClient.query.subscription.forOrg({ organizationId });
-  if (!subscription || subscription.plan === "trial") {
-    return 100;
-  }
-  return null;
-};
-
-// Per-integration async mutex to serialize backfill status read-modify-write operations
-const backfillLocks = new Map<string, Promise<void>>();
-
-export const withBackfillLock = async <T>(
-  integrationId: string,
-  fn: () => Promise<T>,
-): Promise<T> => {
-  const existing = backfillLocks.get(integrationId) ?? Promise.resolve();
-  let resolve: () => void;
-  const next = new Promise<void>((r) => {
-    resolve = r;
-  });
-  backfillLocks.set(integrationId, next);
-
-  try {
-    await existing;
-    return await fn();
-  } finally {
-    resolve!();
-    if (backfillLocks.get(integrationId) === next) {
-      backfillLocks.delete(integrationId);
-    }
-  }
-};
-
-export const safeParseIntegrationSettings = (
-  configStr: string | null,
-): z.infer<typeof slackIntegrationSchema> | undefined => {
-  if (!configStr) return undefined;
-  try {
-    return slackIntegrationSchema.parse(JSON.parse(configStr));
-  } catch {
-    return undefined;
-  }
-};
+export const {
+  withBackfillLock,
+  updateBackfillStatus,
+  updateSyncedChannels,
+  getBackfillLimit,
+} = createBackfillHelpers(fetchClient);


### PR DESCRIPTION
## Summary

De-dup pass now that Discord + Slack are both on the ingest contract (FRO-197/FRO-198). Lifts shared connector **runtime** scaffolding into a node-only subpath export `@connectors/framework/runtime`, keeping the package root (`.`) dependency-free/browser-safe so the web client can still import the manifest for FRO-194 gating.

Part of FRO-196 (emitting-side connector retrofit, ADR-0009).

## Lifted into `@connectors/framework/runtime`

- **live-state** — client bootstrap (`client` + `fetchClient` + reconnect logging), bot-key credential name parameterized
- **redis** — connection + BullMQ Queue/Worker factory (kills the 3× `getRedisConnection`)
- **feature-flag** — shared `reflag` client
- **backfill** — orchestration (`withBackfillLock`, `updateBackfillStatus`, `updateSyncedChannels`, `getBackfillLimit`) via generic `integration.settings` writes
- **portal** — thread URL builder
- **settings** — integration-settings parse helpers (`safeParseIntegrationSettings` / `safeParseJSON`)
- **outbound** — normalized outbound-subscription pull-deliver loop (watch un-replicated `update`/`message`, deliver, round-trip external id) so connectors stop re-implementing `markReplicated` / `setExternalMessageId`

## Explicitly NOT lifted (stays per-connector)

Provider SDK setup (discord.js / bolt / octokit), webhook signature verification, OAuth/install, digest rendering, author display-name resolution, `env` loading.

## Done when

`getRedisConnection`, `live-state.ts`, `feature-flag.ts`, and the backfill helpers exist once in `@connectors/framework/runtime`; the browser bundle still imports only the pure root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted shared connector runtime into node‑only `@connectors/framework/runtime` to dedupe Discord and Slack and centralize outbound replication. Adds strict JSON validation for settings/replication blobs, fixes BullMQ Redis connection ownership and `REDIS_URL` parsing (incl. query options), and keeps the root browser‑safe for the web manifest (FRO-199).

- **Refactors**
  - Added shared runtime: live‑state bootstrap, Redis/BullMQ factories, Reflag client, backfill helpers, settings parser with record validation, portal URL builder, and a normalized outbound replication loop.
  - Migrated Discord and Slack to the shared helpers; removed local live‑state, feature‑flag, queue/Redis, backfill, and outbound code. GitHub now uses the live‑state client and Redis helper.
  - Outbound replies and updates run through `startOutboundReplication`; Slack adds a `threadFilter` requiring `externalMetadataStr`.

- **Bug Fixes**
  - BullMQ connections: pass ioredis options (parsed from `REDIS_URL` or env) so BullMQ constructs and closes its own sockets; carry URL query options (e.g. `?family=6`) and coerce numeric values; removed ad‑hoc `getRedisConnection` and fixed a leaked‑connection bug.
  - Outbound hardening: provider invariants can’t be overridden, in‑flight guards prevent duplicate deliveries, and `replicatedStr` is validated per row and skipped if malformed.
  - Settings/backfill safety: `configStr` is parsed as a plain record (Zod) before merging and aborts on malformed JSON; `updateSyncedChannels` re‑reads the latest config; only `pro` is uncapped, free plans are capped at 100 threads.
  - Slack: require a non‑empty `channelId` in `externalMetadataStr` before posting.

<sup>Written for commit a2c084edbea84aefeb47ff3f0bdb8a14e44b2933. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared connector runtime capabilities for outbound message/update replication, live-state access, queues/workers, feature flags, settings parsing, backfills, and portal thread links.
  * Discord and Slack now deliver outbound messages and updates using the shared replication workflow, reducing legacy polling/subscription behavior.
* **Refactor**
  * Standardized Discord, Slack, and GitHub connector infrastructure to shared runtime helpers for Redis/queue setup, live-state bootstrapping, feature flag clients, and safe JSON/settings parsing.
  * Consolidated backfill state handling and syncing logic using runtime-provided helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->