### PR TITLE
feat(worker,api,connectors): push-side match-pr to pr_matched (FRO-205)

### DIFF
--- a/apps/api/src/live-state/router/external-entity.ts
+++ b/apps/api/src/live-state/router/external-entity.ts
@@ -3,9 +3,16 @@ import type { PrIndexJobData } from "@workspace/schemas/signals";
 import { ulid } from "ulid";
 import { z } from "zod";
 import { authorize, requireInternalApiKey } from "../../lib/authorize";
-import { enqueueGithubBackfill, enqueuePrIndex } from "../../lib/queue";
+import {
+  enqueueGithubBackfill,
+  enqueuePrIndex,
+  enqueueThreadRead,
+} from "../../lib/queue";
 import { privateRoute } from "../factories";
 import { schema } from "../schema";
+
+/** Thread statuses a push-side PR match may light up: Open (0), In progress (1). */
+const PR_MATCH_ACTIVE_STATUSES = new Set([0, 1]);
 
 /**
  * Org-scoped mirror of external issues/PRs.
@@ -103,6 +110,77 @@ export default privateRoute.withProcedures(({ mutation, query }) => ({
           }),
         )[0] ?? null
       );
+    }),
+
+    /**
+     * Fan out `pr_matched` thread reads for a push-side PR match (FRO-205). The
+     * worker's `match-pr` job passes the similar-thread candidates it found in
+     * the vector index; this resolves the PR from the mirror, filters the
+     * candidates to *unlinked* Open / In-progress threads (the DB is the source
+     * of truth — a vector payload's status can lag), and enqueues one
+     * `pr_matched` read per survivor. Synthesis decides whether to emit
+     * `link_pr` (ADR 0006). Internal (worker) use only.
+     */
+    fanOutPrMatch: mutation(
+      z.object({
+        organizationId: z.string(),
+        externalKey: z.string(),
+        matches: z.array(
+          z.object({ threadId: z.string(), score: z.number().min(0).max(1) }),
+        ),
+      }),
+    ).handler(async ({ req, db }) => {
+      requireInternalApiKey(req.context);
+
+      const { organizationId, externalKey, matches } = req.input;
+      if (matches.length === 0) return { enqueued: 0 };
+
+      const pr = Object.values(
+        await db.find(schema.externalEntity, {
+          where: {
+            organizationId,
+            externalKey,
+            type: "pull_request",
+            deletedAt: null,
+          },
+        }),
+      )[0];
+      // PR gone (closed-and-deleted / transferred out) since the match ran.
+      if (!pr) return { enqueued: 0 };
+
+      const threads = new Map(
+        Object.values(
+          await db.find(schema.thread, {
+            where: { id: { $in: matches.map((m) => m.threadId) } },
+          }),
+        ).map((thread) => [thread.id, thread]),
+      );
+
+      let enqueued = 0;
+      for (const { threadId, score } of matches) {
+        const thread = threads.get(threadId);
+        // Skip threads that are gone, closed/resolved, or already PR-linked.
+        if (
+          !thread ||
+          !PR_MATCH_ACTIVE_STATUSES.has(thread.status) ||
+          thread.externalPrId
+        ) {
+          continue;
+        }
+
+        const jobId = await enqueueThreadRead(threadId, {
+          kind: "pr_matched",
+          prMatched: {
+            prId: pr.id,
+            url: pr.url,
+            title: pr.title,
+            score,
+          },
+        });
+        if (jobId) enqueued += 1;
+      }
+
+      return { enqueued };
     }),
 
     /**

--- a/apps/api/src/live-state/router/external-entity.ts
+++ b/apps/api/src/live-state/router/external-entity.ts
@@ -155,7 +155,10 @@ export default privateRoute.withProcedures(({ mutation, query }) => ({
     const threads = new Map(
       Object.values(
         await db.find(schema.thread, {
-          where: { id: { $in: matches.map((m) => m.threadId) } },
+          where: {
+            id: { $in: matches.map((m) => m.threadId) },
+            organizationId,
+          },
         }),
       ).map((thread) => [thread.id, thread]),
     );

--- a/apps/api/src/live-state/router/external-entity.ts
+++ b/apps/api/src/live-state/router/external-entity.ts
@@ -62,309 +62,324 @@ const externalEntityFields = z.object({
 });
 
 export default privateRoute.withProcedures(({ mutation, query }) => ({
-    /**
-     * Non-deleted mirror rows for a repo — the reconcile job's cursor/baseline.
-     * Internal (integration) use only; in-app reads flow through the org tree.
-     */
-    listForRepo: query(
-      z.object({
-        organizationId: z.string(),
-        repoFullName: z.string(),
+  /**
+   * Non-deleted mirror rows for a repo — the reconcile job's cursor/baseline.
+   * Internal (integration) use only; in-app reads flow through the org tree.
+   */
+  listForRepo: query(
+    z.object({
+      organizationId: z.string(),
+      repoFullName: z.string(),
+    }),
+  ).handler(async ({ req, db }) => {
+    requireInternalApiKey(req.context);
+    return Object.values(
+      await db.find(schema.externalEntity, {
+        where: {
+          organizationId: req.input.organizationId,
+          repoFullName: req.input.repoFullName,
+          provider: "github",
+          deletedAt: null,
+        },
       }),
-    ).handler(async ({ req, db }) => {
-      requireInternalApiKey(req.context);
-      return Object.values(
+    );
+  }),
+
+  /**
+   * A single non-deleted mirrored pull request by canonical URL — the
+   * synthesis `read_pr` tool's depth-verification lookup (FRO-204). Keyed by
+   * URL to mirror the link-PR handler, which routes by the same canonical URL
+   * the `link_pr` action carries. Internal (worker) use only.
+   */
+  prByUrl: query(
+    z.object({
+      organizationId: z.string(),
+      url: z.string(),
+    }),
+  ).handler(async ({ req, db }) => {
+    requireInternalApiKey(req.context);
+    return (
+      Object.values(
         await db.find(schema.externalEntity, {
           where: {
             organizationId: req.input.organizationId,
-            repoFullName: req.input.repoFullName,
-            provider: "github",
-            deletedAt: null,
-          },
-        }),
-      );
-    }),
-
-    /**
-     * A single non-deleted mirrored pull request by canonical URL — the
-     * synthesis `read_pr` tool's depth-verification lookup (FRO-204). Keyed by
-     * URL to mirror the link-PR handler, which routes by the same canonical URL
-     * the `link_pr` action carries. Internal (worker) use only.
-     */
-    prByUrl: query(
-      z.object({
-        organizationId: z.string(),
-        url: z.string(),
-      }),
-    ).handler(async ({ req, db }) => {
-      requireInternalApiKey(req.context);
-      return (
-        Object.values(
-          await db.find(schema.externalEntity, {
-            where: {
-              organizationId: req.input.organizationId,
-              url: req.input.url,
-              type: "pull_request",
-              deletedAt: null,
-            },
-          }),
-        )[0] ?? null
-      );
-    }),
-
-    /**
-     * Fan out `pr_matched` thread reads for a push-side PR match (FRO-205). The
-     * worker's `match-pr` job passes the similar-thread candidates it found in
-     * the vector index; this resolves the PR from the mirror, filters the
-     * candidates to *unlinked* Open / In-progress threads (the DB is the source
-     * of truth — a vector payload's status can lag), and enqueues one
-     * `pr_matched` read per survivor. Synthesis decides whether to emit
-     * `link_pr` (ADR 0006). Internal (worker) use only.
-     */
-    fanOutPrMatch: mutation(
-      z.object({
-        organizationId: z.string(),
-        externalKey: z.string(),
-        matches: z.array(
-          z.object({ threadId: z.string(), score: z.number().min(0).max(1) }),
-        ),
-      }),
-    ).handler(async ({ req, db }) => {
-      requireInternalApiKey(req.context);
-
-      const { organizationId, externalKey, matches } = req.input;
-      if (matches.length === 0) return { enqueued: 0 };
-
-      const pr = Object.values(
-        await db.find(schema.externalEntity, {
-          where: {
-            organizationId,
-            externalKey,
+            url: req.input.url,
             type: "pull_request",
             deletedAt: null,
           },
         }),
-      )[0];
-      // PR gone (closed-and-deleted / transferred out) since the match ran.
-      if (!pr) return { enqueued: 0 };
+      )[0] ?? null
+    );
+  }),
 
-      const threads = new Map(
-        Object.values(
-          await db.find(schema.thread, {
-            where: { id: { $in: matches.map((m) => m.threadId) } },
-          }),
-        ).map((thread) => [thread.id, thread]),
-      );
+  /**
+   * Fan out `pr_matched` thread reads for a push-side PR match (FRO-205). The
+   * worker's `match-pr` job passes the similar-thread candidates it found in
+   * the vector index; this resolves the PR from the mirror, filters the
+   * candidates to *unlinked* Open / In-progress threads (the DB is the source
+   * of truth — a vector payload's status can lag), and enqueues one
+   * `pr_matched` read per survivor. Synthesis decides whether to emit
+   * `link_pr` (ADR 0006). Internal (worker) use only.
+   */
+  fanOutPrMatch: mutation(
+    z.object({
+      organizationId: z.string(),
+      externalKey: z.string(),
+      matches: z.array(
+        z.object({ threadId: z.string(), score: z.number().min(0).max(1) }),
+      ),
+    }),
+  ).handler(async ({ req, db }) => {
+    requireInternalApiKey(req.context);
 
-      let enqueued = 0;
-      for (const { threadId, score } of matches) {
-        const thread = threads.get(threadId);
-        // Skip threads that are gone, closed/resolved, or already PR-linked.
-        if (
-          !thread ||
-          !PR_MATCH_ACTIVE_STATUSES.has(thread.status) ||
-          thread.externalPrId
-        ) {
-          continue;
-        }
+    const { organizationId, externalKey, matches } = req.input;
+    if (matches.length === 0) return { enqueued: 0 };
 
-        const jobId = await enqueueThreadRead(threadId, {
-          kind: "pr_matched",
-          prMatched: {
-            prId: pr.id,
-            url: pr.url,
-            title: pr.title,
-            score,
-          },
-        });
-        if (jobId) enqueued += 1;
+    const pr = Object.values(
+      await db.find(schema.externalEntity, {
+        where: {
+          organizationId,
+          externalKey,
+          type: "pull_request",
+          deletedAt: null,
+        },
+      }),
+    )[0];
+    // Authoritative eligibility gate: the mirror is the source of truth, so a
+    // PR that went gone (closed-and-deleted / transferred out) or flipped to
+    // closed / draft since the match ran is dropped rather than fanned out.
+    if (!pr || pr.state !== "open" || pr.draft === true) {
+      return { enqueued: 0 };
+    }
+
+    const threads = new Map(
+      Object.values(
+        await db.find(schema.thread, {
+          where: { id: { $in: matches.map((m) => m.threadId) } },
+        }),
+      ).map((thread) => [thread.id, thread]),
+    );
+
+    let enqueued = 0;
+    for (const { threadId, score } of matches) {
+      const thread = threads.get(threadId);
+      // Skip threads that are gone, archived, closed/resolved, or already
+      // PR-linked.
+      if (
+        !thread ||
+        thread.deletedAt !== null ||
+        !PR_MATCH_ACTIVE_STATUSES.has(thread.status) ||
+        thread.externalPrId
+      ) {
+        continue;
       }
 
-      return { enqueued };
-    }),
+      const jobId = await enqueueThreadRead(threadId, {
+        kind: "pr_matched",
+        prMatched: {
+          prId: pr.id,
+          url: pr.url,
+          title: pr.title,
+          score,
+        },
+      });
+      if (jobId) enqueued += 1;
+    }
 
-    /**
-     * Insert or update the mirror row identified by
-     * `(organizationId, externalKey)`. Refreshes `lastSyncedAt` and clears any
-     * previous `deletedAt` (a live event means the entity exists again).
-     *
-     * The find-then-insert/update runs inside a transaction so concurrent
-     * events for the same entity don't race into duplicate rows.
-     */
-    upsert: mutation(externalEntityFields).handler(async ({ req, db }) => {
-      requireInternalApiKey(req.context);
+    return { enqueued };
+  }),
 
-      const { organizationId, externalKey } = req.input;
-      const now = new Date();
+  /**
+   * Insert or update the mirror row identified by
+   * `(organizationId, externalKey)`. Refreshes `lastSyncedAt` and clears any
+   * previous `deletedAt` (a live event means the entity exists again).
+   *
+   * The find-then-insert/update runs inside a transaction so concurrent
+   * events for the same entity don't race into duplicate rows.
+   */
+  upsert: mutation(externalEntityFields).handler(async ({ req, db }) => {
+    requireInternalApiKey(req.context);
 
-      const id = await db.transaction(async ({ trx }) => {
-        const existing = Object.values(
-          await trx.find(schema.externalEntity, {
-            where: { organizationId, externalKey },
-          }),
-        )[0];
+    const { organizationId, externalKey } = req.input;
+    const now = new Date();
 
-        if (existing) {
-          await trx.update(schema.externalEntity, existing.id, {
-            ...req.input,
-            lastSyncedAt: now,
-            deletedAt: null,
-          });
-          return existing.id;
-        }
+    const id = await db.transaction(async ({ trx }) => {
+      const existing = Object.values(
+        await trx.find(schema.externalEntity, {
+          where: { organizationId, externalKey },
+        }),
+      )[0];
 
-        const newId = ulid().toLowerCase();
-        await trx.insert(schema.externalEntity, {
-          id: newId,
+      if (existing) {
+        await trx.update(schema.externalEntity, existing.id, {
           ...req.input,
           lastSyncedAt: now,
           deletedAt: null,
         });
-        return newId;
+        return existing.id;
+      }
+
+      const newId = ulid().toLowerCase();
+      await trx.insert(schema.externalEntity, {
+        id: newId,
+        ...req.input,
+        lastSyncedAt: now,
+        deletedAt: null,
       });
+      return newId;
+    });
 
-      // Keep the PR vector index current on every mirror write (webhook,
-      // backfill, reconcile). Index-only: the worker derives eligibility and
-      // re-embeds; it never fans out `pr_matched` reads (FRO-203). Fire-and-log
-      // so an indexing hiccup never fails the mirror write.
-      if (req.input.type === "pull_request") {
-        const jobData: PrIndexJobData = {
-          organizationId,
-          externalEntityId: id,
-          externalKey,
-          provider: req.input.provider,
-          repoFullName: req.input.repoFullName,
-          number: req.input.number,
-          url: req.input.url,
-          title: req.input.title,
-          body: req.input.body,
-          headRef: req.input.headRef,
-          state: req.input.state,
-          draft: req.input.draft,
-        };
-        enqueuePrIndex(jobData).catch((error) => {
-          console.error(`Failed to enqueue PR index for ${externalKey}:`, error);
-        });
-      }
-
-      return id;
-    }),
-
-    /**
-     * Soft-delete the mirror row (issue deletion / transfer-out). No-op when the
-     * entity was never mirrored.
-     */
-    softDelete: mutation(
-      z.object({
-        organizationId: z.string(),
-        externalKey: z.string(),
-      }),
-    ).handler(async ({ req, db }) => {
-      requireInternalApiKey(req.context);
-
-      const { organizationId, externalKey } = req.input;
-
-      const deleted = await db.transaction(async ({ trx }) => {
-        const existing = Object.values(
-          await trx.find(schema.externalEntity, {
-            where: { organizationId, externalKey },
-          }),
-        )[0];
-
-        if (!existing) return null;
-
-        const now = new Date();
-        await trx.update(schema.externalEntity, existing.id, {
-          deletedAt: now,
-          lastSyncedAt: now,
-        });
-        return { id: existing.id, type: existing.type };
+    // Keep the PR vector index current on every mirror write (webhook,
+    // backfill, reconcile). Index-only: the worker derives eligibility and
+    // re-embeds; it never fans out `pr_matched` reads (FRO-203). Fire-and-log
+    // so an indexing hiccup never fails the mirror write.
+    if (req.input.type === "pull_request") {
+      const jobData: PrIndexJobData = {
+        organizationId,
+        externalEntityId: id,
+        externalKey,
+        provider: req.input.provider,
+        repoFullName: req.input.repoFullName,
+        number: req.input.number,
+        url: req.input.url,
+        title: req.input.title,
+        body: req.input.body,
+        headRef: req.input.headRef,
+        state: req.input.state,
+        draft: req.input.draft,
+      };
+      enqueuePrIndex(jobData).catch((error) => {
+        console.error(`Failed to enqueue PR index for ${externalKey}:`, error);
       });
+    }
 
-      // Drop the PR vector when its mirror row is removed (PR deleted /
-      // transferred out) so stale points can't surface in similarity search.
-      if (deleted && deleted.type === "pull_request") {
-        const jobData: PrIndexJobData = {
-          organizationId,
-          externalEntityId: deleted.id,
-          externalKey,
-          deleted: true,
-        };
-        enqueuePrIndex(jobData).catch((error) => {
-          console.error(
-            `Failed to enqueue PR index delete for ${externalKey}:`,
-            error,
-          );
-        });
-      }
+    return id;
+  }),
 
-      return deleted?.id ?? null;
+  /**
+   * Soft-delete the mirror row (issue deletion / transfer-out). No-op when the
+   * entity was never mirrored.
+   */
+  softDelete: mutation(
+    z.object({
+      organizationId: z.string(),
+      externalKey: z.string(),
     }),
+  ).handler(async ({ req, db }) => {
+    requireInternalApiKey(req.context);
 
-    /**
-     * Dev-only manual sync: enqueue a full issue/PR backfill for each connected
-     * repo, populating the mirror without webhooks (which aren't wired up
-     * locally). The github app owns the backfill worker that processes the jobs;
-     * this just kicks them off. Refuses to run in production, where webhooks +
-     * the daily reconcile keep the mirror current.
-     */
-    syncFromGithub: mutation(
-      z.object({
-        organizationId: z.string(),
-      }),
-    ).handler(async ({ req, db }) => {
-      if (process.env.NODE_ENV === "production") {
-        throw new Error("DEV_ONLY");
-      }
+    const { organizationId, externalKey } = req.input;
 
-      const { organizationId } = req.input;
-
-      authorize(req, { organizationId });
-
-      const integration = Object.values(
-        await db.find(schema.integration, {
-          where: { organizationId, type: "github", enabled: true },
+    const deleted = await db.transaction(async ({ trx }) => {
+      const existing = Object.values(
+        await trx.find(schema.externalEntity, {
+          where: { organizationId, externalKey },
         }),
       )[0];
-      if (!integration || !integration.configStr) {
-        throw new Error("GITHUB_INTEGRATION_NOT_CONFIGURED");
-      }
 
-      let rawConfig: unknown;
-      try {
-        rawConfig = JSON.parse(integration.configStr);
-      } catch {
-        throw new Error("GITHUB_INTEGRATION_NOT_CONFIGURED");
-      }
-      const parsedConfig = githubBackfillConfigSchema.safeParse(rawConfig);
-      if (!parsedConfig.success) {
-        throw new Error("GITHUB_INTEGRATION_NOT_CONFIGURED");
-      }
-      const { repos, installationId } = parsedConfig.data;
-      if (repos.length === 0) {
-        throw new Error("GITHUB_REPOSITORIES_NOT_CONFIGURED");
-      }
-      if (!installationId) {
-        throw new Error("GITHUB_INSTALLATION_NOT_CONFIGURED");
-      }
+      if (!existing) return null;
 
-      const results = await Promise.allSettled(
-        repos.map((repo) =>
-          enqueueGithubBackfill({
-            organizationId,
-            installationId,
-            owner: repo.owner,
-            repo: repo.name,
-            fullName: repo.fullName,
-          }),
-        ),
-      );
+      const now = new Date();
+      await trx.update(schema.externalEntity, existing.id, {
+        deletedAt: now,
+        lastSyncedAt: now,
+      });
+      return { id: existing.id, type: existing.type };
+    });
 
-      const enqueued = results.filter(
-        (result): result is PromiseFulfilledResult<string> =>
-          result.status === "fulfilled" && result.value !== null,
-      ).length;
+    // Drop the PR vector when its mirror row is removed (PR deleted /
+    // transferred out) so stale points can't surface in similarity search.
+    if (deleted && deleted.type === "pull_request") {
+      const jobData: PrIndexJobData = {
+        organizationId,
+        externalEntityId: deleted.id,
+        externalKey,
+        provider: "",
+        repoFullName: "",
+        number: 0,
+        url: "",
+        title: "",
+        body: null,
+        headRef: null,
+        state: "closed",
+        draft: null,
+        deleted: true,
+      };
+      enqueuePrIndex(jobData).catch((error) => {
+        console.error(
+          `Failed to enqueue PR index delete for ${externalKey}:`,
+          error,
+        );
+      });
+    }
 
-      return { enqueued, repos: repos.length };
+    return deleted?.id ?? null;
+  }),
+
+  /**
+   * Dev-only manual sync: enqueue a full issue/PR backfill for each connected
+   * repo, populating the mirror without webhooks (which aren't wired up
+   * locally). The github app owns the backfill worker that processes the jobs;
+   * this just kicks them off. Refuses to run in production, where webhooks +
+   * the daily reconcile keep the mirror current.
+   */
+  syncFromGithub: mutation(
+    z.object({
+      organizationId: z.string(),
     }),
-  }));
+  ).handler(async ({ req, db }) => {
+    if (process.env.NODE_ENV === "production") {
+      throw new Error("DEV_ONLY");
+    }
+
+    const { organizationId } = req.input;
+
+    authorize(req, { organizationId });
+
+    const integration = Object.values(
+      await db.find(schema.integration, {
+        where: { organizationId, type: "github", enabled: true },
+      }),
+    )[0];
+    if (!integration || !integration.configStr) {
+      throw new Error("GITHUB_INTEGRATION_NOT_CONFIGURED");
+    }
+
+    let rawConfig: unknown;
+    try {
+      rawConfig = JSON.parse(integration.configStr);
+    } catch {
+      throw new Error("GITHUB_INTEGRATION_NOT_CONFIGURED");
+    }
+    const parsedConfig = githubBackfillConfigSchema.safeParse(rawConfig);
+    if (!parsedConfig.success) {
+      throw new Error("GITHUB_INTEGRATION_NOT_CONFIGURED");
+    }
+    const { repos, installationId } = parsedConfig.data;
+    if (repos.length === 0) {
+      throw new Error("GITHUB_REPOSITORIES_NOT_CONFIGURED");
+    }
+    if (!installationId) {
+      throw new Error("GITHUB_INSTALLATION_NOT_CONFIGURED");
+    }
+
+    const results = await Promise.allSettled(
+      repos.map((repo) =>
+        enqueueGithubBackfill({
+          organizationId,
+          installationId,
+          owner: repo.owner,
+          repo: repo.name,
+          fullName: repo.fullName,
+        }),
+      ),
+    );
+
+    const enqueued = results.filter(
+      (result): result is PromiseFulfilledResult<string> =>
+        result.status === "fulfilled" && result.value !== null,
+    ).length;
+
+    return { enqueued, repos: repos.length };
+  }),
+}));

--- a/apps/worker/src/handlers/index-pr.ts
+++ b/apps/worker/src/handlers/index-pr.ts
@@ -1,12 +1,8 @@
 import { createHash } from "node:crypto";
-import { google } from "@ai-sdk/google";
-import type {
-  PrIndexJobData,
-  PrIndexUpsertJobData,
-} from "@workspace/schemas/signals";
+import type { PrIndexJobData } from "@workspace/schemas/signals";
 import { log } from "@workspace/utils/logging";
-import { embed } from "ai";
 import type { Job } from "bullmq";
+import { buildPrEmbedText, generatePrEmbedding } from "../lib/pr-embedding";
 import {
   deletePrVector,
   getPrPoint,
@@ -15,52 +11,8 @@ import {
   upsertPrVector,
 } from "../lib/qdrant/pull-requests";
 
-const EMBEDDING_MODEL = "gemini-embedding-001";
-const embeddingModel = google.embedding(EMBEDDING_MODEL);
-
-/**
- * Text embedded for PR similarity: title + body + head ref (design lock,
- * FRO-201). The head ref (branch name) is a strong, terse signal
- * (e.g. `fix/oauth-token-refresh`) worth its own line.
- */
-const buildEmbedText = (data: PrIndexUpsertJobData): string =>
-  [
-    `title: ${data.title}`,
-    data.body ? `body: ${data.body}` : null,
-    data.headRef ? `head: ${data.headRef}` : null,
-  ]
-    .filter(Boolean)
-    .join("\n")
-    .trim();
-
 const computeSha256 = (data: string): string =>
   createHash("sha256").update(data).digest("hex");
-
-/**
- * Generate a normalized embedding vector. Uses SEMANTIC_SIMILARITY (matching the
- * thread index) so PR and thread vectors live in a comparable space for
- * cross-searches.
- */
-const generateEmbedding = async (text: string): Promise<number[] | null> => {
-  if (!text || text.trim().length === 0) {
-    return null;
-  }
-
-  const { embedding } = await embed({
-    model: embeddingModel,
-    value: text,
-    providerOptions: {
-      google: { taskType: "SEMANTIC_SIMILARITY" },
-    },
-  });
-
-  const norm = Math.hypot(...embedding);
-  if (!Number.isFinite(norm) || norm === 0) {
-    console.warn("PR embedding normalization failed: invalid norm", norm);
-    return embedding;
-  }
-  return embedding.map((value) => value / norm);
-};
 
 /**
  * Index-only handler for the `pr-index` queue (FRO-203). Keeps the PR vector
@@ -95,7 +47,7 @@ export const handleIndexPr = async (job: Job<PrIndexJobData>) => {
     return { externalKey, action: "skipped" as const };
   }
 
-  const embedText = buildEmbedText(data);
+  const embedText = buildPrEmbedText(data);
   const contentHash = computeSha256(embedText);
   const now = Date.now();
 
@@ -111,7 +63,7 @@ export const handleIndexPr = async (job: Job<PrIndexJobData>) => {
   }
 
   // New PR or edited content: embed and upsert the full point.
-  const embedding = await generateEmbedding(embedText);
+  const embedding = await generatePrEmbedding(embedText);
   if (!embedding) {
     throw new Error(`Failed to embed PR ${externalKey}`);
   }

--- a/apps/worker/src/handlers/match-pr.ts
+++ b/apps/worker/src/handlers/match-pr.ts
@@ -1,0 +1,71 @@
+import type { PrMatchJobData } from "@workspace/schemas/signals";
+import { log } from "@workspace/utils/logging";
+import type { Job } from "bullmq";
+import { fetchClient } from "../lib/database/client";
+import { buildPrEmbedText, generatePrEmbedding } from "../lib/pr-embedding";
+import { PR_MATCH_THRESHOLD } from "../lib/qdrant/pull-requests";
+import { searchSimilarThreads } from "../lib/qdrant/threads";
+
+/** Open (0) and In progress (1) — the only threads a PR match may light up. */
+const ACTIVE_STATUSES = [0, 1];
+
+/** How many similar threads to consider per PR match. */
+const MATCH_LIMIT = 10;
+
+/**
+ * Push-side PR↔thread discovery (FRO-205). A GitHub webhook enqueues this when
+ * an eligible PR opens / reopens / becomes ready-for-review / is edited. The
+ * handler embeds the PR, searches for similar Open / In-progress threads, and
+ * hands the candidates to the API, which filters to *unlinked* threads and fans
+ * out one `pr_matched` thread read per match (ADR 0006 trigger channel).
+ *
+ * Eligibility (open, non-draft) is re-derived here from `state` / `draft` rather
+ * than trusted from the enqueue, so a job that raced a since-closed / re-drafted
+ * PR is dropped instead of matching a dead PR.
+ */
+export const handleMatchPr = async (job: Job<PrMatchJobData>) => {
+  const data = job.data;
+  const { organizationId, externalKey } = data;
+
+  const eligible = data.state === "open" && data.draft !== true;
+  if (!eligible) {
+    log.info(
+      "worker.match-pr",
+      `Skipped ineligible PR ${externalKey} (state=${data.state}, draft=${data.draft})`,
+    );
+    return { externalKey, action: "skipped" as const };
+  }
+
+  const embedText = buildPrEmbedText(data);
+  const embedding = await generatePrEmbedding(embedText);
+  if (!embedding) {
+    throw new Error(`Failed to embed PR ${externalKey}`);
+  }
+
+  const matches = await searchSimilarThreads(embedding, {
+    organizationId,
+    statusFilter: ACTIVE_STATUSES,
+    scoreThreshold: PR_MATCH_THRESHOLD,
+    limit: MATCH_LIMIT,
+  });
+
+  if (matches.length === 0) {
+    log.info("worker.match-pr", `No similar threads for PR ${externalKey}`);
+    return { externalKey, action: "matched" as const, enqueued: 0 };
+  }
+
+  // The API owns the authoritative unlinked-thread filter (the vector payload's
+  // status can lag the mirror) and the thread-read enqueue with its ADR-0006
+  // coalescing, so hand it the raw candidates and let it fan out.
+  const { enqueued } = await fetchClient.mutate.externalEntity.fanOutPrMatch({
+    organizationId,
+    externalKey,
+    matches: matches.map((m) => ({ threadId: m.threadId, score: m.score })),
+  });
+
+  log.info(
+    "worker.match-pr",
+    `PR ${externalKey}: ${matches.length} similar thread(s), ${enqueued} pr_matched read(s) enqueued`,
+  );
+  return { externalKey, action: "matched" as const, enqueued };
+};

--- a/apps/worker/src/lib/pr-embedding.ts
+++ b/apps/worker/src/lib/pr-embedding.ts
@@ -1,0 +1,56 @@
+import { google } from "@ai-sdk/google";
+import { embed } from "ai";
+
+const EMBEDDING_MODEL = "gemini-embedding-001";
+const embeddingModel = google.embedding(EMBEDDING_MODEL);
+
+/** The subset of a PR needed to build its embed text. */
+export type PrEmbedInput = {
+  title: string;
+  body: string | null;
+  headRef: string | null;
+};
+
+/**
+ * Text embedded for PR similarity: title + body + head ref (design lock,
+ * FRO-201). The head ref (branch name) is a strong, terse signal
+ * (e.g. `fix/oauth-token-refresh`) worth its own line. Shared by the index-only
+ * (`pr-index`) and push-side (`match-pr`) paths so both embed identically.
+ */
+export const buildPrEmbedText = (data: PrEmbedInput): string =>
+  [
+    `title: ${data.title}`,
+    data.body ? `body: ${data.body}` : null,
+    data.headRef ? `head: ${data.headRef}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+
+/**
+ * Generate a normalized embedding vector. Uses SEMANTIC_SIMILARITY (matching the
+ * thread index) so PR and thread vectors live in a comparable space for
+ * cross-searches.
+ */
+export const generatePrEmbedding = async (
+  text: string,
+): Promise<number[] | null> => {
+  if (!text || text.trim().length === 0) {
+    return null;
+  }
+
+  const { embedding } = await embed({
+    model: embeddingModel,
+    value: text,
+    providerOptions: {
+      google: { taskType: "SEMANTIC_SIMILARITY" },
+    },
+  });
+
+  const norm = Math.hypot(...embedding);
+  if (!Number.isFinite(norm) || norm === 0) {
+    console.warn("PR embedding normalization failed: invalid norm", norm);
+    return embedding;
+  }
+  return embedding.map((value) => value / norm);
+};

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -1,5 +1,6 @@
 import type {
   PrIndexJobData,
+  PrMatchJobData,
   ThreadReadJobData,
 } from "@workspace/schemas/signals";
 import { initSharedLogger, log } from "@workspace/utils/logging";
@@ -7,6 +8,7 @@ import { type Job, Worker } from "bullmq";
 import Redis from "ioredis";
 import { handleCrawlDocumentation } from "./handlers/crawl-documentation";
 import { handleIndexPr } from "./handlers/index-pr";
+import { handleMatchPr } from "./handlers/match-pr";
 import { ensureDocumentationCollection } from "./lib/qdrant/documentation";
 import { ensureMessagesCollection } from "./lib/qdrant/messages";
 import { ensurePrsCollection } from "./lib/qdrant/pull-requests";
@@ -17,6 +19,7 @@ import { registerDefaultProcessors } from "./pipeline/processors/registration";
 const THREAD_PIPELINE_QUEUE = "thread-pipeline";
 const CRAWL_DOCUMENTATION_QUEUE = "crawl-documentation";
 const PR_INDEX_QUEUE = "pr-index";
+const PR_MATCH_QUEUE = "pr-match";
 
 const parseBooleanEnv = (value: string | undefined): boolean | undefined => {
   if (value === undefined) {
@@ -223,6 +226,35 @@ prIndexWorker.on("error", (err) => {
   log.error("worker.pr-index", `Worker error: ${formatError(err)}`);
 });
 
+// Create PR push-side match worker (FRO-205). Embeds an eligible PR, searches
+// for similar Open / In-progress threads, and fans out `pr_matched` reads for
+// the unlinked ones.
+const prMatchWorker = new Worker<PrMatchJobData>(PR_MATCH_QUEUE, handleMatchPr, {
+  connection,
+  autorun: false,
+  concurrency: 3,
+  removeOnComplete: {
+    count: 100,
+    age: 24 * 3600,
+  },
+  removeOnFail: {
+    count: 500,
+  },
+});
+
+prMatchWorker.on("completed", (job) => {
+  log.info("worker.match-pr", `Job ${job.id} completed`);
+});
+
+prMatchWorker.on("failed", (job, err) => {
+  log.error("worker.match-pr", `Job ${job?.id} failed: ${err.message}`);
+  log.error("worker.match-pr", formatError(err));
+});
+
+prMatchWorker.on("error", (err) => {
+  log.error("worker.match-pr", `Worker error: ${formatError(err)}`);
+});
+
 // Initialize and start
 const initialize = async () => {
   log.info("worker", "Initializing worker");
@@ -251,6 +283,7 @@ const initialize = async () => {
   threadPipelineWorker.run();
   crawlDocWorker.run();
   prIndexWorker.run();
+  prMatchWorker.run();
 
   log.info("worker", "Listening for jobs");
 };
@@ -262,6 +295,7 @@ const handleShutdown = async () => {
     threadPipelineWorker.close(),
     crawlDocWorker.close(),
     prIndexWorker.close(),
+    prMatchWorker.close(),
   ]);
   await connection.quit();
   log.info("worker", "Workers shut down successfully");

--- a/connectors/github/src/lib/queue.ts
+++ b/connectors/github/src/lib/queue.ts
@@ -1,4 +1,5 @@
 import { createRedisConnection } from "@connectors/framework/runtime";
+import type { PrMatchJobData } from "@workspace/schemas/signals";
 import { Queue } from "bullmq";
 
 export { createRedisConnection } from "@connectors/framework/runtime";
@@ -125,5 +126,54 @@ export const enqueueRepoReconcile = async (data: ReconcileRepoJobData) => {
     backoff: { type: "exponential", delay: 10_000 },
     removeOnComplete: { count: 100, age: 24 * 3600 },
     removeOnFail: { count: 200 },
+  });
+};
+
+/**
+ * PR push-side match queue (FRO-205). The github connector produces onto it from
+ * the pull-request webhook; the worker (apps/worker) owns the processor —
+ * signals/embedding is the worker's domain, not this app's. Keep the queue and
+ * job names in sync with the consumer (`PR_MATCH_QUEUE` in apps/worker).
+ */
+const PR_MATCH_QUEUE = "pr-match";
+const PR_MATCH_JOB_NAME = "match-pr";
+
+let prMatchQueue: Queue<PrMatchJobData> | null = null;
+
+const getPrMatchQueue = (): Queue<PrMatchJobData> => {
+  if (!prMatchQueue) {
+    prMatchQueue = new Queue<PrMatchJobData>(PR_MATCH_QUEUE, {
+      connection: createRedisConnection(),
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: { type: "exponential", delay: 5000 },
+      },
+    });
+  }
+  return prMatchQueue;
+};
+
+/**
+ * Enqueue a push-side match for a PR. One pending job per PR
+ * (`pr-match:{externalKey}`) coalesces a burst of webhook events (open → edit)
+ * into a single embed + search: any prior non-active job for the same PR is
+ * dropped so the latest content wins, matching `enqueuePrIndex`'s scheme.
+ */
+export const enqueuePrMatch = async (data: PrMatchJobData) => {
+  const q = getPrMatchQueue();
+  const jobId = `pr-match:${data.externalKey}`;
+
+  const existing = await q.getJob(jobId);
+  if (existing) {
+    const state = await existing.getState();
+    if (state !== "active") {
+      await existing.remove();
+    }
+  }
+
+  await q.add(PR_MATCH_JOB_NAME, data, {
+    jobId,
+    removeOnComplete: { count: 100, age: 24 * 3600 },
+    removeOnFail: { count: 500 },
   });
 };

--- a/connectors/github/src/lib/queue.ts
+++ b/connectors/github/src/lib/queue.ts
@@ -154,14 +154,24 @@ const getPrMatchQueue = (): Queue<PrMatchJobData> => {
 };
 
 /**
- * Enqueue a push-side match for a PR. One pending job per PR
- * (`pr-match:{externalKey}`) coalesces a burst of webhook events (open → edit)
- * into a single embed + search: any prior non-active job for the same PR is
- * dropped so the latest content wins, matching `enqueuePrIndex`'s scheme.
+ * Enqueue a push-side match for a PR. One pending job per PR — scoped by
+ * `(organizationId, externalKey)` so orgs sharing a repo don't coalesce onto
+ * each other's match (`externalKey` is `provider:owner/repo#number`, not
+ * org-unique) — coalesces a burst of webhook events (open → edit) into a single
+ * embed + search: any prior non-active job for the same PR is dropped so the
+ * latest content wins, matching `enqueuePrIndex`'s scheme.
+ *
+ * BullMQ reserves `:` as a Redis key separator and rejects it in custom job
+ * ids, so the parts are joined with `_` and `externalKey`'s `:` is replaced
+ * (its `_`s escaped first) to keep the id injective — the same scheme the
+ * backfill/reconcile ids use.
  */
 export const enqueuePrMatch = async (data: PrMatchJobData) => {
   const q = getPrMatchQueue();
-  const jobId = `pr-match:${data.externalKey}`;
+  const safeExternalKey = data.externalKey
+    .replaceAll("_", "__")
+    .replaceAll(":", "_");
+  const jobId = `pr-match_${data.organizationId}_${safeExternalKey}`;
 
   const existing = await q.getJob(jobId);
   if (existing) {

--- a/connectors/github/src/webhooks/index.ts
+++ b/connectors/github/src/webhooks/index.ts
@@ -7,7 +7,22 @@ import {
 } from "../lib/external-entity";
 import { app } from "../lib/github";
 import { fetchClient, store } from "../lib/live-state";
+import { enqueuePrMatch } from "../lib/queue";
 import { STATUS_CLOSED, STATUS_OPEN, STATUS_RESOLVED } from "../utils";
+
+/**
+ * Pull-request actions that warrant a push-side thread match (FRO-205): the PR
+ * became newly matchable — opened, reopened, undrafted, or its title/body was
+ * edited. Deliberately excludes `synchronize` (new commits don't change the
+ * semantic content we match on) and close/draft transitions (those make it
+ * ineligible). A draft PR is filtered out again below by the eligibility check.
+ */
+const PR_MATCH_ACTIONS = new Set([
+  "opened",
+  "reopened",
+  "ready_for_review",
+  "edited",
+]);
 
 /**
  * Resolve the FrontDesk organization that owns a GitHub installation by
@@ -180,6 +195,26 @@ export const setupWebhooks = () => {
 
       if (action === "closed") {
         resolveLinkedThreads(fields, { merged: fields.merged ?? false });
+      }
+
+      // Push-side discovery (FRO-205): when an eligible (open, non-draft) PR
+      // becomes newly matchable, embed it and fan out `pr_matched` reads to
+      // similar active threads. The worker owns the embed/search/fan-out; this
+      // only kicks it off. Excludes `synchronize` and close/draft transitions.
+      if (
+        PR_MATCH_ACTIONS.has(action) &&
+        fields.state === "open" &&
+        fields.draft !== true
+      ) {
+        await enqueuePrMatch({
+          organizationId,
+          externalKey: fields.externalKey,
+          title: fields.title,
+          body: fields.body,
+          headRef: fields.headRef,
+          state: fields.state,
+          draft: fields.draft,
+        });
       }
     } catch (error) {
       console.error("[GitHub] Error handling pull_request webhook:", error);

--- a/packages/schemas/src/signals.ts
+++ b/packages/schemas/src/signals.ts
@@ -443,6 +443,34 @@ export type PrIndexJobData = z.infer<typeof prIndexJobDataSchema>;
 /** The upsert (embed-and-index) variant, narrowed from a non-`deleted` job. */
 export type PrIndexUpsertJobData = z.infer<typeof prIndexUpsertSchema>;
 
+// --- PR push-side match (FRO-205) -----------------------------------------
+
+/**
+ * Contract for a `match-pr` job: GitHub webhooks enqueue one when an eligible
+ * PR opens / reopens / is marked ready-for-review / is edited (not on
+ * `synchronize`). The worker embeds the PR (title + body + head ref), searches
+ * for similar Open / In-progress unlinked [threads](../../CONTEXT.md), and fans
+ * out a `pr_matched` thread read per strong match (ADR 0006 trigger channel).
+ *
+ * This is the *push* side of PR↔thread discovery — distinct from the index-only
+ * `pr-index` channel (FRO-203), which keeps the vector current but never fans
+ * out reads. The worker re-derives eligibility from `state` / `draft` so a
+ * stale enqueue for a since-closed / re-drafted PR is dropped.
+ */
+export const prMatchJobDataSchema = z.object({
+  organizationId: z.string(),
+  /** Provider-agnostic key `provider:owner/repo#number`; the PR's identity. */
+  externalKey: z.string(),
+  title: z.string(),
+  body: z.string().nullable(),
+  headRef: z.string().nullable(),
+  /** Upstream PR state ("open" | "closed"); drives eligibility. */
+  state: z.string(),
+  /** Draft flag; a draft PR is never eligible. */
+  draft: z.boolean().nullable(),
+});
+export type PrMatchJobData = z.infer<typeof prMatchJobDataSchema>;
+
 // --- Status labels (kept) -------------------------------------------------
 
 export const STATUS_LABELS: Record<number, string> = {


### PR DESCRIPTION
## What & why

Push-side PR↔thread discovery (FRO-205, part of [FRO-201](https://linear.app/front-desk/issue/FRO-201)). When an eligible PR becomes newly matchable, we proactively surface it to similar active threads as a `pr_matched` lead — synthesis then decides whether to emit `link_pr` (ADR 0006).

## How it works

1. **connectors/github** — the pull-request webhook enqueues a `match-pr` job on `opened` / `reopened` / `ready_for_review` / `edited` (not `synchronize`, not close/draft transitions), gated to eligible (open, non-draft) PRs. One pending job per PR coalesces a burst of events.
2. **worker `match-pr`** — re-derives eligibility, embeds the PR (title + body + head ref, same vector space as the index), searches similar **Open / In-progress** threads above the `PR_MATCH_THRESHOLD` (0.85), and hands the candidates to the API.
3. **api `externalEntity.fanOutPrMatch`** — resolves the PR from the mirror, filters candidates to **unlinked** active threads (DB is the source of truth — a vector payload's status can lag), and enqueues one `pr_matched` read per survivor via the ADR-0006 coalescing enqueue.

The `pr-index` (FRO-203) channel stays index-only; this is the separate push path. Shared PR embed helpers were extracted so index and match embed identically.

## Acceptance criteria

- [x] `match-pr` runs after the listed webhook events for eligible PRs
- [x] Matching threads filtered to Open / In progress and unlinked
- [x] Each match enqueues a thread read with `pr_matched` payload (score + PR)
- [x] Opening a PR similar to an active unlinked thread can produce a link-PR read
- [x] Reopen / undraft re-runs match; close / draft does not fan out new reads

## Stack

Stacked on #325 (FRO-204). Base will retarget to `main` as the stack merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Push-side PR-to-thread matching: when an eligible PR opens/reopens/undrafts/edits, we embed it and fan out `pr_matched` leads to similar active, unlinked threads. Delivers FRO-205 (part of FRO-201) so synthesis can emit `link_pr` faster.

- **New Features**
  - GitHub webhook enqueues a coalesced `pr-match` job on `opened`, `reopened`, `ready_for_review`, and `edited` (not `synchronize` or close/draft transitions).
  - Worker re-checks eligibility (open, non-draft), embeds the PR (title, body, head ref), searches similar Open/In‑progress threads (limit 10, thresholded), and asks the API to fan out `pr_matched` reads to unlinked active threads.
  - Shared embed helpers `buildPrEmbedText` and `generatePrEmbedding`; added schema `prMatchJobData` and a worker-owned `pr-match` queue. `pr-index` remains index-only.

- **Bug Fixes**
  - `pr-match` job ids are org-scoped and escape `:` to avoid cross-org coalescing and BullMQ key issues.
  - API `fanOutPrMatch` revalidates the PR from the mirror (must be open and non-draft), scopes thread lookup by `organizationId`, skips soft-deleted threads, and enqueues reads with ADR‑0006 coalescing.

<sup>Written for commit e59156a60a1a479d11d1249d96a1ecb4be778bfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #323
2. #324
3. #325
4. **#326** 👈 current
<!-- stack:links:end -->