### PR TITLE
feat(api,connectors): drop deprecated thread.discordChannelId (FRO-200)

### DIFF
--- a/apps/api/src/live-state/router/ingest.ts
+++ b/apps/api/src/live-state/router/ingest.ts
@@ -119,9 +119,6 @@ export const ingestRoute = publicRoute.withProcedures(({ mutation }) => ({
           assignedUserId: null,
           createdAt: message.createdAt,
           deletedAt: null,
-          // Provider-neutral: the deprecated discord-specific column is left
-          // unset; outbound delivery reads `externalId`/`externalOrigin`.
-          discordChannelId: null,
           externalIssueId: null,
           externalPrId: null,
           externalId: externalThreadId,

--- a/apps/api/src/live-state/router/threads.ts
+++ b/apps/api/src/live-state/router/threads.ts
@@ -84,7 +84,6 @@ const threadCreateInputSchema = z.object({
   id: z.string().optional(),
   createdAt: z.coerce.date().optional(),
   status: z.number().int().min(0).max(4).optional(),
-  discordChannelId: z.string().nullable().optional(),
   externalId: z.string().nullable().optional(),
   externalOrigin: z.string().nullable().optional(),
   externalMetadataStr: z.string().nullable().optional(),
@@ -104,7 +103,6 @@ export default publicRoute.withProcedures(({ mutation, query }) => ({
       req.input.id !== undefined ||
       req.input.createdAt !== undefined ||
       req.input.status !== undefined ||
-      req.input.discordChannelId !== undefined ||
       req.input.externalId !== undefined ||
       req.input.externalOrigin !== undefined ||
       req.input.externalMetadataStr !== undefined ||
@@ -195,7 +193,6 @@ export default publicRoute.withProcedures(({ mutation, query }) => ({
         assignedUserId: null,
         createdAt: req.input.createdAt ?? new Date(),
         deletedAt: null,
-        discordChannelId: req.input.discordChannelId ?? null,
         externalIssueId: null,
         externalPrId: null,
         externalId: req.input.externalId ?? null,

--- a/apps/api/src/live-state/schema.ts
+++ b/apps/api/src/live-state/schema.ts
@@ -56,8 +56,6 @@ const thread = object("thread", {
   authorId: reference("author.id"),
   createdAt: timestamp(),
   deletedAt: timestamp().nullable(),
-  /** @deprecated use externalId and externalOrigin instead */
-  discordChannelId: string().nullable(),
   // Link to a mirrored externalEntity by its externalKey (`provider:owner/repo#number`).
   externalIssueId: string().nullable(),
   externalPrId: string().nullable(),

--- a/apps/worker/src/evals/thread-similarity.dataset.ts
+++ b/apps/worker/src/evals/thread-similarity.dataset.ts
@@ -1213,7 +1213,6 @@ export const convertToThread = (data: FakeThreadData): Thread => {
     authorId: "author_eval",
     createdAt,
     deletedAt: null,
-    discordChannelId: null,
     externalIssueId: null,
     externalPrId: null,
     status: 0,

--- a/connectors/discord/src/index.ts
+++ b/connectors/discord/src/index.ts
@@ -633,8 +633,7 @@ client.on("messageCreate", async (message) => {
 /**
  * Resolve the Discord channel a normalized thread maps to, or `null` if this
  * connector can't currently deliver to it (no matching guild in cache, etc.).
- * The channel id lives on `thread.externalId` (guarded by `externalOrigin`),
- * no longer on the deprecated `discordChannelId` column ingest stopped writing.
+ * The channel id lives on `thread.externalId`, guarded by `externalOrigin`.
  */
 const resolveDiscordChannel = async (thread: {
   organizationId?: string;


### PR DESCRIPTION
## What

Retires the `@deprecated` `thread.discordChannelId` column (FRO-200, part of FRO-196 emitting-side connector retrofit).

The Discord pull-deliver path was already migrated to read the channel id from `externalId` (guarded by `externalOrigin === "discord"`) via `resolveDiscordChannel` in an earlier sub-issue. This PR removes the last writers and drops the column.

## Changes

- **schema** (`apps/api/src/live-state/schema.ts`) — drop the `discordChannelId` column
- **threads router** — remove the input-schema field, the `hasIntegrationOnlyFields` gating check, and the insert value
- **ingest router** — remove the `discordChannelId: null` insert
- **worker eval fixture** — remove the field
- **discord** — update the now-stale doc comment on `resolveDiscordChannel`

## Data

No data migration needed — existing rows already carry the same value in `externalId`/`externalOrigin`, and the column had no remaining readers. The physical Postgres column drop is managed by live-state from `schema.ts`.

## Verification

- `grep discordChannelId` across the repo → zero matches
- `bun run typecheck` → 11/11 packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Threads can now link directly to external issues and pull requests for improved tracking.

* **Bug Fixes**
  * Removed support for the deprecated Discord channel identifier when creating and storing threads.
  * Updated Discord channel resolution to use the thread’s external identifier consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->