### PR TITLE
feat(worker,api): synthesis can emit link_pr (FRO-204)

### DIFF
--- a/apps/api/src/live-state/router/external-entity.ts
+++ b/apps/api/src/live-state/router/external-entity.ts
@@ -79,6 +79,33 @@ export default privateRoute.withProcedures(({ mutation, query }) => ({
     }),
 
     /**
+     * A single non-deleted mirrored pull request by canonical URL — the
+     * synthesis `read_pr` tool's depth-verification lookup (FRO-204). Keyed by
+     * URL to mirror the link-PR handler, which routes by the same canonical URL
+     * the `link_pr` action carries. Internal (worker) use only.
+     */
+    prByUrl: query(
+      z.object({
+        organizationId: z.string(),
+        url: z.string(),
+      }),
+    ).handler(async ({ req, db }) => {
+      requireInternalApiKey(req.context);
+      return (
+        Object.values(
+          await db.find(schema.externalEntity, {
+            where: {
+              organizationId: req.input.organizationId,
+              url: req.input.url,
+              type: "pull_request",
+              deletedAt: null,
+            },
+          }),
+        )[0] ?? null
+      );
+    }),
+
+    /**
      * Insert or update the mirror row identified by
      * `(organizationId, externalKey)`. Refreshes `lastSyncedAt` and clears any
      * previous `deletedAt` (a live event means the entity exists again).

--- a/apps/worker/src/lib/database/client.ts
+++ b/apps/worker/src/lib/database/client.ts
@@ -32,6 +32,33 @@ export const fetchThreadWithRelations = async (
 };
 
 /**
+ * A mirrored pull request as returned by the API's `prByUrl` query — the
+ * depth-verification payload for synthesis' `read_pr` tool (FRO-204).
+ */
+export type MirroredPr = NonNullable<
+  Awaited<ReturnType<typeof fetchClient.query.externalEntity.prByUrl>>
+>;
+
+/**
+ * Fetch a single mirrored pull request by its canonical URL, scoped to the org.
+ * Returns null when the PR was never mirrored (or has been soft-deleted).
+ */
+export const fetchMirroredPrByUrl = async (
+  organizationId: string,
+  url: string,
+): Promise<MirroredPr | null> => {
+  try {
+    return await fetchClient.query.externalEntity.prByUrl({
+      organizationId,
+      url,
+    });
+  } catch (error) {
+    console.error(`Failed to fetch mirrored PR ${url}:`, error);
+    return null;
+  }
+};
+
+/**
  * Fetch multiple threads with their messages and labels
  */
 export const fetchThreadsWithRelations = async (
@@ -55,4 +82,3 @@ export const fetchThreadsWithRelations = async (
 
   return threads;
 };
-

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/agent-dataset.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/agent-dataset.ts
@@ -57,6 +57,8 @@ export type SynthesisAgentEvalCase = {
       search_documentation?: number;
       read_documentation_page?: number;
     };
+    /** When set, every emitted link_pr.prUrl must equal this exact URL. */
+    expectedLinkPrUrl?: string;
     forbiddenReplyPhrases?: string[];
   };
 };
@@ -777,6 +779,7 @@ const synthesisAgentDatasetCases: Array<
       mustIncludePrimaryKinds: ["link_pr"],
       requiresReplyDraft: false,
       minToolCalls: { read_pr: 1 },
+      expectedLinkPrUrl: "https://github.com/acme/api/pull/482",
     },
   },
   {
@@ -836,6 +839,7 @@ const synthesisAgentDatasetCases: Array<
       mustIncludePrimaryKinds: ["link_pr", "reply"],
       requiresReplyDraft: true,
       minToolCalls: { read_pr: 1 },
+      expectedLinkPrUrl: "https://github.com/acme/api/pull/511",
     },
   },
   {

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/agent-dataset.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/agent-dataset.ts
@@ -26,21 +26,42 @@ export type SynthesisAgentEvalCase = {
     >;
     docsSearchHitsByQuery?: Record<string, DocumentationSearchHit[]>;
     docsPageChunksByUrl?: Record<string, DocumentationPageChunk[]>;
+    /** Mirrored PRs keyed by URL, served by the mocked `read_pr` tool. */
+    prsByUrl?: Record<
+      string,
+      {
+        url: string;
+        repoFullName: string;
+        number: number;
+        title: string;
+        body: string | null;
+        state: string;
+        draft: boolean | null;
+        merged: boolean | null;
+        headRef: string | null;
+        baseRef: string | null;
+        authorLogin: string | null;
+        labels: string[];
+      }
+    >;
   };
   expected: {
-    mustIncludePrimaryKinds: Array<"reply" | "mark_duplicate" | "close">;
-    mustExcludePrimaryKinds?: Array<"reply" | "mark_duplicate" | "close">;
+    mustIncludePrimaryKinds: SynthesisActionKind[];
+    mustExcludePrimaryKinds?: SynthesisActionKind[];
     allowEmptyPrimary?: boolean;
     requiresReplyDraft: boolean;
     replyMustContainAny?: string[];
     minToolCalls?: {
       read_thread?: number;
+      read_pr?: number;
       search_documentation?: number;
       read_documentation_page?: number;
     };
     forbiddenReplyPhrases?: string[];
   };
 };
+
+type SynthesisActionKind = "reply" | "mark_duplicate" | "link_pr" | "close";
 
 export type SynthesisAgentEvalInput = {
   synthesisInput: SynthesizeThreadReadInput;
@@ -689,6 +710,191 @@ const synthesisAgentDatasetCases: Array<
         "confirmed refund",
         "already issued",
       ],
