### PR TITLE
feat(worker,api): PR embedding index + eligibility (FRO-203)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -96,7 +96,7 @@ _Avoid_: "cache" (implies disposable/expiry; the mirror is durable and queried a
 
 ### PR index
 
-The vector index of mirrored [external pull requests](#external-pull-request), kept in step with the [mirror](#mirror) so PR↔thread similarity can be searched. Each indexed PR carries an **`eligible`** flag — true only while the PR is *open and non-draft* — and search filters to eligible PRs. Every mirror write (webhook, backfill, drift reconciliation) refreshes the index; close / convert-to-draft flips `eligible` false, reopen / ready_for_review / content edits refresh it. Indexing is **index-only**: it never enqueues a `pr_matched` [trigger](#trigger). The index feeds both discovery paths — the push-side match (PR → similar threads) and the pull-side `related_prs` [hint](#read-hint) (thread → similar PRs). A PR is embedded from its *title + body + head ref*.
+The vector index of mirrored [external pull requests](#external-pull-request), kept in step with the [mirror](#mirror) so PR↔thread similarity can be searched. Each indexed PR carries an **`eligible`** flag — true only while the PR is *open and non-draft* — and search filters to eligible PRs. Every mirror write (webhook, backfill, drift reconciliation) refreshes the index; close / convert-to-draft flips `eligible` false, reopen / ready_for_review / content edits refresh it. Indexing is **index-only**: it never enqueues a `pr_matched` [trigger](#trigger). This PR only *maintains* the index — it implements neither discovery flow. The index is intended to feed two future consumers: the push-side match (PR → similar threads) and the pull-side `related_prs` [hint](#read-hint) (thread → similar PRs). A PR is embedded from its *title + body + head ref*.
 
 ### Flagged ambiguities
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -94,6 +94,10 @@ _Avoid_: "PR" alone when ambiguous, "merge request".
 FrontDesk's local, read-only replica of authoritative external data ([external issues](#external-issue) and [external pull requests](#external-pull-request)). The external system is the source of truth; the mirror is only ever updated *from* it (webhooks + backfill + drift reconciliation), never written canonically from our side. Actions taken in FrontDesk go out to the external system and round-trip back into the mirror. Used as a verb ("we mirror the repo's issues") and a noun ("the mirror").
 _Avoid_: "cache" (implies disposable/expiry; the mirror is durable and queried as primary), "sync copy".
 
+### PR index
+
+The vector index of mirrored [external pull requests](#external-pull-request), kept in step with the [mirror](#mirror) so PR↔thread similarity can be searched. Each indexed PR carries an **`eligible`** flag — true only while the PR is *open and non-draft* — and search filters to eligible PRs. Every mirror write (webhook, backfill, drift reconciliation) refreshes the index; close / convert-to-draft flips `eligible` false, reopen / ready_for_review / content edits refresh it. Indexing is **index-only**: it never enqueues a `pr_matched` [trigger](#trigger). The index feeds both discovery paths — the push-side match (PR → similar threads) and the pull-side `related_prs` [hint](#read-hint) (thread → similar PRs). A PR is embedded from its *title + body + head ref*.
+
 ### Flagged ambiguities
 
 **"External" is overloaded.** On a thread, `externalId` / `externalOrigin` mean *where the thread itself originated* (Discord channel, Slack message). This is **not** the same as a linked [external issue](#external-issue) / [external pull request](#external-pull-request), which is a separate developer-system entity the thread points to. When the origin is meant, say "thread origin"; when the linked entity is meant, say "external issue / pull request".

--- a/apps/api/src/lib/queue.ts
+++ b/apps/api/src/lib/queue.ts
@@ -1,4 +1,5 @@
 import type {
+  PrIndexJobData,
   PrMatchCandidate,
   ThreadReadJobData,
   ThreadReadKind,
@@ -17,6 +18,8 @@ export const areWorkerJobsEnabled = (): boolean => !WORKER_JOBS_DISABLED;
 const THREAD_PIPELINE_QUEUE = "thread-pipeline";
 const THREAD_READ_JOB_NAME = "thread-read";
 const CRAWL_DOCUMENTATION_QUEUE = "crawl-documentation";
+const PR_INDEX_QUEUE = "pr-index";
+const PR_INDEX_JOB_NAME = "index-pr";
 
 const DEFAULT_DEBOUNCE_MS = (() => {
   const raw = process.env.THREAD_READ_DEBOUNCE_MS;
@@ -196,6 +199,70 @@ export const enqueueCrawlDocumentation = async (
 
   const job = await queue.add("crawl-documentation", data, {
     jobId: `crawl-${data.documentationSourceId}`,
+  });
+
+  return job.id ?? null;
+};
+
+// PR embedding index queue (FRO-203)
+//
+// The worker owns the PR vector index (embedding + Qdrant live only there); the
+// API is the single mirror choke point (`externalEntity.upsert`), so it enqueues
+// an index job after every PR mirror write. Index-only: this never fans out
+// `pr_matched` thread reads. One pending job per PR (`pr-index:{externalKey}`)
+// coalesces a burst of mirror events into a single re-embed.
+
+let prIndexQueue: Queue<PrIndexJobData> | null = null;
+
+const getPrIndexQueue = (): Queue<PrIndexJobData> | null => {
+  if (prIndexQueue) {
+    return prIndexQueue;
+  }
+
+  connection ??= createRedisConnection();
+  if (!connection) {
+    return null;
+  }
+
+  prIndexQueue = new Queue<PrIndexJobData>(PR_INDEX_QUEUE, {
+    connection,
+    defaultJobOptions: {
+      attempts: 3,
+      backoff: { type: "exponential", delay: 5000 },
+    },
+  });
+  return prIndexQueue;
+};
+
+export const enqueuePrIndex = async (
+  data: PrIndexJobData,
+): Promise<string | null> => {
+  if (WORKER_JOBS_DISABLED) {
+    return null;
+  }
+
+  const q = getPrIndexQueue();
+  if (!q) {
+    return null;
+  }
+
+  // Latest mirror state wins: a pending re-index for the same PR is replaced by
+  // this newer one (BullMQ ignores `add` for an existing jobId, so drop the
+  // stale job first). Cheap because the worker skips re-embedding on unchanged
+  // content anyway.
+  const jobId = `pr-index:${data.externalKey}`;
+  const existing = await q.getJob(jobId);
+  if (existing) {
+    const state = await existing.getState();
+    if (state === "delayed" || state === "waiting") {
+      await existing.remove();
+    }
+  }
+
+  const job = await q.add(PR_INDEX_JOB_NAME, data, {
+    jobId,
+    removeOnComplete: { count: 100, age: 24 * 3600 },
+    removeOnFail: { count: 500 },
   });
 
   return job.id ?? null;

--- a/apps/api/src/lib/queue.ts
+++ b/apps/api/src/lib/queue.ts
@@ -246,15 +246,17 @@ export const enqueuePrIndex = async (
     return null;
   }
 
-  // Latest mirror state wins: a pending re-index for the same PR is replaced by
-  // this newer one (BullMQ ignores `add` for an existing jobId, so drop the
-  // stale job first). Cheap because the worker skips re-embedding on unchanged
-  // content anyway.
+  // Latest mirror state wins: any prior re-index for the same PR is replaced by
+  // this newer one (BullMQ ignores `add` for an existing jobId — across *all*
+  // states, including completed/failed — so drop the stale job first). We remove
+  // in every state except `active`, where the processor is mid-run and removal is
+  // unsafe; that window is narrow and the worker's content-hash dedup mitigates
+  // it. Cheap because the worker skips re-embedding on unchanged content anyway.
   const jobId = `pr-index:${data.externalKey}`;
   const existing = await q.getJob(jobId);
   if (existing) {
     const state = await existing.getState();
-    if (state === "delayed" || state === "waiting") {
+    if (state !== "active") {
       await existing.remove();
     }
   }

--- a/apps/api/src/live-state/router/external-entity.ts
+++ b/apps/api/src/live-state/router/external-entity.ts
@@ -1,8 +1,9 @@
 // TODO refactor with new live-state mental model
+import type { PrIndexJobData } from "@workspace/schemas/signals";
 import { ulid } from "ulid";
 import { z } from "zod";
 import { authorize, requireInternalApiKey } from "../../lib/authorize";
-import { enqueueGithubBackfill } from "../../lib/queue";
+import { enqueueGithubBackfill, enqueuePrIndex } from "../../lib/queue";
 import { privateRoute } from "../factories";
 import { schema } from "../schema";
 
@@ -91,7 +92,7 @@ export default privateRoute.withProcedures(({ mutation, query }) => ({
       const { organizationId, externalKey } = req.input;
       const now = new Date();
 
-      return db.transaction(async ({ trx }) => {
+      const id = await db.transaction(async ({ trx }) => {
         const existing = Object.values(
           await trx.find(schema.externalEntity, {
             where: { organizationId, externalKey },
@@ -107,15 +108,41 @@ export default privateRoute.withProcedures(({ mutation, query }) => ({
           return existing.id;
         }
 
-        const id = ulid().toLowerCase();
+        const newId = ulid().toLowerCase();
         await trx.insert(schema.externalEntity, {
-          id,
+          id: newId,
           ...req.input,
           lastSyncedAt: now,
           deletedAt: null,
         });
-        return id;
+        return newId;
       });
+
+      // Keep the PR vector index current on every mirror write (webhook,
+      // backfill, reconcile). Index-only: the worker derives eligibility and
+      // re-embeds; it never fans out `pr_matched` reads (FRO-203). Fire-and-log
+      // so an indexing hiccup never fails the mirror write.
+      if (req.input.type === "pull_request") {
+        const jobData: PrIndexJobData = {
+          organizationId,
+          externalEntityId: id,
+          externalKey,
+          provider: req.input.provider,
+          repoFullName: req.input.repoFullName,
+          number: req.input.number,
+          url: req.input.url,
+          title: req.input.title,
+          body: req.input.body,
+          headRef: req.input.headRef,
+          state: req.input.state,
+          draft: req.input.draft,
+        };
+        enqueuePrIndex(jobData).catch((error) => {
+          console.error(`Failed to enqueue PR index for ${externalKey}:`, error);
+        });
+      }
+
+      return id;
     }),
 
     /**
@@ -132,7 +159,7 @@ export default privateRoute.withProcedures(({ mutation, query }) => ({
 
       const { organizationId, externalKey } = req.input;
 
-      return db.transaction(async ({ trx }) => {
+      const deleted = await db.transaction(async ({ trx }) => {
         const existing = Object.values(
           await trx.find(schema.externalEntity, {
             where: { organizationId, externalKey },
@@ -146,8 +173,36 @@ export default privateRoute.withProcedures(({ mutation, query }) => ({
           deletedAt: now,
           lastSyncedAt: now,
         });
-        return existing.id;
+        return { id: existing.id, type: existing.type };
       });
+
+      // Drop the PR vector when its mirror row is removed (PR deleted /
+      // transferred out) so stale points can't surface in similarity search.
+      if (deleted && deleted.type === "pull_request") {
+        const jobData: PrIndexJobData = {
+          organizationId,
+          externalEntityId: deleted.id,
+          externalKey,
+          provider: "",
+          repoFullName: "",
+          number: 0,
+          url: "",
+          title: "",
+          body: null,
+          headRef: null,
+          state: "closed",
+          draft: null,
+          deleted: true,
+        };
+        enqueuePrIndex(jobData).catch((error) => {
+          console.error(
+            `Failed to enqueue PR index delete for ${externalKey}:`,
+            error,
+          );
+        });
+      }
+
+      return deleted?.id ?? null;
     }),
 
     /**

--- a/apps/api/src/live-state/router/external-entity.ts
+++ b/apps/api/src/live-state/router/external-entity.ts
@@ -183,15 +183,6 @@ export default privateRoute.withProcedures(({ mutation, query }) => ({
           organizationId,
           externalEntityId: deleted.id,
           externalKey,
-          provider: "",
-          repoFullName: "",
-          number: 0,
-          url: "",
-          title: "",
-          body: null,
-          headRef: null,
-          state: "closed",
-          draft: null,
           deleted: true,
         };
         enqueuePrIndex(jobData).catch((error) => {

--- a/apps/worker/src/handlers/index-pr.ts
+++ b/apps/worker/src/handlers/index-pr.ts
@@ -75,13 +75,13 @@ export const handleIndexPr = async (job: Job<PrIndexJobData>) => {
 
   // Mirror row removed: drop the vector and stop.
   if (data.deleted) {
-    await deletePrVector(externalKey);
+    await deletePrVector(organizationId, externalKey);
     log.info("worker.pr-index", `Deleted PR vector ${externalKey}`);
     return { externalKey, action: "deleted" as const };
   }
 
   const eligible = data.state === "open" && data.draft !== true;
-  const existing = await getPrPoint(externalKey);
+  const existing = await getPrPoint(organizationId, externalKey);
 
   // Ineligible and never indexed — nothing searchable to store or exclude.
   if (!eligible && !existing) {
@@ -99,7 +99,7 @@ export const handleIndexPr = async (job: Job<PrIndexJobData>) => {
   // Content unchanged since the last index: no re-embed needed. Flip the
   // eligibility flag (and refresh updatedAt) on the existing point in place.
   if (existing && existing.payload.contentHash === contentHash) {
-    await setPrEligibility(externalKey, eligible, now);
+    await setPrEligibility(organizationId, externalKey, eligible, now);
     log.info(
       "worker.pr-index",
       `Refreshed PR ${externalKey} eligibility=${eligible} (no re-embed)`,

--- a/apps/worker/src/handlers/index-pr.ts
+++ b/apps/worker/src/handlers/index-pr.ts
@@ -1,6 +1,9 @@
 import { createHash } from "node:crypto";
 import { google } from "@ai-sdk/google";
-import type { PrIndexJobData } from "@workspace/schemas/signals";
+import type {
+  PrIndexJobData,
+  PrIndexUpsertJobData,
+} from "@workspace/schemas/signals";
 import { log } from "@workspace/utils/logging";
 import { embed } from "ai";
 import type { Job } from "bullmq";
@@ -20,7 +23,7 @@ const embeddingModel = google.embedding(EMBEDDING_MODEL);
  * FRO-201). The head ref (branch name) is a strong, terse signal
  * (e.g. `fix/oauth-token-refresh`) worth its own line.
  */
-const buildEmbedText = (data: PrIndexJobData): string =>
+const buildEmbedText = (data: PrIndexUpsertJobData): string =>
   [
     `title: ${data.title}`,
     data.body ? `body: ${data.body}` : null,

--- a/apps/worker/src/handlers/index-pr.ts
+++ b/apps/worker/src/handlers/index-pr.ts
@@ -1,0 +1,138 @@
+import { createHash } from "node:crypto";
+import { google } from "@ai-sdk/google";
+import type { PrIndexJobData } from "@workspace/schemas/signals";
+import { log } from "@workspace/utils/logging";
+import { embed } from "ai";
+import type { Job } from "bullmq";
+import {
+  deletePrVector,
+  getPrPoint,
+  type PrPayload,
+  setPrEligibility,
+  upsertPrVector,
+} from "../lib/qdrant/pull-requests";
+
+const EMBEDDING_MODEL = "gemini-embedding-001";
+const embeddingModel = google.embedding(EMBEDDING_MODEL);
+
+/**
+ * Text embedded for PR similarity: title + body + head ref (design lock,
+ * FRO-201). The head ref (branch name) is a strong, terse signal
+ * (e.g. `fix/oauth-token-refresh`) worth its own line.
+ */
+const buildEmbedText = (data: PrIndexJobData): string =>
+  [
+    `title: ${data.title}`,
+    data.body ? `body: ${data.body}` : null,
+    data.headRef ? `head: ${data.headRef}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+
+const computeSha256 = (data: string): string =>
+  createHash("sha256").update(data).digest("hex");
+
+/**
+ * Generate a normalized embedding vector. Uses SEMANTIC_SIMILARITY (matching the
+ * thread index) so PR and thread vectors live in a comparable space for
+ * cross-searches.
+ */
+const generateEmbedding = async (text: string): Promise<number[] | null> => {
+  if (!text || text.trim().length === 0) {
+    return null;
+  }
+
+  const { embedding } = await embed({
+    model: embeddingModel,
+    value: text,
+    providerOptions: {
+      google: { taskType: "SEMANTIC_SIMILARITY" },
+    },
+  });
+
+  const norm = Math.hypot(...embedding);
+  if (!Number.isFinite(norm) || norm === 0) {
+    console.warn("PR embedding normalization failed: invalid norm", norm);
+    return embedding;
+  }
+  return embedding.map((value) => value / norm);
+};
+
+/**
+ * Index-only handler for the `pr-index` queue (FRO-203). Keeps the PR vector
+ * index in step with the mirror: embeds eligible (open, non-draft) PRs, marks
+ * closed / draft PRs `eligible: false` so they drop out of search, and removes
+ * the point when the mirror row is deleted. Never fans out `pr_matched` reads.
+ *
+ * Re-embedding is skipped when the embed-relevant content (title + body + head
+ * ref) is unchanged: a pure eligibility flip (close / reopen / draft /
+ * ready_for_review) just updates the payload flag.
+ */
+export const handleIndexPr = async (job: Job<PrIndexJobData>) => {
+  const data = job.data;
+  const { externalKey, organizationId } = data;
+
+  // Mirror row removed: drop the vector and stop.
+  if (data.deleted) {
+    await deletePrVector(externalKey);
+    log.info("worker.pr-index", `Deleted PR vector ${externalKey}`);
+    return { externalKey, action: "deleted" as const };
+  }
+
+  const eligible = data.state === "open" && data.draft !== true;
+  const existing = await getPrPoint(externalKey);
+
+  // Ineligible and never indexed — nothing searchable to store or exclude.
+  if (!eligible && !existing) {
+    log.info(
+      "worker.pr-index",
+      `Skipped ineligible, unindexed PR ${externalKey}`,
+    );
+    return { externalKey, action: "skipped" as const };
+  }
+
+  const embedText = buildEmbedText(data);
+  const contentHash = computeSha256(embedText);
+  const now = Date.now();
+
+  // Content unchanged since the last index: no re-embed needed. Flip the
+  // eligibility flag (and refresh updatedAt) on the existing point in place.
+  if (existing && existing.payload.contentHash === contentHash) {
+    await setPrEligibility(externalKey, eligible, now);
+    log.info(
+      "worker.pr-index",
+      `Refreshed PR ${externalKey} eligibility=${eligible} (no re-embed)`,
+    );
+    return { externalKey, action: "eligibility" as const, eligible };
+  }
+
+  // New PR or edited content: embed and upsert the full point.
+  const embedding = await generateEmbedding(embedText);
+  if (!embedding) {
+    throw new Error(`Failed to embed PR ${externalKey}`);
+  }
+
+  const payload: PrPayload = {
+    externalKey,
+    externalEntityId: data.externalEntityId,
+    organizationId,
+    provider: data.provider,
+    repoFullName: data.repoFullName,
+    number: data.number,
+    url: data.url,
+    title: data.title,
+    headRef: data.headRef,
+    eligible,
+    contentHash,
+    updatedAt: now,
+  };
+
+  const stored = await upsertPrVector(embedding, payload);
+  if (!stored) {
+    throw new Error(`Failed to store PR vector ${externalKey}`);
+  }
+
+  log.info("worker.pr-index", `Indexed PR ${externalKey} eligible=${eligible}`);
+  return { externalKey, action: "indexed" as const, eligible };
+};

--- a/apps/worker/src/lib/qdrant/pull-requests.ts
+++ b/apps/worker/src/lib/qdrant/pull-requests.ts
@@ -16,8 +16,10 @@ export const PR_MATCH_THRESHOLD = 0.85;
 
 /**
  * A mirrored [external pull request](../../../../CONTEXT.md) as stored in the
- * vector index. The point is keyed deterministically by `externalKey`, so a
- * re-index overwrites in place rather than accumulating duplicates.
+ * vector index. The point is keyed deterministically by
+ * `(organizationId, externalKey)` — the mirror row's real identity — so a
+ * re-index overwrites in place rather than accumulating duplicates, and the same
+ * upstream PR mirrored under two orgs stays on distinct points.
  */
 export interface PrPayload {
   /** Provider-agnostic key `provider:owner/repo#number`. */
@@ -41,11 +43,18 @@ export interface PrPayload {
 
 /**
  * Deterministic Qdrant point id for a PR. Qdrant point ids must be an unsigned
- * integer or a UUID string; we hash the `externalKey` and format the digest as a
- * UUID so the same PR always lands on the same point (idempotent upsert).
+ * integer or a UUID string; we hash the mirror row's identity
+ * (`organizationId:externalKey`) and format the digest as a UUID so the same PR
+ * always lands on the same point (idempotent upsert) while two orgs mirroring the
+ * same upstream PR never collide.
  */
-export const prPointId = (externalKey: string): string => {
-  const hex = createHash("sha256").update(externalKey).digest("hex");
+export const prPointId = (
+  organizationId: string,
+  externalKey: string,
+): string => {
+  const hex = createHash("sha256")
+    .update(`${organizationId}:${externalKey}`)
+    .digest("hex");
   return [
     hex.slice(0, 8),
     hex.slice(8, 12),
@@ -107,11 +116,12 @@ export const ensurePrsCollection = async (): Promise<boolean> => {
 
 /** Fetch the stored point for a PR, or null when it was never indexed. */
 export const getPrPoint = async (
+  organizationId: string,
   externalKey: string,
 ): Promise<{ payload: PrPayload } | null> => {
   try {
     const points = await qdrantClient.retrieve(PRS_COLLECTION, {
-      ids: [prPointId(externalKey)],
+      ids: [prPointId(organizationId, externalKey)],
       with_payload: true,
     });
     const point = points[0];
@@ -133,7 +143,7 @@ export const upsertPrVector = async (
       wait: true,
       points: [
         {
-          id: prPointId(payload.externalKey),
+          id: prPointId(payload.organizationId, payload.externalKey),
           vector,
           payload: payload as unknown as Record<string, unknown>,
         },
@@ -152,6 +162,7 @@ export const upsertPrVector = async (
  * embed-relevant content unchanged.
  */
 export const setPrEligibility = async (
+  organizationId: string,
   externalKey: string,
   eligible: boolean,
   updatedAt: number,
@@ -159,7 +170,7 @@ export const setPrEligibility = async (
   try {
     await qdrantClient.setPayload(PRS_COLLECTION, {
       wait: true,
-      points: [prPointId(externalKey)],
+      points: [prPointId(organizationId, externalKey)],
       payload: { eligible, updatedAt },
     });
     return true;
@@ -170,11 +181,14 @@ export const setPrEligibility = async (
 };
 
 /** Remove a PR's point (mirror row deleted / transferred out). */
-export const deletePrVector = async (externalKey: string): Promise<boolean> => {
+export const deletePrVector = async (
+  organizationId: string,
+  externalKey: string,
+): Promise<boolean> => {
   try {
     await qdrantClient.delete(PRS_COLLECTION, {
       wait: true,
-      points: [prPointId(externalKey)],
+      points: [prPointId(organizationId, externalKey)],
     });
     return true;
   } catch (error) {

--- a/apps/worker/src/lib/qdrant/pull-requests.ts
+++ b/apps/worker/src/lib/qdrant/pull-requests.ts
@@ -1,20 +1,59 @@
+import { createHash } from "node:crypto";
 import { qdrantClient } from "./client";
 
-export const PRS_COLLECTION = "prs-v1";
+// v2: FRO-203 reshaped the payload (eligibility + content hash, keyed by
+// externalKey) and the embedded text (title + body + head ref). The v1
+// collection was scaffolding that never had data written to it.
+export const PRS_COLLECTION = "prs-v2";
 export const PR_EMBEDDING_DIMENSIONS = 3072;
 
+/**
+ * Default cosine-similarity floor for treating a PR as a match (design lock,
+ * FRO-201). Consumed by the push-side match and pull-side `related_prs` hint;
+ * the index itself stores every eligible PR regardless of any thread's score.
+ */
+export const PR_MATCH_THRESHOLD = 0.85;
+
+/**
+ * A mirrored [external pull request](../../../../CONTEXT.md) as stored in the
+ * vector index. The point is keyed deterministically by `externalKey`, so a
+ * re-index overwrites in place rather than accumulating duplicates.
+ */
 export interface PrPayload {
-  prNumber: number;
-  owner: string;
-  repo: string;
-  prUrl: string;
-  prTitle: string;
-  shortDescription: string;
-  keywords: string[];
+  /** Provider-agnostic key `provider:owner/repo#number`. */
+  externalKey: string;
+  /** Mirror row id, so a push-side match can resolve a `PrMatchCandidate.prId`. */
+  externalEntityId: string;
   organizationId: string;
-  mergedAt: number;
-  confidence: number;
+  provider: string;
+  repoFullName: string;
+  number: number;
+  url: string;
+  title: string;
+  headRef: string | null;
+  /** Open and non-draft — only eligible PRs are returned by similarity search. */
+  eligible: boolean;
+  /** sha256 of the embed-relevant content (title + body + head ref); lets a
+   * re-index skip re-embedding when only eligibility changed. */
+  contentHash: string;
+  updatedAt: number;
 }
+
+/**
+ * Deterministic Qdrant point id for a PR. Qdrant point ids must be an unsigned
+ * integer or a UUID string; we hash the `externalKey` and format the digest as a
+ * UUID so the same PR always lands on the same point (idempotent upsert).
+ */
+export const prPointId = (externalKey: string): string => {
+  const hex = createHash("sha256").update(externalKey).digest("hex");
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join("-");
+};
 
 export const ensurePrsCollection = async (): Promise<boolean> => {
   try {
@@ -43,23 +82,19 @@ export const ensurePrsCollection = async (): Promise<boolean> => {
     });
 
     await qdrantClient.createPayloadIndex(PRS_COLLECTION, {
-      field_name: "owner",
+      field_name: "externalKey",
       field_schema: "keyword",
     });
 
     await qdrantClient.createPayloadIndex(PRS_COLLECTION, {
-      field_name: "repo",
+      field_name: "repoFullName",
       field_schema: "keyword",
     });
 
+    // The hot filter: similarity search only ever wants eligible PRs.
     await qdrantClient.createPayloadIndex(PRS_COLLECTION, {
-      field_name: "prNumber",
-      field_schema: "integer",
-    });
-
-    await qdrantClient.createPayloadIndex(PRS_COLLECTION, {
-      field_name: "mergedAt",
-      field_schema: "integer",
+      field_name: "eligible",
+      field_schema: "bool",
     });
 
     console.log(`Created Qdrant collection: ${PRS_COLLECTION}`);
@@ -70,8 +105,26 @@ export const ensurePrsCollection = async (): Promise<boolean> => {
   }
 };
 
+/** Fetch the stored point for a PR, or null when it was never indexed. */
+export const getPrPoint = async (
+  externalKey: string,
+): Promise<{ payload: PrPayload } | null> => {
+  try {
+    const points = await qdrantClient.retrieve(PRS_COLLECTION, {
+      ids: [prPointId(externalKey)],
+      with_payload: true,
+    });
+    const point = points[0];
+    if (!point) return null;
+    return { payload: point.payload as unknown as PrPayload };
+  } catch (error) {
+    console.error(`Failed to retrieve PR vector ${externalKey}:`, error);
+    return null;
+  }
+};
+
+/** Upsert the full PR point (vector + payload). Used when content changes. */
 export const upsertPrVector = async (
-  pointId: string,
   vector: number[],
   payload: PrPayload,
 ): Promise<boolean> => {
@@ -80,7 +133,7 @@ export const upsertPrVector = async (
       wait: true,
       points: [
         {
-          id: pointId,
+          id: prPointId(payload.externalKey),
           vector,
           payload: payload as unknown as Record<string, unknown>,
         },
@@ -88,38 +141,115 @@ export const upsertPrVector = async (
     });
     return true;
   } catch (error) {
-    console.error(
-      `Failed to upsert PR vector ${payload.owner}/${payload.repo}#${payload.prNumber} (pointId: ${pointId}):`,
-      error,
-    );
+    console.error(`Failed to upsert PR vector ${payload.externalKey}:`, error);
     return false;
   }
 };
 
-export const deletePrVectors = async (
-  organizationId: string,
-  prNumber: number,
-  owner: string,
-  repo: string,
+/**
+ * Flip a PR's eligibility (and `updatedAt`) without re-embedding — the cheap
+ * path when a close / draft / reopen / ready_for_review event leaves the
+ * embed-relevant content unchanged.
+ */
+export const setPrEligibility = async (
+  externalKey: string,
+  eligible: boolean,
+  updatedAt: number,
 ): Promise<boolean> => {
   try {
-    await qdrantClient.delete(PRS_COLLECTION, {
+    await qdrantClient.setPayload(PRS_COLLECTION, {
       wait: true,
-      filter: {
-        must: [
-          { key: "organizationId", match: { value: organizationId } },
-          { key: "prNumber", match: { value: prNumber } },
-          { key: "owner", match: { value: owner } },
-          { key: "repo", match: { value: repo } },
-        ],
-      },
+      points: [prPointId(externalKey)],
+      payload: { eligible, updatedAt },
     });
     return true;
   } catch (error) {
-    console.error(
-      `Failed to delete PR vector ${owner}/${repo}#${prNumber}:`,
-      error,
-    );
+    console.error(`Failed to set PR eligibility ${externalKey}:`, error);
     return false;
+  }
+};
+
+/** Remove a PR's point (mirror row deleted / transferred out). */
+export const deletePrVector = async (externalKey: string): Promise<boolean> => {
+  try {
+    await qdrantClient.delete(PRS_COLLECTION, {
+      wait: true,
+      points: [prPointId(externalKey)],
+    });
+    return true;
+  } catch (error) {
+    console.error(`Failed to delete PR vector ${externalKey}:`, error);
+    return false;
+  }
+};
+
+export interface SimilarPrSearchOptions {
+  organizationId: string;
+  limit?: number;
+  scoreThreshold?: number;
+  /** Restrict to eligible (open, non-draft) PRs. Defaults to true — the only
+   * case downstream match/hint code wants. */
+  eligibleOnly?: boolean;
+  /** PR keys to omit (e.g. one already linked to the thread). */
+  excludeExternalKeys?: string[];
+}
+
+export interface SimilarPrResult {
+  externalKey: string;
+  score: number;
+  payload: PrPayload;
+}
+
+/**
+ * Rank PRs by similarity to a query vector (a thread embedding on the pull side,
+ * a PR embedding on the push side), filtered to the org and — by default —
+ * eligible PRs only.
+ */
+export const searchSimilarPrs = async (
+  vector: number[],
+  options: SimilarPrSearchOptions,
+): Promise<SimilarPrResult[]> => {
+  const {
+    organizationId,
+    limit = 10,
+    scoreThreshold = PR_MATCH_THRESHOLD,
+    eligibleOnly = true,
+    excludeExternalKeys = [],
+  } = options;
+
+  try {
+    const mustConditions: Array<{
+      key: string;
+      match: { value: string | number | boolean };
+    }> = [{ key: "organizationId", match: { value: organizationId } }];
+
+    if (eligibleOnly) {
+      mustConditions.push({ key: "eligible", match: { value: true } });
+    }
+
+    const mustNotConditions = excludeExternalKeys.map((key) => ({
+      key: "externalKey",
+      match: { value: key },
+    }));
+
+    const results = await qdrantClient.search(PRS_COLLECTION, {
+      vector,
+      limit,
+      score_threshold: scoreThreshold,
+      filter: {
+        must: mustConditions,
+        must_not: mustNotConditions.length > 0 ? mustNotConditions : undefined,
+      },
+      with_payload: true,
+    });
+
+    return results.map((result) => ({
+      externalKey: (result.payload as unknown as PrPayload).externalKey,
+      score: result.score,
+      payload: result.payload as unknown as PrPayload,
+    }));
+  } catch (error) {
+    console.error("Failed to search similar PRs:", error);
+    return [];
   }
 };

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -1,8 +1,12 @@
+import type {
+  PrIndexJobData,
+  ThreadReadJobData,
+} from "@workspace/schemas/signals";
+import { initSharedLogger, log } from "@workspace/utils/logging";
 import { type Job, Worker } from "bullmq";
 import Redis from "ioredis";
-import type { ThreadReadJobData } from "@workspace/schemas/signals";
-import { initSharedLogger, log } from "@workspace/utils/logging";
 import { handleCrawlDocumentation } from "./handlers/crawl-documentation";
+import { handleIndexPr } from "./handlers/index-pr";
 import { ensureDocumentationCollection } from "./lib/qdrant/documentation";
 import { ensureMessagesCollection } from "./lib/qdrant/messages";
 import { ensurePrsCollection } from "./lib/qdrant/pull-requests";
@@ -12,6 +16,7 @@ import { registerDefaultProcessors } from "./pipeline/processors/registration";
 
 const THREAD_PIPELINE_QUEUE = "thread-pipeline";
 const CRAWL_DOCUMENTATION_QUEUE = "crawl-documentation";
+const PR_INDEX_QUEUE = "pr-index";
 
 const parseBooleanEnv = (value: string | undefined): boolean | undefined => {
   if (value === undefined) {
@@ -144,10 +149,7 @@ threadPipelineWorker.on("completed", (job) => {
 });
 
 threadPipelineWorker.on("failed", (job, err) => {
-  log.error(
-    "worker.thread-pipeline",
-    `Job ${job?.id} failed: ${err.message}`,
-  );
+  log.error("worker.thread-pipeline", `Job ${job?.id} failed: ${err.message}`);
   log.error("worker.thread-pipeline", formatError(err));
 });
 
@@ -186,10 +188,39 @@ crawlDocWorker.on("failed", (job, err) => {
 });
 
 crawlDocWorker.on("error", (err) => {
-  log.error(
-    "worker.crawl-documentation",
-    `Worker error: ${formatError(err)}`,
-  );
+  log.error("worker.crawl-documentation", `Worker error: ${formatError(err)}`);
+});
+
+// Create PR embedding index worker (FRO-203). Index-only: keeps the PR vector
+// index in step with the mirror; never fans out `pr_matched` reads.
+const prIndexWorker = new Worker<PrIndexJobData>(
+  PR_INDEX_QUEUE,
+  handleIndexPr,
+  {
+    connection,
+    autorun: false,
+    concurrency: 3,
+    removeOnComplete: {
+      count: 100,
+      age: 24 * 3600,
+    },
+    removeOnFail: {
+      count: 500,
+    },
+  },
+);
+
+prIndexWorker.on("completed", (job) => {
+  log.info("worker.pr-index", `Job ${job.id} completed`);
+});
+
+prIndexWorker.on("failed", (job, err) => {
+  log.error("worker.pr-index", `Job ${job?.id} failed: ${err.message}`);
+  log.error("worker.pr-index", formatError(err));
+});
+
+prIndexWorker.on("error", (err) => {
+  log.error("worker.pr-index", `Worker error: ${formatError(err)}`);
 });
 
 // Initialize and start
@@ -201,14 +232,17 @@ const initialize = async () => {
   log.info("worker", "Processors registered");
 
   // Ensure Qdrant collections exist
-  const [threadsReady, messagesReady, documentationReady, prsReady] = await Promise.all([
-    ensureThreadsCollection(),
-    ensureMessagesCollection(),
-    ensureDocumentationCollection(),
-    ensurePrsCollection(),
-  ]);
+  const [threadsReady, messagesReady, documentationReady, prsReady] =
+    await Promise.all([
+      ensureThreadsCollection(),
+      ensureMessagesCollection(),
+      ensureDocumentationCollection(),
+      ensurePrsCollection(),
+    ]);
   if (!threadsReady || !messagesReady || !documentationReady || !prsReady) {
-    throw new Error("Qdrant collections are not ready; refusing to start workers");
+    throw new Error(
+      "Qdrant collections are not ready; refusing to start workers",
+    );
   }
 
   log.info("worker", "Qdrant collections ready");
@@ -216,6 +250,7 @@ const initialize = async () => {
   // Start workers now that collections are ready
   threadPipelineWorker.run();
   crawlDocWorker.run();
+  prIndexWorker.run();
 
   log.info("worker", "Listening for jobs");
 };
@@ -223,7 +258,11 @@ const initialize = async () => {
 // Graceful shutdown
 const handleShutdown = async () => {
   log.info("worker", "Shutting down workers");
-  await Promise.all([threadPipelineWorker.close(), crawlDocWorker.close()]);
+  await Promise.all([
+    threadPipelineWorker.close(),
+    crawlDocWorker.close(),
+    prIndexWorker.close(),
+  ]);
   await connection.quit();
   log.info("worker", "Workers shut down successfully");
   process.exit(0);

--- a/packages/schemas/src/signals.ts
+++ b/packages/schemas/src/signals.ts
@@ -385,6 +385,43 @@ export const threadReadJobDataSchema = z.object({
 });
 export type ThreadReadJobData = z.infer<typeof threadReadJobDataSchema>;
 
+// --- PR embedding index (FRO-203) -----------------------------------------
+
+/**
+ * Contract for a `pr-index` job: the API enqueues one after every mirror write
+ * that touches an [external pull request](../../CONTEXT.md); the worker embeds
+ * it (title + body + head ref) and upserts it into the PR vector index with an
+ * `eligible` flag (open, non-draft). This channel is **index-only** — it never
+ * fans out `pr_matched` thread reads (that push path is separate).
+ *
+ * The worker derives eligibility itself from `state`/`draft` rather than
+ * trusting a precomputed flag, so the mirror row stays the single source of
+ * truth. `deleted` signals the mirror row was soft-deleted (issue/PR removed or
+ * transferred out) and the vector should be dropped.
+ */
+export const prIndexJobDataSchema = z.object({
+  organizationId: z.string(),
+  /** Mirror row id (`externalEntity.id`); stored on the vector so a push-side
+   * match can resolve it back to a `PrMatchCandidate.prId`. */
+  externalEntityId: z.string(),
+  /** Provider-agnostic key `provider:owner/repo#number`; the vector's identity. */
+  externalKey: z.string(),
+  provider: z.string(),
+  repoFullName: z.string(),
+  number: z.number(),
+  url: z.string(),
+  title: z.string(),
+  body: z.string().nullable(),
+  headRef: z.string().nullable(),
+  /** Upstream PR state ("open" | "closed"); drives eligibility. */
+  state: z.string(),
+  /** Draft flag; a draft PR is never eligible. */
+  draft: z.boolean().nullable(),
+  /** Mirror row was soft-deleted — drop the vector instead of embedding. */
+  deleted: z.boolean().optional(),
+});
+export type PrIndexJobData = z.infer<typeof prIndexJobDataSchema>;
+
 // --- Status labels (kept) -------------------------------------------------
 
 export const STATUS_LABELS: Record<number, string> = {

--- a/packages/schemas/src/signals.ts
+++ b/packages/schemas/src/signals.ts
@@ -427,8 +427,10 @@ export const prIndexUpsertSchema = z.object({
   draft: z.boolean().nullable(),
 });
 
-/** Delete variant: drop the vector. Carries only identity — no embed content. */
-export const prIndexDeleteSchema = z.object({
+/** Delete variant: drop the vector. Carries only identity — no embed content.
+ * Strict so a payload with stray embed keys fails instead of silently parsing
+ * as an identity-only delete. */
+export const prIndexDeleteSchema = z.strictObject({
   ...prIndexIdentity,
   deleted: z.literal(true),
 });

--- a/packages/schemas/src/signals.ts
+++ b/packages/schemas/src/signals.ts
@@ -396,16 +396,24 @@ export type ThreadReadJobData = z.infer<typeof threadReadJobDataSchema>;
  *
  * The worker derives eligibility itself from `state`/`draft` rather than
  * trusting a precomputed flag, so the mirror row stays the single source of
- * truth. `deleted` signals the mirror row was soft-deleted (issue/PR removed or
- * transferred out) and the vector should be dropped.
+ * truth. A `deleted` job signals the mirror row was soft-deleted (issue/PR
+ * removed or transferred out) and the vector should be dropped — it carries
+ * only the identity fields, since none of the embed content is meaningful for a
+ * delete.
  */
-export const prIndexJobDataSchema = z.object({
+const prIndexIdentity = {
   organizationId: z.string(),
   /** Mirror row id (`externalEntity.id`); stored on the vector so a push-side
    * match can resolve it back to a `PrMatchCandidate.prId`. */
   externalEntityId: z.string(),
   /** Provider-agnostic key `provider:owner/repo#number`; the vector's identity. */
   externalKey: z.string(),
+};
+
+/** Upsert variant: embed the PR and (re)index it with a derived `eligible` flag. */
+export const prIndexUpsertSchema = z.object({
+  ...prIndexIdentity,
+  deleted: z.literal(false).optional(),
   provider: z.string(),
   repoFullName: z.string(),
   number: z.number(),
@@ -417,10 +425,21 @@ export const prIndexJobDataSchema = z.object({
   state: z.string(),
   /** Draft flag; a draft PR is never eligible. */
   draft: z.boolean().nullable(),
-  /** Mirror row was soft-deleted — drop the vector instead of embedding. */
-  deleted: z.boolean().optional(),
 });
+
+/** Delete variant: drop the vector. Carries only identity — no embed content. */
+export const prIndexDeleteSchema = z.object({
+  ...prIndexIdentity,
+  deleted: z.literal(true),
+});
+
+export const prIndexJobDataSchema = z.union([
+  prIndexUpsertSchema,
+  prIndexDeleteSchema,
+]);
 export type PrIndexJobData = z.infer<typeof prIndexJobDataSchema>;
+/** The upsert (embed-and-index) variant, narrowed from a non-`deleted` job. */
+export type PrIndexUpsertJobData = z.infer<typeof prIndexUpsertSchema>;
 
 // --- Status labels (kept) -------------------------------------------------
 


### PR DESCRIPTION
Stacked on #323 (FRO-202). Base is the FRO-202 branch — review/merge that first.

Part of FRO-201 (thread reads that suggest linking a PR). Indexes mirrored external pull requests for similarity search so the push-side match (FRO-205) and pull-side `related_prs` hint (FRO-206) have a vector index to query. **Index-only** — this never enqueues `pr_matched` reads.

## What it does

- **Single choke point.** Every PR mirror write (webhook, backfill, drift reconcile) already funnels through the API's `externalEntity.upsert`. That now enqueues a `pr-index` worker job after a `pull_request` write; `softDelete` drops the vector. One coalesced job per PR (`pr-index:{externalKey}`), latest mirror state wins.
- **Worker owns the embed.** Qdrant/embedding live only in the worker, so the `index-pr` handler embeds *title + body + head ref* and upserts the vector, mirroring how the API enqueues thread-read jobs.
- **Eligibility.** The worker derives `eligible = open && !draft` from the mirror row (single source of truth). Close / convert-to-draft flips `eligible: false` (kept, excluded from search); reopen / ready_for_review / content edits refresh it. Re-embedding is skipped when the embed-relevant content is unchanged — a pure eligibility flip just updates the payload.
- **Search helper.** `searchSimilarPrs(vector, { organizationId, eligibleOnly })` filters to eligible PRs by default (default threshold `PR_MATCH_THRESHOLD = 0.85`), ready for FRO-205/206.

## Acceptance criteria

- [x] Eligible open non-draft PRs upserted into the PR vector index after mirror events that matter
- [x] Closed / draft PRs marked `eligible: false` and excluded from search
- [x] Reconcile/backfill index (or refresh) eligible mirrored PRs without enqueueing `pr_matched` reads
- [x] Search helper returns similar PRs filtered by eligibility

## Notes

- The legacy `prs-v1` collection was scaffolding that never held data; the payload and vector semantics changed, so this bumps to `prs-v2` (created fresh with `eligible` / `externalKey` / `repoFullName` payload indexes). No back-compat shim.
- Verified the qdrant module end-to-end against local Qdrant (upsert → search eligibility filter → flip → delete, deterministic point ids). Typecheck green across the monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a PR embedding index for mirrored external pull requests with an eligibility flag (open, non-draft) to power PR↔thread similarity. Index-only; prepares push/pull discovery for FRO-205/206 per FRO-203.

- New Features
  - API enqueues `pr-index:{externalKey}` after each PR mirror write; removes stale same-id jobs in any non-active state; `softDelete` enqueues a delete.
  - Worker embeds title + body + head ref with `gemini-embedding-001`, normalizes, derives `eligible = open && !draft`, skips re-embed if content is unchanged, and deletes on mirror removal.
  - Qdrant `prs-v2`: deterministic point ids from `(organizationId, externalKey)`; payload carries `eligible` and `contentHash`; indexed fields `eligible`, `externalKey`, `repoFullName`.
  - Schemas: `PrIndexJobData` is a discriminated union (`upsert` | `delete`); added `searchSimilarPrs(vector, { organizationId, eligibleOnly, excludeExternalKeys, limit, scoreThreshold })` with a default threshold of 0.85 (eligible-only by default).

- Bug Fixes
  - Schemas: `prIndexDeleteSchema` is now strict to reject delete jobs carrying stray embed fields.

<sup>Written for commit 8f5ba19e895123665e72e5da97389f18f0b3185b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #323
2. **#324** 👈 current
3. #325
4. #326
<!-- stack:links:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic semantic indexing for mirrored pull requests to power similarity search.
  * Similar-PR and related-thread discovery now includes pull requests based on updated index data.
  * Indexes stay in sync with pull request updates, deletions, and eligibility changes (including draft status).
  * Similarity results are organization-scoped and filtered to eligible open, non-draft pull requests by default.
  * Introduced stable PR identity so repeated indexing requests don’t duplicate data and updates refresh efficiently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->