### PR TITLE
fix(web): silently re-enable GitHub on reconnect

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,7 +80,7 @@ The counterpart of an [integration](#integration) on the external system — the
 
 ### External install liveness
 
-Whether an [integration](#integration)'s [external install](#external-install) still exists and is usable on the other system. Orthogonal to FrontDesk's `integration.enabled` flag and to any [capability](#capability) the connector provides — it is a property of the install itself, not of issue tracking, notifications, or support entry.
+Whether an [integration](#integration)'s [external install](#external-install) still exists and is reachable on the other system. Orthogonal to FrontDesk's `integration.enabled` flag and to any [capability](#capability) the connector provides — it is a property of the install itself, not of issue tracking, notifications, or support entry. The probe answers existence/reachability only (e.g. GitHub: installation still present); it does not validate repository access or broader install usability.
 
 ### Thread
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,7 +72,15 @@ A role a [connector](#connector) can play, expressed as a typed interface (a bun
 
 ### Integration
 
-One org's installed, configured instance of a [connector](#connector). A row in the `integration` table (`type`, `enabled`, `configStr`), scoped by `organizationId`. "Integration" is the _installed connection_, not the code that powers it (that is the [connector](#connector)) and not the role it plays (that is a [capability](#capability)).
+One org's installed, configured instance of a [connector](#connector). A row in the `integration` table (`type`, `enabled`, `configStr`), scoped by `organizationId`. "Integration" is the _installed connection_, not the code that powers it (that is the [connector](#connector)) and not the role it plays (that is a [capability](#capability)). Distinct from the [external install](#external-install): `enabled` here is FrontDesk's local switch, not whether the install still exists on the other system.
+
+### External install
+
+The counterpart of an [integration](#integration) on the external system — the GitHub App installation, Slack workspace install, Discord bot membership, etc. FrontDesk does not own it; the external system does. An integration may be `enabled: false` while its external install still exists, or `enabled: true` after the external install has been removed (stale). _Avoid_: calling this "the integration" or saying "integration enabled" when the external side is meant.
+
+### External install liveness
+
+Whether an [integration](#integration)'s [external install](#external-install) still exists and is usable on the other system. Orthogonal to FrontDesk's `integration.enabled` flag and to any [capability](#capability) the connector provides — it is a property of the install itself, not of issue tracking, notifications, or support entry.
 
 ### Thread
 

--- a/apps/api/src/live-state/router/integration.ts
+++ b/apps/api/src/live-state/router/integration.ts
@@ -185,11 +185,30 @@ export default privateRoute.withProcedures(({ mutation, query }) => ({
       return { outcome: "needs_connect" as const };
     }
 
+    const probedConfigStr = integration.configStr;
     const probeResult = await probeConnection(
       entry.probeUrl,
-      { config: integration.configStr },
+      { config: probedConfigStr },
       { secret: connectorInvokeSecret }
     );
+
+    // Probe is a network round-trip — reconnect/setup or uninstall clearing may
+    // have rewritten config (or flipped enabled) while we were waiting. Do not
+    // apply a stale probe result over a newer install identity.
+    const current = await db.integration.one(integration.id).get();
+    if (!current) {
+      throw new Error("INTEGRATION_NOT_FOUND");
+    }
+    if (current.configStr !== probedConfigStr) {
+      return {
+        outcome: current.enabled
+          ? ("enabled" as const)
+          : ("needs_connect" as const),
+      };
+    }
+    if (current.enabled) {
+      return { outcome: "enabled" as const };
+    }
 
     const now = new Date();
 

--- a/apps/api/src/live-state/router/integration.ts
+++ b/apps/api/src/live-state/router/integration.ts
@@ -1,7 +1,12 @@
+import { probeConnection } from "@connectors/framework";
 import { ulid } from "ulid";
 import { z } from "zod";
 
 import { authorize, requireInternalApiKey } from "../../lib/authorize";
+import {
+  connectorInvokeSecret,
+  connectorRegistry,
+} from "../../lib/connector-registry";
 import { privateRoute } from "../factories";
 import { schema } from "../schema";
 import { slackChannelsCache } from "./slack-channels";
@@ -30,6 +35,10 @@ const updateInstallationInputSchema = z
     },
     { message: "NO_FIELDS_TO_UPDATE" }
   );
+
+const reenableInputSchema = z.object({
+  integrationId: z.string(),
+});
 
 export default privateRoute.withProcedures(({ mutation, query }) => ({
   // --- Reads ---------------------------------------------------------------
@@ -148,6 +157,58 @@ export default privateRoute.withProcedures(({ mutation, query }) => ({
       });
     }
   ),
+
+  /**
+   * Re-enable a disabled integration after checking external install liveness
+   * (ADR-0010). Opt-in per connector manifest (`supportsConnectionProbe`):
+   * - `live: true` → set `enabled: true` only (no metadata refresh)
+   * - `live: false` → write suggested sanitized `configStr` (when present) and
+   *   return `needs_connect`
+   * - transport/unknown failure → throw (fail soft: no enable, no clear)
+   * - connector has not opted in → `needs_connect` (never silent-enable)
+   */
+  reenable: mutation(reenableInputSchema).handler(async ({ req, db }) => {
+    const integration = await db.integration
+      .one(req.input.integrationId)
+      .get();
+    if (!integration) {
+      throw new Error("INTEGRATION_NOT_FOUND");
+    }
+
+    authorize(req, {
+      organizationId: integration.organizationId,
+      role: "owner",
+    });
+
+    const entry = connectorRegistry.getByType(integration.type);
+    if (!entry?.manifest.supportsConnectionProbe) {
+      return { outcome: "needs_connect" as const };
+    }
+
+    const probeResult = await probeConnection(
+      entry.probeUrl,
+      { config: integration.configStr },
+      { secret: connectorInvokeSecret }
+    );
+
+    const now = new Date();
+
+    if (probeResult.live) {
+      await db.update(schema.integration, integration.id, {
+        enabled: true,
+        updatedAt: now,
+      });
+      return { outcome: "enabled" as const };
+    }
+
+    await db.update(schema.integration, integration.id, {
+      ...(probeResult.configStr === undefined
+        ? {}
+        : { configStr: probeResult.configStr }),
+      updatedAt: now,
+    });
+    return { outcome: "needs_connect" as const };
+  }),
 
   fetchSlackChannels: mutation(
     z.object({

--- a/apps/web/src/routes/app/_workspace/settings/organization/integration/github/index.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/integration/github/index.tsx
@@ -90,6 +90,25 @@ function RouteComponent() {
       return;
     }
 
+    // Reconnect: the GitHub App is still installed (we have its installationId
+    // from a previous setup), so re-enable silently instead of sending the user
+    // back through GitHub — where an already-installed app lands them on GitHub's
+    // configure page rather than the first-time install flow.
+    if (integration && parsedConfig?.data?.installationId) {
+      await fetchClient.mutate.integration.updateInstallation({
+        enabled: true,
+        integrationId: integration.id,
+        updatedAt: new Date(),
+      });
+
+      posthog?.capture("integration_enable", {
+        integration_type: "github",
+        reconnect: true,
+      });
+
+      return;
+    }
+
     const csrfToken = generateStateToken();
 
     if (integration) {

--- a/apps/web/src/routes/app/_workspace/settings/organization/integration/github/index.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/integration/github/index.tsx
@@ -11,6 +11,7 @@ import { Separator } from "@workspace/ui/components/separator";
 import { useAtomValue } from "jotai/react";
 import { ArrowLeft } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
+import { toast } from "sonner";
 import { ulid } from "ulid";
 
 import { IntegrationWarningCallout } from "~/components/integration-settings/warning-callout";
@@ -90,31 +91,46 @@ function RouteComponent() {
       return;
     }
 
-    // Reconnect: the GitHub App is still installed (we have its installationId
-    // from a previous setup), so re-enable silently instead of sending the user
-    // back through GitHub — where an already-installed app lands them on GitHub's
-    // configure page rather than the first-time install flow.
-    if (integration && parsedConfig?.data?.installationId) {
-      await fetchClient.mutate.integration.updateInstallation({
-        enabled: true,
-        integrationId: integration.id,
-        updatedAt: new Date(),
-      });
+    // Existing row: ask the core to probe external-install liveness (ADR-0010)
+    // before silent re-enable. Never trust a stored installationId alone.
+    if (integration) {
+      try {
+        const result = await fetchClient.mutate.integration.reenable({
+          integrationId: integration.id,
+        });
 
-      posthog?.capture("integration_enable", {
-        integration_type: "github",
-        reconnect: true,
-      });
+        if (result?.outcome === "enabled") {
+          posthog?.capture("integration_enable", {
+            integration_type: "github",
+            reconnect: true,
+          });
+          return;
+        }
+      } catch (error) {
+        // Fail soft: transport/unknown probe failure — no enable, no clear.
+        console.error("[GitHub] Re-enable probe failed:", error);
+        toast.error(
+          "Couldn't verify your GitHub connection. Try again in a moment."
+        );
+        return;
+      }
 
-      return;
+      // needs_connect — fall through to the install URL with a fresh csrfToken.
+      // Strip any stale install identity from local view so we don't rewrite it.
     }
 
     const csrfToken = generateStateToken();
 
+    const {
+      installationId: _staleInstallationId,
+      repos: _staleRepos,
+      ...restConfig
+    } = parsedConfig?.data ?? {};
+
     if (integration) {
       await fetchClient.mutate.integration.updateInstallation({
         configStr: JSON.stringify({
-          ...parsedConfig?.data,
+          ...restConfig,
           csrfToken,
         }),
         enabled: false,
@@ -124,7 +140,7 @@ function RouteComponent() {
     } else if (activeOrg?.id) {
       await fetchClient.mutate.integration.connectInstallation({
         configStr: JSON.stringify({
-          ...parsedConfig?.data,
+          ...restConfig,
           csrfToken,
         }),
         createdAt: new Date(),

--- a/connectors/framework/src/index.ts
+++ b/connectors/framework/src/index.ts
@@ -39,6 +39,16 @@ export {
   typesProvidingCapability,
 } from "./manifest";
 export {
+  CONNECTION_PROBE_PATH,
+  CONNECTION_PROBE_SECRET_HEADER,
+  CONNECTION_PROBE_TIMEOUT_MS,
+  type ProbeRequest,
+  type ProbeResult,
+  probeConnection,
+  probeRequestSchema,
+  probeResultSchema,
+} from "./probe";
+export {
   buildRegistry,
   type ConnectorRegistry,
   type RegistryEntry,

--- a/connectors/framework/src/manifest.ts
+++ b/connectors/framework/src/manifest.ts
@@ -14,6 +14,13 @@ export interface ConnectorManifest {
   baseUrlEnv: string;
   /** Fallback base URL for local dev. */
   defaultBaseUrl: string;
+  /**
+   * Whether this connector exposes `POST /api/connection/probe` so the core can
+   * check external install liveness before silent re-enable. Emitting-only
+   * connectors (Discord/Slack) omit this until they expose an HTTP host that
+   * needs silent reconnect. See ADR-0010.
+   */
+  supportsConnectionProbe?: boolean;
 }
 
 /**
@@ -25,6 +32,7 @@ export const githubManifest: ConnectorManifest = {
   baseUrlEnv: "BASE_GITHUB_SERVER_URL",
   capabilities: ["issue-tracker", "pr-tracker"],
   defaultBaseUrl: "http://localhost:3334",
+  supportsConnectionProbe: true,
   type: "github",
 };
 

--- a/connectors/framework/src/probe.ts
+++ b/connectors/framework/src/probe.ts
@@ -93,7 +93,16 @@ export async function probeConnection(
     );
   }
 
-  const parsed = probeResultSchema.safeParse(await response.json());
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch (error) {
+    throw new Error("CONNECTION_PROBE_INVALID_RESPONSE: non-JSON body", {
+      cause: error,
+    });
+  }
+
+  const parsed = probeResultSchema.safeParse(json);
   if (!parsed.success) {
     throw new Error(
       `CONNECTION_PROBE_INVALID_RESPONSE: ${parsed.error.issues[0]?.message ?? "invalid body"}`

--- a/connectors/framework/src/probe.ts
+++ b/connectors/framework/src/probe.ts
@@ -1,0 +1,104 @@
+import { z } from "zod";
+
+import {
+  CAPABILITY_INVOKE_SECRET_HEADER,
+  CAPABILITY_INVOKE_TIMEOUT_MS,
+} from "./invoke";
+
+/** Standardized HTTP path every probe-capable connector host exposes. */
+export const CONNECTION_PROBE_PATH = "/api/connection/probe";
+
+/**
+ * Same shared-secret header as capability invoke — same trust boundary (core ↔
+ * connector). Re-exported under the probe name so callers don't import invoke
+ * symbols for a non-capability path.
+ */
+export const CONNECTION_PROBE_SECRET_HEADER = CAPABILITY_INVOKE_SECRET_HEADER;
+
+/** Same bounded deadline as capability invoke. */
+export const CONNECTION_PROBE_TIMEOUT_MS = CAPABILITY_INVOKE_TIMEOUT_MS;
+
+/**
+ * Probe request body. `config` is the integration's opaque `configStr`,
+ * forwarded untouched — only the connector interprets it.
+ */
+export interface ProbeRequest {
+  config: string | null;
+}
+
+/** Runtime validator for the probe request body. */
+export const probeRequestSchema = z.object({
+  config: z.string().nullable(),
+});
+
+/**
+ * Probe response. Read-only: the connector never writes FrontDesk state.
+ * Optional `configStr` is a sanitized suggestion (install identity stripped)
+ * for the core to persist when `live` is false.
+ */
+export interface ProbeResult {
+  live: boolean;
+  configStr?: string;
+}
+
+/** Runtime validator for the probe response. */
+export const probeResultSchema = z.object({
+  configStr: z.string().optional(),
+  live: z.boolean(),
+});
+
+/**
+ * POST to a connector's connection-probe endpoint and return the parsed result.
+ * Throws on a non-2xx response, or on timeout after
+ * {@link CONNECTION_PROBE_TIMEOUT_MS} so the caller fails fast (fail soft at
+ * the orchestration layer — no silent enable, no clear).
+ *
+ * `secret` is the shared internal key, sent in
+ * {@link CONNECTION_PROBE_SECRET_HEADER}.
+ */
+export async function probeConnection(
+  probeUrl: string,
+  request: ProbeRequest,
+  options: { secret?: string | null } = {}
+): Promise<ProbeResult> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (options.secret) {
+    headers[CONNECTION_PROBE_SECRET_HEADER] = options.secret;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(probeUrl, {
+      body: JSON.stringify(request),
+      headers,
+      method: "POST",
+      signal: AbortSignal.timeout(CONNECTION_PROBE_TIMEOUT_MS),
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "TimeoutError") {
+      throw new Error(
+        `CONNECTION_PROBE_TIMEOUT: no response after ${CONNECTION_PROBE_TIMEOUT_MS}ms`,
+        { cause: error }
+      );
+    }
+    throw error;
+  }
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(
+      `CONNECTION_PROBE_FAILED: ${response.status} ${detail}`.trim()
+    );
+  }
+
+  const parsed = probeResultSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new Error(
+      `CONNECTION_PROBE_INVALID_RESPONSE: ${parsed.error.issues[0]?.message ?? "invalid body"}`
+    );
+  }
+
+  return parsed.data;
+}

--- a/connectors/framework/src/registry.ts
+++ b/connectors/framework/src/registry.ts
@@ -2,6 +2,7 @@ import type { Capability } from "./capabilities";
 import { CAPABILITY_INVOKE_PATH } from "./invoke";
 import { manifests as defaultManifests } from "./manifest";
 import type { ConnectorManifest } from "./manifest";
+import { CONNECTION_PROBE_PATH } from "./probe";
 
 /** A manifest with its resolved host location. */
 export interface RegistryEntry {
@@ -9,6 +10,11 @@ export interface RegistryEntry {
   baseUrl: string;
   /** Fully-resolved URL to POST invoke envelopes to. */
   invokeUrl: string;
+  /**
+   * Fully-resolved URL to POST connection probes to. Only meaningful when
+   * `manifest.supportsConnectionProbe` is true.
+   */
+  probeUrl: string;
 }
 
 export interface ConnectorRegistry {
@@ -52,6 +58,7 @@ export function buildRegistry(
       baseUrl,
       invokeUrl: `${baseUrl}${CAPABILITY_INVOKE_PATH}`,
       manifest,
+      probeUrl: `${baseUrl}${CONNECTION_PROBE_PATH}`,
     });
   }
 

--- a/connectors/github/src/index.ts
+++ b/connectors/github/src/index.ts
@@ -6,6 +6,7 @@ import { startReconcileWorker } from "./jobs/reconcile";
 import { app as githubApp } from "./lib/github";
 import {
   capabilitiesRoutes,
+  connectionProbeRoutes,
   issuesRoutes,
   pullRequestsRoutes,
   setupRoutes,
@@ -19,6 +20,7 @@ startReconcileWorker();
 
 const app = new Elysia()
   .use(capabilitiesRoutes)
+  .use(connectionProbeRoutes)
   .use(issuesRoutes)
   .use(pullRequestsRoutes)
   .use(setupRoutes)

--- a/connectors/github/src/routes/connection-probe.ts
+++ b/connectors/github/src/routes/connection-probe.ts
@@ -6,16 +6,7 @@ import {
 import Elysia from "elysia";
 
 import { app } from "../lib/github";
-
-/**
- * Strip install identity from opaque GitHub config, keeping unrelated fields
- * (e.g. csrfToken, selectedEvents). The probe never writes FrontDesk state —
- * this string is a suggestion for the core to persist on `live: false`.
- */
-const sanitizeConfig = (raw: Record<string, unknown>): string => {
-  const { installationId: _installationId, repos: _repos, ...rest } = raw;
-  return JSON.stringify(rest);
-};
+import { sanitizeGithubInstallConfig } from "../utils";
 
 /**
  * External-install liveness probe (ADR-0010). Not a Capability — orthogonal to
@@ -63,9 +54,11 @@ export const connectionProbeRoutes = new Elysia().post(
 
     const configObj = raw as Record<string, unknown>;
     const installationId = Number(configObj.installationId);
+    const sanitizedConfigStr = () =>
+      JSON.stringify(sanitizeGithubInstallConfig(configObj));
 
     if (!Number.isInteger(installationId) || installationId <= 0) {
-      return { configStr: sanitizeConfig(configObj), live: false };
+      return { configStr: sanitizedConfigStr(), live: false };
     }
 
     try {
@@ -81,7 +74,7 @@ export const connectionProbeRoutes = new Elysia().post(
 
       // Installation gone (uninstalled) or never existed.
       if (status === 404) {
-        return { configStr: sanitizeConfig(configObj), live: false };
+        return { configStr: sanitizedConfigStr(), live: false };
       }
 
       console.error("[GitHub] Connection probe failed:", error);

--- a/connectors/github/src/routes/connection-probe.ts
+++ b/connectors/github/src/routes/connection-probe.ts
@@ -1,0 +1,92 @@
+import {
+  CONNECTION_PROBE_PATH,
+  CONNECTION_PROBE_SECRET_HEADER,
+  probeRequestSchema,
+} from "@connectors/framework";
+import Elysia from "elysia";
+
+import { app } from "../lib/github";
+
+/**
+ * Strip install identity from opaque GitHub config, keeping unrelated fields
+ * (e.g. csrfToken, selectedEvents). The probe never writes FrontDesk state —
+ * this string is a suggestion for the core to persist on `live: false`.
+ */
+const sanitizeConfig = (raw: Record<string, unknown>): string => {
+  const { installationId: _installationId, repos: _repos, ...rest } = raw;
+  return JSON.stringify(rest);
+};
+
+/**
+ * External-install liveness probe (ADR-0010). Not a Capability — orthogonal to
+ * issue-tracker / pr-tracker. Checks whether the stored GitHub App installation
+ * still exists; on dead, returns a sanitized `configStr` suggestion.
+ */
+export const connectionProbeRoutes = new Elysia().post(
+  CONNECTION_PROBE_PATH,
+  async ({ body: requestBody, headers, set }) => {
+    const expectedSecret = process.env.DISCORD_BOT_KEY;
+    if (
+      !expectedSecret ||
+      headers[CONNECTION_PROBE_SECRET_HEADER] !== expectedSecret
+    ) {
+      set.status = 401;
+      return { error: "UNAUTHORIZED" };
+    }
+
+    const parsed = probeRequestSchema.safeParse(requestBody);
+    if (!parsed.success) {
+      set.status = 400;
+      return {
+        error: parsed.error.issues[0]?.message ?? "Invalid probe request",
+      };
+    }
+
+    const { config } = parsed.data;
+
+    if (!config) {
+      return { live: false };
+    }
+
+    let raw: unknown;
+    try {
+      raw = JSON.parse(config);
+    } catch {
+      set.status = 400;
+      return { error: "INVALID_CONFIG" };
+    }
+
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+      set.status = 400;
+      return { error: "INVALID_CONFIG" };
+    }
+
+    const configObj = raw as Record<string, unknown>;
+    const installationId = Number(configObj.installationId);
+
+    if (!Number.isInteger(installationId) || installationId <= 0) {
+      return { configStr: sanitizeConfig(configObj), live: false };
+    }
+
+    try {
+      await app.octokit.request("GET /app/installations/{installation_id}", {
+        installation_id: installationId,
+      });
+      return { live: true };
+    } catch (error) {
+      const status =
+        error && typeof error === "object" && "status" in error
+          ? Number((error as { status: unknown }).status)
+          : undefined;
+
+      // Installation gone (uninstalled) or never existed.
+      if (status === 404) {
+        return { configStr: sanitizeConfig(configObj), live: false };
+      }
+
+      console.error("[GitHub] Connection probe failed:", error);
+      set.status = 500;
+      return { error: "PROBE_FAILED" };
+    }
+  }
+);

--- a/connectors/github/src/routes/index.ts
+++ b/connectors/github/src/routes/index.ts
@@ -1,4 +1,5 @@
 export { capabilitiesRoutes } from "./capabilities";
+export { connectionProbeRoutes } from "./connection-probe";
 export { issuesRoutes } from "./issues";
 export { pullRequestsRoutes } from "./pull-requests";
 export { setupRoutes } from "./setup";

--- a/connectors/github/src/utils/index.ts
+++ b/connectors/github/src/utils/index.ts
@@ -2,6 +2,19 @@ export const STATUS_OPEN = 0;
 export const STATUS_RESOLVED = 2;
 export const STATUS_CLOSED = 3;
 
+/**
+ * Strip GitHub App install identity from opaque integration config, keeping
+ * unrelated fields (e.g. csrfToken, selectedEvents). Shared by the connection
+ * probe suggestion and `installation.deleted` cleanup so the field set cannot
+ * drift.
+ */
+export const sanitizeGithubInstallConfig = (
+  raw: Record<string, unknown>
+): Record<string, unknown> => {
+  const { installationId: _installationId, repos: _repos, ...rest } = raw;
+  return rest;
+};
+
 export const getBaseUrl = (): string =>
   process.env.VITE_BASE_URL || "http://localhost:3000";
 

--- a/connectors/github/src/webhooks/index.ts
+++ b/connectors/github/src/webhooks/index.ts
@@ -26,14 +26,12 @@ const PR_MATCH_ACTIONS = new Set([
 ]);
 
 /**
- * Resolve the FrontDesk organization that owns a GitHub installation by
- * matching the `installationId` persisted in the github integration config
+ * Resolve the FrontDesk github integration that owns a GitHub installation by
+ * matching the `installationId` persisted in the integration config
  * (see `routes/setup.ts`). Integrations are loaded into the live-state store,
  * so this is an in-memory lookup.
  */
-const resolveOrganizationId = (
-  installationId: number | undefined
-): string | null => {
+const findGithubIntegration = (installationId: number | undefined) => {
   if (!installationId) {
     return null;
   }
@@ -47,7 +45,7 @@ const resolveOrganizationId = (
     try {
       const config = JSON.parse(integration.configStr);
       if (config.installationId === installationId) {
-        return integration.organizationId;
+        return integration;
       }
     } catch {
       // Ignore malformed config; other integrations may still match.
@@ -56,6 +54,14 @@ const resolveOrganizationId = (
 
   return null;
 };
+
+/**
+ * Resolve the FrontDesk organization that owns a GitHub installation.
+ */
+const resolveOrganizationId = (
+  installationId: number | undefined
+): string | null =>
+  findGithubIntegration(installationId)?.organizationId ?? null;
 
 /**
  * Read the installation id from a webhook payload. Typed loosely because the
@@ -133,6 +139,50 @@ const repoRefFromWebhook = (repository: {
 });
 
 export const setupWebhooks = () => {
+  // Complementary to the connection probe (ADR-0010): when the GitHub App is
+  // uninstalled, clear install identity immediately so a later Enable can't
+  // silent-reenable a dead installationId. Probe still covers missed deliveries.
+  app.webhooks.on("installation.deleted", async ({ payload }) => {
+    try {
+      const installationId = payload.installation.id;
+      const integration = findGithubIntegration(installationId);
+
+      if (!integration) {
+        console.warn(
+          `[GitHub] No integration for deleted installation ${installationId}, skipping`
+        );
+        return;
+      }
+
+      let rest: Record<string, unknown> = {};
+      if (integration.configStr) {
+        try {
+          const {
+            installationId: _installationId,
+            repos: _repos,
+            ...kept
+          } = JSON.parse(integration.configStr) as Record<string, unknown>;
+          rest = kept;
+        } catch {
+          rest = {};
+        }
+      }
+
+      await fetchClient.mutate.integration.updateInstallation({
+        configStr: JSON.stringify(rest),
+        enabled: false,
+        integrationId: integration.id,
+        updatedAt: new Date(),
+      });
+
+      console.log(
+        `[GitHub] Cleared install identity for integration ${integration.id} after installation.deleted`
+      );
+    } catch (error) {
+      console.error("[GitHub] Error handling installation.deleted:", error);
+    }
+  });
+
   // Keep the mirror current on every issue-mutating event. `deleted` and
   // `transferred` (transfer-out) soft-delete the source row; `closed` resolves
   // linked threads as a reaction to the mirror change.

--- a/connectors/github/src/webhooks/index.ts
+++ b/connectors/github/src/webhooks/index.ts
@@ -9,7 +9,12 @@ import type { ExternalEntityFields } from "../lib/external-entity";
 import { app } from "../lib/github";
 import { fetchClient, store } from "../lib/live-state";
 import { enqueuePrMatch } from "../lib/queue";
-import { STATUS_CLOSED, STATUS_OPEN, STATUS_RESOLVED } from "../utils";
+import {
+  STATUS_CLOSED,
+  STATUS_OPEN,
+  STATUS_RESOLVED,
+  sanitizeGithubInstallConfig,
+} from "../utils";
 
 /**
  * Pull-request actions that warrant a push-side thread match (FRO-205): the PR
@@ -154,29 +159,40 @@ export const setupWebhooks = () => {
         return;
       }
 
-      let rest: Record<string, unknown> = {};
-      if (integration.configStr) {
+      // Authoritative re-read before write: a delayed delivery must not wipe a
+      // newer install identity that replaced this one while the handler was queued.
+      const latest = await fetchClient.query.integration.byId({
+        id: integration.id,
+      });
+      if (!latest) {
+        return;
+      }
+
+      let raw: Record<string, unknown> = {};
+      if (latest.configStr) {
         try {
-          const {
-            installationId: _installationId,
-            repos: _repos,
-            ...kept
-          } = JSON.parse(integration.configStr) as Record<string, unknown>;
-          rest = kept;
+          raw = JSON.parse(latest.configStr) as Record<string, unknown>;
         } catch {
-          rest = {};
+          raw = {};
         }
       }
 
+      if (raw.installationId !== installationId) {
+        console.warn(
+          `[GitHub] Skipping installation.deleted cleanup for ${installationId}: stored install identity no longer matches`
+        );
+        return;
+      }
+
       await fetchClient.mutate.integration.updateInstallation({
-        configStr: JSON.stringify(rest),
+        configStr: JSON.stringify(sanitizeGithubInstallConfig(raw)),
         enabled: false,
-        integrationId: integration.id,
+        integrationId: latest.id,
         updatedAt: new Date(),
       });
 
       console.log(
-        `[GitHub] Cleared install identity for integration ${integration.id} after installation.deleted`
+        `[GitHub] Cleared install identity for integration ${latest.id} after installation.deleted`
       );
     } catch (error) {
       console.error("[GitHub] Error handling installation.deleted:", error);

--- a/docs/adr/0010-external-install-liveness-probe.md
+++ b/docs/adr/0010-external-install-liveness-probe.md
@@ -1,0 +1,30 @@
+# External install liveness as framework substrate
+
+Silent reconnect of a disabled [integration](../../CONTEXT.md) must not trust stored install identity alone: the [external install](../../CONTEXT.md) may have been removed while FrontDesk was disabled. We check [external install liveness](../../CONTEXT.md) through a **framework** HTTP contract — not a [Capability](../../CONTEXT.md) — and keep provider connect/OAuth URLs provider-specific (per ADR-0008).
+
+## Status
+
+accepted
+
+## Decisions
+
+- **Liveness is framework substrate, not a Capability.** It is orthogonal to `issue-tracker` / `pr-tracker` / `support-entry-point` / `notification-center`. Do not bolt `probe` onto those interfaces or invent a `connection` capability for this.
+- **Standardized connector-host path:** `POST /api/connection/probe`. Same secret and timeout conventions as capability invoke; request forwards the integration's opaque `configStr`. Response is read-only: `{ live: boolean, configStr?: string }` where optional `configStr` is a sanitized suggestion (install identity stripped) for the core to persist — the probe itself never writes FrontDesk state.
+- **Core orchestration:** `integration.reenable` mutation. If an integration row exists, the API runs the probe when the connector manifest opts in (`supportsConnectionProbe: true`); on `live: true` it sets `enabled: true` without refreshing install metadata; on `live: false` it writes the suggested `configStr` (when present) and returns `needs_connect`; on transport/unknown failure it fails soft (error to UI, no enable, no clear). Connectors that have not opted in never silent-enable — `reenable` returns `needs_connect`.
+- **Web choreography:** If an integration row exists, Enable calls `reenable` and branches on `{ outcome: "enabled" | "needs_connect" }`. Provider install/OAuth URLs stay in the settings UI (ADR-0008 control plane). No row → existing first-time connect path.
+- **Webhook clearing is complementary.** Provider-private uninstall events (e.g. GitHub `installation.deleted`) clear install identity and typically set `enabled: false` via existing bot mutations. Probe covers missed deliveries; webhooks cover the common path without waiting for Enable.
+- **Rollout:** GitHub opts in first. Emitting-only connectors (Discord/Slack) omit `supportsConnectionProbe` until they expose an HTTP host and need silent reconnect.
+
+## Considered options
+
+- **New `connection` capability (rejected).** Liveness is not a role the product offers; stuffing it into the capability model invites every install concern to become a capability.
+- **Reuse `/api/capabilities/invoke` with a sentinel (rejected).** Convenient but lies about the model.
+- **Probe mutates config itself (rejected).** Opaque config interpretation stays in the connector; persistence stays in the core (`updateInstallation`).
+- **Fail open on probe transport errors (rejected).** Would reintroduce enabled-but-dead after outages. Fail soft instead; only explicit `live: false` clears and forces reconnect.
+- **Refresh repos/metadata on live reenable (deferred).** Mirror/reconcile already own freshness; keep this probe minimal.
+
+## Consequences
+
+- Narrowly extends ADR-0008: connect/OAuth URLs remain provider-specific, but **asking whether the external install still exists** is a generic framework question.
+- Manifest gains an opt-in flag alongside capabilities/host metadata.
+- Settings Enable for opted-in connectors gains a safe silent-reconnect path without trusting stale install ids.

--- a/docs/adr/0010-external-install-liveness-probe.md
+++ b/docs/adr/0010-external-install-liveness-probe.md
@@ -20,7 +20,7 @@ accepted
 - **New `connection` capability (rejected).** Liveness is not a role the product offers; stuffing it into the capability model invites every install concern to become a capability.
 - **Reuse `/api/capabilities/invoke` with a sentinel (rejected).** Convenient but lies about the model.
 - **Probe mutates config itself (rejected).** Opaque config interpretation stays in the connector; persistence stays in the core (`updateInstallation`).
-- **Fail open on probe transport errors (rejected).** Would reintroduce enabled-but-dead after outages. Fail soft instead; only explicit `live: false` clears and forces reconnect.
+- **Fail open on probe transport errors (rejected).** Would reintroduce enabled-but-dead after outages. Fail soft instead; only explicit `live: false` persists the probe's sanitized config suggestion (when provided) and forces reconnect.
 - **Refresh repos/metadata on live reenable (deferred).** Mirror/reconcile already own freshness; keep this probe minimal.
 
 ## Consequences


### PR DESCRIPTION
## Problem

When reconnecting GitHub — the GitHub App is still installed on the org, but the integration was disabled in FrontDesk — clicking **Enable** and selecting the org lands the user on GitHub's own **configure installation** page instead of the first-time install flow.

**Root cause:** the Enable button always redirects to `https://github.com/apps/<slug>/installations/new`. When the app is already installed, GitHub short-circuits that URL to its configure page. Disabling the integration in FrontDesk never uninstalls the app on GitHub's side, and the stored `installationId`/`repos` config is left intact, so on reconnect there's a live installation to detect.

## Fix

In `handleEnableGitHub`, check for an existing `installationId` in the stored config before building the GitHub redirect. If present, the app is still installed — re-enable silently by flipping `enabled: true` via `updateInstallation`, with no GitHub round-trip. First-time connections (no stored `installationId`) still go through the full GitHub install flow.

Also tags the `integration_enable` PostHog event with `reconnect: true` to distinguish the two paths.

## Trade-off

The silent reconnect reuses the `repos` list from the last setup. If repo access changed on GitHub while the integration was disabled, those changes are picked up on the next webhook rather than immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silently re-enables GitHub on reconnect only after verifying the external install still exists, with race-safe checks to avoid stale writes. If the install is gone, we clear stale identity and route users through the normal GitHub flow.

- **Bug Fixes**
  - Use `integration.reenable` with a connection probe: live → enable; dead → return `needs_connect` and persist a sanitized `configStr`; transport errors fail soft (no enable, UI toast). Guards against concurrent reconnect races by re-checking `configStr` before writing.
  - Add framework probe (`POST /api/connection/probe`, opt-in via `supportsConnectionProbe`); GitHub implements it with hardened JSON parsing and shared config sanitization, and its `installation.deleted` webhook clears install identity safely (read-verify before update).
  - Tag PostHog `integration_enable` with `reconnect: true`; repo selection is reused and refreshed on the next webhook.

<sup>Written for commit 9a9b098f8abb6fdbdf79bab72fa48fc0e280f996. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guarded “reconnect” for previously configured GitHub integrations using an external-install liveness check.
  * Introduced a standardized connection probe capability to determine whether an external install is still live.
  * Updated connection handling to avoid reusing stale installation identity when reconnecting.
* **Bug Fixes**
  * Improved failure handling for reconnect probes to prevent proceeding when re-enable isn’t possible.
  * Ensured GitHub install deletions automatically disable the corresponding integration. 
* **Documentation**
  * Expanded integration glossary to clarify enabled state vs external install liveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->