+    },
+  },
+  {
+    name: "verified pr_matched lead on replied thread should link the pr",
+    input: {
+      threadId: "t17",
+      threadName: "Webhook retries drop the idempotency key",
+      sourceInputMessageId: "t17m2",
+      hasTeamReply: true,
+      threadMessages: [
+        {
+          id: "t17m1",
+          authorId: "c17",
+          createdAt: now,
+          content:
+            "Your webhook retries drop the Idempotency-Key header, so our billing endpoint double-charges on retry.",
+        },
+        {
+          id: "t17m2",
+          authorId: "agent17",
+          createdAt: now,
+          content:
+            "Thanks — we've reproduced the double-charge on retry and are working on a fix.",
+        },
+      ],
+      summary: {
+        title: "Webhook retries omit the idempotency key",
+        shortDescription:
+          "Retried webhook deliveries drop Idempotency-Key, causing duplicate billing side effects.",
+        keywords: ["webhook", "retry", "idempotency"],
+        entities: ["webhooks", "billing"],
+        expectedAction: "engineering fix",
+      },
+      hints: {},
+      trigger: {
+        kind: "pr_matched",
+        prMatched: {
+          prId: "pr17",
+          url: "https://github.com/acme/api/pull/482",
+          title: "Preserve Idempotency-Key header across webhook retries",
+          score: 0.91,
+        },
+      },
+    },
+    toolFixtures: {
+      threads: { t17: mkThread("t17", "Webhook retries drop the idempotency key") },
+      prsByUrl: {
+        "https://github.com/acme/api/pull/482": {
+          url: "https://github.com/acme/api/pull/482",
+          repoFullName: "acme/api",
+          number: 482,
+          title: "Preserve Idempotency-Key header across webhook retries",
+          body: "Webhook retry logic rebuilt the request without copying the Idempotency-Key header, so downstream billing endpoints treated each retry as a new request and double-charged. This copies the original idempotency key onto every retry attempt and adds a regression test.",
+          state: "open",
+          draft: false,
+          merged: false,
+          headRef: "fix/webhook-idempotency-key",
+          baseRef: "main",
+          authorLogin: "dev-alice",
+          labels: ["bug", "billing"],
+        },
+      },
+    },
+    expected: {
+      mustIncludePrimaryKinds: ["link_pr"],
+      requiresReplyDraft: false,
+      minToolCalls: { read_pr: 1 },
+    },
+  },
+  {
+    name: "unreplied pr_matched lead must couple link_pr with a reply",
+    input: {
+      threadId: "t18",
+      threadName: "CSV export truncates rows past 10k",
+      sourceInputMessageId: "t18m1",
+      hasTeamReply: false,
+      threadMessages: [
+        {
+          id: "t18m1",
+          authorId: "c18",
+          createdAt: now,
+          content:
+            "Exporting our contacts to CSV silently stops at 10,000 rows — the rest are missing from the file.",
+        },
+      ],
+      summary: {
+        title: "CSV export truncated at 10k rows",
+        shortDescription: "Contact CSV export drops every row past the 10,000th.",
+        keywords: ["csv", "export", "pagination"],
+        entities: ["export"],
+        expectedAction: "engineering fix",
+      },
+      hints: {},
+      trigger: {
+        kind: "pr_matched",
+        prMatched: {
+          prId: "pr18",
+          url: "https://github.com/acme/api/pull/511",
+          title: "Paginate CSV export beyond the 10k row cap",
+          score: 0.9,
+        },
+      },
+    },
+    toolFixtures: {
+      threads: { t18: mkThread("t18", "CSV export truncates rows past 10k") },
+      prsByUrl: {
+        "https://github.com/acme/api/pull/511": {
+          url: "https://github.com/acme/api/pull/511",
+          repoFullName: "acme/api",
+          number: 511,
+          title: "Paginate CSV export beyond the 10k row cap",
+          body: "The CSV export query used a hard LIMIT of 10000, so large accounts lost every row past the cap. This streams the export in pages until the full result set is written.",
+          state: "open",
+          draft: false,
+          merged: false,
+          headRef: "fix/csv-export-pagination",
+          baseRef: "main",
+          authorLogin: "dev-bob",
+          labels: ["bug"],
+        },
+      },
+    },
+    expected: {
+      mustIncludePrimaryKinds: ["link_pr", "reply"],
+      requiresReplyDraft: true,
+      minToolCalls: { read_pr: 1 },
+    },
+  },
+  {
+    name: "weak unrelated pr lead should refuse link_pr",
+    input: {
+      threadId: "t19",
+      threadName: "How do I change my billing email?",
+      sourceInputMessageId: "t19m1",
+      hasTeamReply: false,
+      threadMessages: [
+        {
+          id: "t19m1",
+          authorId: "c19",
+          createdAt: now,
+          content:
+            "Where in settings can I update the email address that invoices are sent to?",
+        },
+      ],
+      summary: {
+        title: "Changing the billing email address",
+        shortDescription: "Customer asks how to update the invoice recipient email.",
+        keywords: ["billing", "email", "settings"],
+        entities: ["billing"],
+        expectedAction: "how-to answer",
+      },
+      hints: {},
+      trigger: {
+        kind: "pr_matched",
+        prMatched: {
+          prId: "pr19",
+          url: "https://github.com/acme/api/pull/523",
+          title: "Add dark mode to the analytics dashboard",
+          score: 0.86,
+        },
+      },
+    },
+    toolFixtures: {
+      threads: { t19: mkThread("t19", "How do I change my billing email?") },
+      prsByUrl: {
+        "https://github.com/acme/api/pull/523": {
+          url: "https://github.com/acme/api/pull/523",
+          repoFullName: "acme/web",
+          number: 523,
+          title: "Add dark mode to the analytics dashboard",
+          body: "Introduces a dark theme toggle for the analytics dashboard and persists the choice per user. No billing or account-settings changes.",
+          state: "open",
+          draft: false,
+          merged: false,
+          headRef: "feat/dashboard-dark-mode",
+          baseRef: "main",
+          authorLogin: "dev-carol",
+          labels: ["feature", "ui"],
+        },
+      },
+    },
+    expected: {
+      mustIncludePrimaryKinds: ["reply"],
+      mustExcludePrimaryKinds: ["link_pr"],
+      requiresReplyDraft: true,
     },
   },
 ];

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/agent-scorers.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/agent-scorers.ts
@@ -282,6 +282,38 @@ export const atMostOneLinkPr = createScorer<In, Out, Expected>({
   },
 });
 
+export const expectedLinkPrUrl = createScorer<In, Out, Expected>({
+  name: "Expected Link PR URL",
+  description:
+    "When expectedLinkPrUrl is set, every emitted link_pr must use that exact URL (from read_pr).",
+  scorer: ({ output, expected }) => {
+    const expectedUrl = expected?.expectedLinkPrUrl;
+    if (!expectedUrl) {
+      return { score: 1, metadata: { skipped: true } };
+    }
+
+    const linkPrUrls = [
+      ...output.raw.primary,
+      ...(output.raw.alternatives ?? []),
+    ]
+      .filter((action) => action.kind === "link_pr")
+      .map((action) => (action.kind === "link_pr" ? action.prUrl : ""));
+
+    if (linkPrUrls.length === 0) {
+      return {
+        score: 0,
+        metadata: { reason: "missing_link_pr", expectedUrl },
+      };
+    }
+
+    const mismatches = linkPrUrls.filter((url) => url !== expectedUrl);
+    return {
+      score: mismatches.length === 0 ? 1 : 0,
+      metadata: { expectedUrl, linkPrUrls, mismatches },
+    };
+  },
+});
+
 export const reasoningUserSafe = createScorer<In, Out, Expected>({
   name: "Reasoning User Safe",
   description:

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/agent-scorers.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/agent-scorers.ts
@@ -9,6 +9,7 @@ type Out = {
   raw: SynthesisRawActionSet;
   toolCalls: {
     read_thread: number;
+    read_pr: number;
     search_documentation: number;
     read_documentation_page: number;
   };
@@ -141,6 +142,12 @@ export const minimumToolCalls = createScorer<In, Out, Expected>({
       failures.push(`read_thread<${minimums.read_thread}`);
     }
     if (
+      typeof minimums.read_pr === "number" &&
+      output.toolCalls.read_pr < minimums.read_pr
+    ) {
+      failures.push(`read_pr<${minimums.read_pr}`);
+    }
+    if (
       typeof minimums.search_documentation === "number" &&
       output.toolCalls.search_documentation < minimums.search_documentation
     ) {
@@ -256,6 +263,22 @@ export const unrepliedThreadReplyCoupling = createScorer<In, Out, Expected>({
     }
 
     return { score: 1, metadata: { primaryKinds } };
+  },
+});
+
+export const atMostOneLinkPr = createScorer<In, Out, Expected>({
+  name: "At Most One Link PR",
+  description:
+    "A thread links a single PR: at most one link_pr across primary + alternatives (FRO-204).",
+  scorer: ({ output }) => {
+    const linkPrCount = [
+      ...output.raw.primary,
+      ...(output.raw.alternatives ?? []),
+    ].filter((action) => action.kind === "link_pr").length;
+    return {
+      score: linkPrCount <= 1 ? 1 : 0,
+      metadata: { linkPrCount },
+    };
   },
 });
 

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/dataset.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/dataset.ts
@@ -10,8 +10,8 @@ export type SynthesisEvalCase = {
   };
   expected: {
     shouldBeNull: boolean;
-    primaryKinds: Array<"reply" | "mark_duplicate" | "close">;
-    alternativesKinds: Array<"reply" | "mark_duplicate" | "close">;
+    primaryKinds: Array<"reply" | "mark_duplicate" | "link_pr" | "close">;
+    alternativesKinds: Array<"reply" | "mark_duplicate" | "link_pr" | "close">;
     sourceInputMessageId: string | null;
   };
 };
@@ -174,7 +174,8 @@ export const synthesisDataset: SynthesisEvalCase[] = [
           { kind: "mark_duplicate", targetThreadId: "t-123" },
           {
             kind: "reply",
-            draftMarkdown: "Thanks for reporting this — it matches an existing thread we are tracking.",
+            draftMarkdown:
+              "Thanks for reporting this — it matches an existing thread we are tracking.",
           },
         ],
         alternatives: [{ kind: "close" }],
@@ -220,6 +221,88 @@ export const synthesisDataset: SynthesisEvalCase[] = [
       primaryKinds: ["close"],
       alternativesKinds: ["reply"],
       sourceInputMessageId: "m5",
+    },
+  },
+  {
+    name: "link_pr primary keeps only the first across primary and alternatives",
+    input: {
+      output: {
+        summary: "Customer hit a bug fixed by an open PR",
+        recommendation: "Link the pull request that fixes this.",
+        reasoning: "The open PR addresses the reported crash.",
+        primary: [
+          { kind: "link_pr", prUrl: "https://github.com/acme/api/pull/1" },
+        ],
+        alternatives: [
+          { kind: "link_pr", prUrl: "https://github.com/acme/api/pull/2" },
+        ],
+        urgencyScore: 40,
+        sourceInputMessageId: "m9",
+      },
+      messageIds: ["m9"],
+      fallbackSourceInputMessageId: "m9",
+      hasTeamReply: true,
+    },
+    expected: {
+      shouldBeNull: false,
+      primaryKinds: ["link_pr"],
+      alternativesKinds: [],
+      sourceInputMessageId: "m9",
+    },
+  },
+  {
+    name: "standalone link_pr on unreplied thread is dropped to null",
+    input: {
+      output: {
+        summary: "Customer reported a bug an open PR fixes",
+        recommendation: "Link the pull request that fixes this.",
+        reasoning: "The open PR resolves the report, but nobody has replied.",
+        primary: [
+          { kind: "link_pr", prUrl: "https://github.com/acme/api/pull/3" },
+        ],
+        alternatives: [],
+        urgencyScore: 45,
+        sourceInputMessageId: "m10",
+      },
+      messageIds: ["m10"],
+      fallbackSourceInputMessageId: "m10",
+      hasTeamReply: false,
+    },
+    expected: {
+      shouldBeNull: true,
+      primaryKinds: [],
+      alternativesKinds: [],
+      sourceInputMessageId: null,
+    },
+  },
+  {
+    name: "link_pr coupled with reply on unreplied thread orders link_pr first",
+    input: {
+      output: {
+        summary: "Customer reported a bug an open PR fixes",
+        recommendation: "Link the pull request and let the customer know.",
+        reasoning: "The open PR resolves the report; acknowledge the customer.",
+        primary: [
+          {
+            kind: "reply",
+            draftMarkdown:
+              "Thanks for the detailed report — a fix for this is already in review and we'll let you know as soon as it ships.",
+          },
+          { kind: "link_pr", prUrl: "https://github.com/acme/api/pull/4" },
+        ],
+        alternatives: [],
+        urgencyScore: 50,
+        sourceInputMessageId: "m11",
+      },
+      messageIds: ["m11"],
+      fallbackSourceInputMessageId: "m11",
+      hasTeamReply: false,
+    },
+    expected: {
+      shouldBeNull: false,
+      primaryKinds: ["link_pr", "reply"],
+      alternativesKinds: [],
+      sourceInputMessageId: "m11",
     },
   },
 ];

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/dataset.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/dataset.ts
@@ -7,6 +7,8 @@ export type SynthesisEvalCase = {
     messageIds: string[];
     fallbackSourceInputMessageId: string;
     hasTeamReply: boolean;
+    /** When set, link_pr URLs not in this list are dropped during normalize. */
+    verifiedPrUrls?: string[];
   };
   expected: {
     shouldBeNull: boolean;
@@ -303,6 +305,64 @@ export const synthesisDataset: SynthesisEvalCase[] = [
       primaryKinds: ["link_pr", "reply"],
       alternativesKinds: [],
       sourceInputMessageId: "m11",
+    },
+  },
+  {
+    name: "unverified link_pr is dropped when verifiedPrUrls is provided",
+    input: {
+      output: {
+        summary: "Customer hit a bug",
+        recommendation: "Link the pull request that fixes this.",
+        reasoning: "Model invented a PR URL without reading it.",
+        primary: [
+          { kind: "link_pr", prUrl: "https://github.com/acme/api/pull/999" },
+          {
+            kind: "reply",
+            draftMarkdown:
+              "Thanks for the report — a fix for this is already in review.",
+          },
+        ],
+        alternatives: [],
+        urgencyScore: 40,
+        sourceInputMessageId: "m12",
+      },
+      messageIds: ["m12"],
+      fallbackSourceInputMessageId: "m12",
+      hasTeamReply: true,
+      // Successfully read a different PR — the fabricated URL must not pass.
+      verifiedPrUrls: ["https://github.com/acme/api/pull/482"],
+    },
+    expected: {
+      shouldBeNull: false,
+      primaryKinds: ["reply"],
+      alternativesKinds: [],
+      sourceInputMessageId: "m12",
+    },
+  },
+  {
+    name: "standalone unverified link_pr becomes null when verifiedPrUrls is provided",
+    input: {
+      output: {
+        summary: "Customer hit a bug",
+        recommendation: "Link the pull request that fixes this.",
+        reasoning: "Model emitted link_pr without a successful read_pr.",
+        primary: [
+          { kind: "link_pr", prUrl: "https://github.com/evil/repo/pull/1" },
+        ],
+        alternatives: [],
+        urgencyScore: 40,
+        sourceInputMessageId: "m13",
+      },
+      messageIds: ["m13"],
+      fallbackSourceInputMessageId: "m13",
+      hasTeamReply: true,
+      verifiedPrUrls: [],
+    },
+    expected: {
+      shouldBeNull: true,
+      primaryKinds: [],
+      alternativesKinds: [],
+      sourceInputMessageId: null,
     },
   },
 ];

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/dataset.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/dataset.ts
@@ -308,7 +308,7 @@ export const synthesisDataset: SynthesisEvalCase[] = [
     },
   },
   {
-    name: "unverified link_pr is dropped when verifiedPrUrls is provided",
+    name: "unverified primary link_pr becomes null (avoids stale recommendation)",
     input: {
       output: {
         summary: "Customer hit a bug",
@@ -330,13 +330,15 @@ export const synthesisDataset: SynthesisEvalCase[] = [
       fallbackSourceInputMessageId: "m12",
       hasTeamReply: true,
       // Successfully read a different PR — the fabricated URL must not pass.
+      // Dropping only link_pr would leave a stale "Link the PR" recommendation
+      // over a reply-only primary, so the whole set is discarded.
       verifiedPrUrls: ["https://github.com/acme/api/pull/482"],
     },
     expected: {
-      shouldBeNull: false,
-      primaryKinds: ["reply"],
+      shouldBeNull: true,
+      primaryKinds: [],
       alternativesKinds: [],
-      sourceInputMessageId: "m12",
+      sourceInputMessageId: null,
     },
   },
   {

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/synthesis-agent.eval.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/synthesis-agent.eval.ts
@@ -6,6 +6,7 @@ import type { createSynthesisTools } from "../tools";
 import { synthesizeThreadRead } from "../synthesize";
 import { synthesisAgentDataset, type SynthesisAgentEvalInput } from "./agent-dataset";
 import {
+  atMostOneLinkPr,
   forbiddenPrimaryKinds,
   minimumToolCalls,
   nonEmptyPrimaryWhenExpected,
@@ -21,6 +22,7 @@ type SynthesisTools = ReturnType<typeof createSynthesisTools>;
 
 type ToolOutput<T> = T extends Tool<infer _I, infer O> ? O : never;
 type ReadThreadOutput = ToolOutput<SynthesisTools["read_thread"]>;
+type ReadPrOutput = ToolOutput<SynthesisTools["read_pr"]>;
 
 const createMockTools = (
   fixtures: SynthesisAgentEvalInput["toolFixtures"],
@@ -28,12 +30,14 @@ const createMockTools = (
   tools: SynthesisTools;
   counters: {
     read_thread: number;
+    read_pr: number;
     search_documentation: number;
     read_documentation_page: number;
   };
 } => {
   const counters = {
     read_thread: 0,
+    read_pr: 0,
     search_documentation: 0,
     read_documentation_page: 0,
   };
@@ -62,6 +66,16 @@ const createMockTools = (
             })),
           },
         };
+      },
+    }),
+    read_pr: tool({
+      description: "Read a mirrored PR from mocked fixtures.",
+      inputSchema: z.object({ prUrl: z.string() }),
+      execute: async ({ prUrl }): Promise<ReadPrOutput> => {
+        counters.read_pr++;
+        const pr = fixtures.prsByUrl?.[prUrl];
+        if (!pr) return { found: false, reason: "not_mirrored" };
+        return { found: true, pr };
       },
     }),
     search_documentation: tool({
@@ -134,5 +148,6 @@ evalite("Synthesis Agent (Model In Loop)", {
     minimumToolCalls,
     reasoningUserSafe,
     unrepliedThreadReplyCoupling,
+    atMostOneLinkPr,
   ],
 });

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/synthesis-agent.eval.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/synthesis-agent.eval.ts
@@ -7,6 +7,7 @@ import { synthesizeThreadRead } from "../synthesize";
 import { synthesisAgentDataset, type SynthesisAgentEvalInput } from "./agent-dataset";
 import {
   atMostOneLinkPr,
+  expectedLinkPrUrl,
   forbiddenPrimaryKinds,
   minimumToolCalls,
   nonEmptyPrimaryWhenExpected,
@@ -149,5 +150,6 @@ evalite("Synthesis Agent (Model In Loop)", {
     reasoningUserSafe,
     unrepliedThreadReplyCoupling,
     atMostOneLinkPr,
+    expectedLinkPrUrl,
   ],
 });

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/synthesis.eval.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/synthesis.eval.ts
@@ -23,6 +23,9 @@ evalite("Synthesis Normalize", {
       messageIds: new Set(input.messageIds),
       fallbackSourceInputMessageId: input.fallbackSourceInputMessageId,
       hasTeamReply: input.hasTeamReply,
+      verifiedPrUrls: input.verifiedPrUrls
+        ? new Set(input.verifiedPrUrls)
+        : undefined,
     });
     reportTrace({
       start,

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/link-pr-verification.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/link-pr-verification.ts
@@ -40,3 +40,25 @@ export const filterLinkPrToVerifiedUrls = <
     const prUrl = action.prUrl?.trim() ?? "";
     return prUrl.length > 0 && verifiedPrUrls.has(prUrl);
   });
+
+/**
+ * Filter `link_pr` to verified URLs. If primary loses any `link_pr`, discard the
+ * whole action set — recommendation (and often the reply draft) were written
+ * assuming that link and would be stale relative to remaining actions.
+ */
+export const filterActionSetToVerifiedLinkPr = <
+  T extends { kind: string; prUrl?: string },
+>(
+  primary: T[],
+  alternatives: T[],
+  verifiedPrUrls: Set<string>,
+): { primary: T[]; alternatives: T[] } => {
+  const filteredPrimary = filterLinkPrToVerifiedUrls(primary, verifiedPrUrls);
+  if (filteredPrimary.length !== primary.length) {
+    return { primary: [], alternatives: [] };
+  }
+  return {
+    primary: filteredPrimary,
+    alternatives: filterLinkPrToVerifiedUrls(alternatives, verifiedPrUrls),
+  };
+};

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/link-pr-verification.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/link-pr-verification.ts
@@ -1,0 +1,42 @@
+/**
+ * Collect PR URLs that were successfully returned by `read_pr` tool calls.
+ * Only these URLs may appear in emitted `link_pr` actions — prompt instructions
+ * alone are not a trust boundary (prompt injection / model bypass).
+ */
+export const collectVerifiedPrUrlsFromToolSteps = (
+  steps: Array<{
+    toolResults: Array<{
+      toolName: string;
+      output: unknown;
+    }>;
+  }>,
+): Set<string> => {
+  const verified = new Set<string>();
+
+  for (const step of steps) {
+    for (const result of step.toolResults) {
+      if (result.toolName !== "read_pr") continue;
+      const output = result.output as
+        | { found?: boolean; pr?: { url?: string } }
+        | null
+        | undefined;
+      const url = output?.found === true ? output.pr?.url?.trim() : undefined;
+      if (url) verified.add(url);
+    }
+  }
+
+  return verified;
+};
+
+/** Drop `link_pr` actions whose `prUrl` was not returned by a successful `read_pr`. */
+export const filterLinkPrToVerifiedUrls = <
+  T extends { kind: string; prUrl?: string },
+>(
+  actions: T[],
+  verifiedPrUrls: Set<string>,
+): T[] =>
+  actions.filter((action) => {
+    if (action.kind !== "link_pr") return true;
+    const prUrl = action.prUrl?.trim() ?? "";
+    return prUrl.length > 0 && verifiedPrUrls.has(prUrl);
+  });

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/normalize.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/normalize.ts
@@ -5,7 +5,7 @@ import {
 } from "@workspace/schemas/signals";
 import type { SynthesisRawActionSet } from "./synthesize";
 
-const allowedKinds = new Set(["reply", "mark_duplicate", "close"]);
+const allowedKinds = new Set(["reply", "mark_duplicate", "link_pr", "close"]);
 
 const normalizeAction = (action: Action): Action | null => {
   if (!allowedKinds.has(action.kind)) return null;
@@ -19,6 +19,12 @@ const normalizeAction = (action: Action): Action | null => {
   if (action.kind === "mark_duplicate") {
     if (!action.targetThreadId.trim()) return null;
     return { kind: "mark_duplicate", targetThreadId: action.targetThreadId };
+  }
+
+  if (action.kind === "link_pr") {
+    const prUrl = action.prUrl.trim();
+    if (prUrl.length === 0) return null;
+    return { kind: "link_pr", prUrl };
   }
 
   return { kind: "close" };
@@ -52,9 +58,25 @@ export const normalizeSynthesisRawActionSet = ({
     .map((action) => normalizeAction(action as Action))
     .filter((action): action is Action => action !== null);
 
+  // At most one link_pr across the whole action set (design lock, FRO-204): a
+  // thread links a single PR. Keep the first — primary takes precedence over
+  // alternatives — and drop any further link_pr entries.
+  let linkPrSeen = false;
+  const dedupeLinkPr = (actions: Action[]): Action[] =>
+    actions.filter((action) => {
+      if (action.kind !== "link_pr") return true;
+      if (linkPrSeen) return false;
+      linkPrSeen = true;
+      return true;
+    });
+  primary = dedupeLinkPr(primary);
+  alternatives = dedupeLinkPr(alternatives);
+
   if (!hasTeamReply) {
     alternatives = alternatives.filter((action) => action.kind === "reply");
-    const primaryHasNonReply = primary.some((action) => action.kind !== "reply");
+    const primaryHasNonReply = primary.some(
+      (action) => action.kind !== "reply",
+    );
     const primaryHasReply = primary.some((action) => action.kind === "reply");
     if (primaryHasNonReply && !primaryHasReply) {
       return null;

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/normalize.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/normalize.ts
@@ -59,6 +59,19 @@ export const normalizeSynthesisRawActionSet = ({
    */
   verifiedPrUrls?: Set<string>;
 }): ThreadRead | null => {
+  // If verified-link filtering would drop a primary link_pr, treat as no action
+  // — recommendation (and often the reply draft) assume that link and would be stale.
+  if (
+    verifiedPrUrls &&
+    output.primary.some(
+      (action) =>
+        action.kind === "link_pr" &&
+        !verifiedPrUrls.has((action.prUrl ?? "").trim()),
+    )
+  ) {
+    return null;
+  }
+
   let primary = output.primary
     .map((action) => normalizeAction(action as Action, verifiedPrUrls))
     .filter((action): action is Action => action !== null);

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/normalize.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/normalize.ts
@@ -7,7 +7,10 @@ import type { SynthesisRawActionSet } from "./synthesize";
 
 const allowedKinds = new Set(["reply", "mark_duplicate", "link_pr", "close"]);
 
-const normalizeAction = (action: Action): Action | null => {
+const normalizeAction = (
+  action: Action,
+  verifiedPrUrls?: Set<string>,
+): Action | null => {
   if (!allowedKinds.has(action.kind)) return null;
 
   if (action.kind === "reply") {
@@ -24,6 +27,8 @@ const normalizeAction = (action: Action): Action | null => {
   if (action.kind === "link_pr") {
     const prUrl = action.prUrl.trim();
     if (prUrl.length === 0) return null;
+    // When verified URLs are provided, reject link_pr that bypassed read_pr.
+    if (verifiedPrUrls && !verifiedPrUrls.has(prUrl)) return null;
     return { kind: "link_pr", prUrl };
   }
 
@@ -42,20 +47,26 @@ export const normalizeSynthesisRawActionSet = ({
   messageIds,
   fallbackSourceInputMessageId,
   hasTeamReply,
+  verifiedPrUrls,
 }: {
   output: SynthesisRawActionSet;
   messageIds: Set<string>;
   fallbackSourceInputMessageId: string;
   hasTeamReply: boolean;
+  /**
+   * PR URLs returned by successful `read_pr` calls. When set, any `link_pr`
+   * whose URL is not in this set is dropped (defense in depth vs synthesize).
+   */
+  verifiedPrUrls?: Set<string>;
 }): ThreadRead | null => {
   let primary = output.primary
-    .map((action) => normalizeAction(action as Action))
+    .map((action) => normalizeAction(action as Action, verifiedPrUrls))
     .filter((action): action is Action => action !== null);
 
   if (primary.length === 0) return null;
 
   let alternatives = (output.alternatives ?? [])
-    .map((action) => normalizeAction(action as Action))
+    .map((action) => normalizeAction(action as Action, verifiedPrUrls))
     .filter((action): action is Action => action !== null);
 
   // At most one link_pr across the whole action set (design lock, FRO-204): a

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
@@ -10,6 +10,10 @@ import type { createAILogger } from "@workspace/utils/logging";
 import { generateText, stepCountIs } from "ai";
 import z from "zod";
 import type { ParsedSummary } from "../../../../types";
+import {
+  collectVerifiedPrUrlsFromToolSteps,
+  filterLinkPrToVerifiedUrls,
+} from "./link-pr-verification";
 
 const synthesisActionSchema = z.discriminatedUnion("kind", [
   replyActionSchema,
@@ -197,12 +201,23 @@ Return a single valid JSON object with exactly this shape:
 `;
 
   const baseModel = google("gemini-2.5-flash");
-  const { text } = await generateText({
+  const { text, steps } = await generateText({
     model: ai ? ai.wrap(baseModel) : baseModel,
     prompt,
     tools,
     stopWhen: stepCountIs(8),
   });
 
-  return parseRawActionSetFromText(text);
+  const raw = parseRawActionSetFromText(text);
+  // Trust boundary: only allow link_pr URLs returned by a successful read_pr.
+  // Prompt instructions alone cannot authorize an external PR link.
+  const verifiedPrUrls = collectVerifiedPrUrlsFromToolSteps(steps);
+  return {
+    ...raw,
+    primary: filterLinkPrToVerifiedUrls(raw.primary, verifiedPrUrls),
+    alternatives: filterLinkPrToVerifiedUrls(
+      raw.alternatives ?? [],
+      verifiedPrUrls,
+    ),
+  };
 };

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
@@ -12,7 +12,7 @@ import z from "zod";
 import type { ParsedSummary } from "../../../../types";
 import {
   collectVerifiedPrUrlsFromToolSteps,
-  filterLinkPrToVerifiedUrls,
+  filterActionSetToVerifiedLinkPr,
 } from "./link-pr-verification";
 
 const synthesisActionSchema = z.discriminatedUnion("kind", [
@@ -210,14 +210,17 @@ Return a single valid JSON object with exactly this shape:
 
   const raw = parseRawActionSetFromText(text);
   // Trust boundary: only allow link_pr URLs returned by a successful read_pr.
-  // Prompt instructions alone cannot authorize an external PR link.
+  // Prompt instructions alone cannot authorize an external PR link. If primary
+  // loses a link_pr, discard the set so recommendation stays consistent.
   const verifiedPrUrls = collectVerifiedPrUrlsFromToolSteps(steps);
+  const filtered = filterActionSetToVerifiedLinkPr(
+    raw.primary,
+    raw.alternatives ?? [],
+    verifiedPrUrls,
+  );
   return {
     ...raw,
-    primary: filterLinkPrToVerifiedUrls(raw.primary, verifiedPrUrls),
-    alternatives: filterLinkPrToVerifiedUrls(
-      raw.alternatives ?? [],
-      verifiedPrUrls,
-    ),
+    primary: filtered.primary,
+    alternatives: filtered.alternatives,
   };
 };

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
@@ -2,6 +2,7 @@ import { google } from "@ai-sdk/google";
 import type { Hints, ThreadReadTrigger } from "@workspace/schemas/signals";
 import {
   closeActionSchema,
+  linkPrActionSchema,
   markDuplicateActionSchema,
   replyActionSchema,
 } from "@workspace/schemas/signals";
@@ -13,6 +14,7 @@ import type { ParsedSummary } from "../../../../types";
 const synthesisActionSchema = z.discriminatedUnion("kind", [
   replyActionSchema,
   markDuplicateActionSchema,
+  linkPrActionSchema,
   closeActionSchema,
 ]);
 
@@ -92,8 +94,8 @@ export const synthesizeThreadRead = async (
 
   // Trigger-context channel (ADR 0006), kept separate from the hint bag. A
   // `pr_matched` trigger pushes a candidate PR — a fuzzy similarity match, not a
-  // confirmed link. Surface it as a lead; acting on it (link_pr) is not yet part
-  // of this agent's vocabulary.
+  // confirmed link. Surface it as a lead the agent must verify with read_pr
+  // before it may emit link_pr.
   const prMatched = input.trigger?.prMatched;
   const triggerBlock = prMatched
     ? `## Trigger context (why this run happened)
@@ -103,7 +105,7 @@ This run was triggered by a push-side pull-request match. A candidate PR was pus
 - url: <pr_url>${prMatched.url}</pr_url>
 - match score: ${prMatched.score.toFixed(2)} (fuzzy similarity, 0-1)
 
-This is a lead, not a confirmed link — a separate detector found it similar to this thread. Weigh it as evidence about what the thread concerns; do not treat it as authoritative.
+This is a lead, not a confirmed link — a separate detector found it similar to this thread. Read it with read_pr and confirm it actually resolves or addresses this thread before you propose link_pr. Do not treat the match as authoritative.
 `
     : "";
 
@@ -112,15 +114,18 @@ This is a lead, not a confirmed link — a separate detector found it similar to
 You must produce an unfiltered raw action set using only this vocabulary:
 - reply (requires draftMarkdown)
 - mark_duplicate (requires targetThreadId)
+- link_pr (requires prUrl) — link a mirrored pull request that resolves or addresses this thread
 - close
 
 Use hints as evidence leads, not as final decisions. Investigate with tools before taking substantive actions.
 
 Requirements:
 - If duplicate evidence exists, verify by reading the target thread with read_thread before choosing mark_duplicate.
-- Prefer no action over weak/conflicting evidence. If no substantive move is justified, return an empty primary array.
+- Before emitting link_pr, you MUST verify the candidate PR with read_pr and confirm from its contents that it genuinely resolves or addresses this thread. Never emit link_pr for a PR you have not read, and use the exact prUrl returned by read_pr.
+- Emit at most one link_pr across primary and alternatives combined — a thread links a single PR.
+- Prefer no action over weak/conflicting evidence. If no substantive move is justified, return an empty primary array. A weak or unrelated PR lead is not grounds for link_pr.
 - sourceInputMessageId must be one of the provided message ids and should usually be the latest inbound message.
-- Do not emit link_pr, apply_label, set_status, or any fields outside schema.
+- Do not emit apply_label, set_status, or any fields outside schema.
 
 ## Unreplied threads (support has not messaged yet)
 
@@ -128,12 +133,12 @@ hasTeamReply: ${input.hasTeamReply}
 
 When hasTeamReply is false, the customer has written but no teammate has replied on this thread yet.
 
-- **Primary:** If you include mark_duplicate or close, you must also include a reply in the same primary array. Order reversibles first: \`[mark_duplicate, reply]\` or \`[close, reply]\`. The reply should briefly acknowledge the customer (thank them, explain the duplicate link, or confirm closure) — never leave them without a first response.
-- **Alternatives:** Offer reply-only alternatives (e.g. a softer or more detailed draft). Do not put standalone mark_duplicate or close in alternatives — the human would execute those without replying.
+- **Primary:** If you include mark_duplicate, link_pr, or close, you must also include a reply in the same primary array. Order the other action first: \`[mark_duplicate, reply]\`, \`[link_pr, reply]\`, or \`[close, reply]\`. The reply should briefly acknowledge the customer (thank them, explain the duplicate link, note the linked PR, or confirm closure) — never leave them without a first response.
+- **Alternatives:** Offer reply-only alternatives (e.g. a softer or more detailed draft). Do not put standalone mark_duplicate, link_pr, or close in alternatives — the human would execute those without replying.
 - **Reply-only primary** is fine when that is the best move (no bundling required).
 - **Empty primary** is still allowed when no substantive move is justified.
 
-When hasTeamReply is true, alternatives may be any allowed action kind (including standalone close or mark_duplicate).
+When hasTeamReply is true, alternatives may be any allowed action kind (including standalone close, mark_duplicate, or link_pr).
 
 ## summary, recommendation, and reasoning (critical)
 
@@ -145,6 +150,7 @@ When hasTeamReply is true, alternatives may be any allowed action kind (includin
 
 - mark_duplicate: "This is a duplicate of [target thread name](thread:targetThreadId)." Use the exact \`targetThreadId\` from primary and the name from read_thread when available.
 - reply: a reply imperative, e.g. "Reply to acknowledge …" or "Reply with an explanation of …"
+- link_pr: a link imperative naming the PR, e.g. "Link the pull request that fixes this and let the customer know a fix is on the way."
 - close: a close imperative, e.g. "Close the thread — the customer confirmed the issue is resolved."
 - empty primary: state that no substantive move is justified, e.g. "No reply, duplicate link, or close is justified yet."
 
@@ -183,8 +189,8 @@ Return a single valid JSON object with exactly this shape:
   "summary": string (one sentence: customer situation only, no imperative),
   "recommendation": string (one imperative sentence tied to primary; use [name](thread:id) for duplicate targets),
   "reasoning": string (user-facing evidence; no internal terms, scores, or raw ids),
-  "primary": Array<{ "kind": "reply", "draftMarkdown": string } | { "kind": "mark_duplicate", "targetThreadId": string } | { "kind": "close" }>,
-  "alternatives": Array<{ "kind": "reply", "draftMarkdown": string } | { "kind": "mark_duplicate", "targetThreadId": string } | { "kind": "close" }>,
+  "primary": Array<{ "kind": "reply", "draftMarkdown": string } | { "kind": "mark_duplicate", "targetThreadId": string } | { "kind": "link_pr", "prUrl": string } | { "kind": "close" }>,
+  "alternatives": Array<{ "kind": "reply", "draftMarkdown": string } | { "kind": "mark_duplicate", "targetThreadId": string } | { "kind": "link_pr", "prUrl": string } | { "kind": "close" }>,
   "urgencyScore": number (0-100),
   "sourceInputMessageId": string
 }

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/tools.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/tools.ts
@@ -1,6 +1,9 @@
 import { tool } from "ai";
 import z from "zod";
-import { fetchThreadWithRelations } from "../../../../lib/database/client";
+import {
+  fetchMirroredPrByUrl,
+  fetchThreadWithRelations,
+} from "../../../../lib/database/client";
 import {
   readDocumentationPage,
   searchDocumentation,
@@ -62,6 +65,44 @@ export const createSynthesisTools = (options: CreateSynthesisToolsOptions) => {
             priority: thread.priority,
             createdAt: thread.createdAt,
             messages: toOrderedMessages(thread),
+          },
+        };
+      },
+    }),
+
+    read_pr: tool({
+      description:
+        "Read a mirrored pull request by its URL (same organization only) to " +
+        "verify a candidate link before emitting link_pr. Returns the PR title, " +
+        "body, state, draft/merged flags, branch refs, author, and labels.",
+      inputSchema: z.object({
+        prUrl: z.string(),
+      }),
+      execute: async ({ prUrl }) => {
+        const pr = await fetchMirroredPrByUrl(organizationId, prUrl);
+
+        if (!pr) {
+          return {
+            found: false,
+            reason: "not_mirrored",
+          };
+        }
+
+        return {
+          found: true,
+          pr: {
+            url: pr.url,
+            repoFullName: pr.repoFullName,
+            number: pr.number,
+            title: pr.title,
+            body: pr.body,
+            state: pr.state,
+            draft: pr.draft,
+            merged: pr.merged,
+            headRef: pr.headRef,
+            baseRef: pr.baseRef,
+            authorLogin: pr.authorLogin,
+            labels: pr.labels,
           },
         };
       },


### PR DESCRIPTION
Implements [FRO-204](https://linear.app/front-desk/issue/FRO-204/synthesis-can-emit-link-pr). Stacked on FRO-203 (#324).

## What

Synthesis can now emit `link_pr` as a substantive next move, gated behind depth verification with a new `read_pr` tool.

- **`read_pr` tool** — fetches a mirrored PR by canonical URL via a new internal `externalEntity.prByUrl` query, returning the title, body, state, draft/merged flags, branch refs, author, and labels needed to verify a lead.
- **Prompt** — `link_pr` is in the vocabulary; the agent must verify the candidate PR with `read_pr` and confirm it genuinely resolves the thread before proposing a link. A `pr_matched` trigger is framed as a lead to verify, not an authoritative link. Unreplied threads must couple `link_pr` with a reply (`[link_pr, reply]`).
- **normalize** — allows `link_pr`, enforces **at most one `link_pr`** across primary + alternatives, and rejects standalone `link_pr` on unreplied threads.
- **Accept path** — unchanged; the existing link-PR handler links by URL end-to-end.

## Eval coverage

- Normalize: `link_pr` dedup across primary/alternatives, standalone-unreplied → null, and `[link_pr, reply]` ordering.
- Model-in-loop: verified emission on a replied thread, unreplied coupling, and weak/unrelated-lead refusal — with a mocked `read_pr` tool and a new `at-most-one-link_pr` scorer.

## Acceptance criteria

- [x] Synthesis vocabulary/prompt/normalize allow `link_pr` (and reject standalone `link_pr` when unreplied)
- [x] `read_pr` tool returns mirrored PR fields needed to verify a lead
- [x] Prompt requires verifying with `read_pr` before emitting `link_pr`
- [x] At most one `link_pr` across primary + alternatives
- [x] Accepting the read links the PR end-to-end (existing handler + UI labels)
- [x] Eval coverage for unreplied coupling and link_pr emission/refusal cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synthesis can now emit `link_pr` to link a PR, gated by `read_pr` verification, per FRO-204. It enforces a single linked PR, requires `[link_pr, reply]` on unreplied threads, and drops the entire action set if a primary `link_pr` is unverified to avoid stale recommendations.

- **New Features**
  - API/Worker: Added `externalEntity.prByUrl` and a `read_pr` tool via `fetchMirroredPrByUrl`; defined `MirroredPr`.
  - Prompt/schema: Added `link_pr`; treats `pr_matched` as a lead; requires `read_pr` before `link_pr`; at most one `link_pr`; unreplied threads must use `[link_pr, reply]`.
  - Normalize: Allows `link_pr`, dedupes to a single `link_pr`, drops standalone `link_pr` on unreplied threads.
  - Eval: Added cases and scorers for minimum `read_pr`, at-most-one `link_pr`, unreplied coupling, weak-lead refusal, and exact `prUrl`.
  - Accept path: Unchanged; existing handler links by URL.

- **Bug Fixes**
  - Trust boundary: Only allow `link_pr` URLs returned by successful `read_pr`; enforced at synthesize time (collects verified URLs from tool steps and filters) and in normalize. If filtering removes any primary `link_pr`, discard the entire action set to prevent stale recommendations.

<sup>Written for commit c2a8fcc3c788c8397e70a619677fe92177a37bb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #323
2. #324
3. **#325** 👈 current
4. #326
<!-- stack:links:end -->