### PR TITLE
feat(api): gate production developer actions

### DIFF
--- a/apps/api/src/lib/authorize.test.ts
+++ b/apps/api/src/lib/authorize.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import type { AuthorizeReq, DeveloperActionDeniedEvent } from "./authorize";
+import {
+  authorizeDeveloperAction,
+  isInternalDeveloperEmail,
+} from "./authorize";
+
+const organizationId = "org-a";
+
+const workspaceRequest = (
+  overrides: Partial<NonNullable<AuthorizeReq["context"]>> = {}
+): AuthorizeReq => ({
+  context: {
+    orgUsers: [{ organizationId, role: "user" }],
+    session: { userId: "user-a" },
+    user: {
+      email: "dev@tryfrontdesk.app",
+      emailVerified: true,
+      name: "Dev User",
+    },
+    ...overrides,
+  },
+});
+
+const expectDenied = (
+  req: AuthorizeReq,
+  options: Parameters<typeof authorizeDeveloperAction>[2] = {}
+): DeveloperActionDeniedEvent => {
+  let event: DeveloperActionDeniedEvent | undefined;
+
+  expect(() =>
+    authorizeDeveloperAction(req, organizationId, {
+      ...options,
+      onDenied: (denial) => {
+        event = denial;
+      },
+    })
+  ).toThrow("UNAUTHORIZED");
+
+  expect(event).toBeDefined();
+  return event as DeveloperActionDeniedEvent;
+};
+
+describe("internal developer email checks", () => {
+  it("accepts the exact domain case-insensitively", () => {
+    expect(isInternalDeveloperEmail("dev@tryfrontdesk.app")).toBeTruthy();
+    expect(isInternalDeveloperEmail("DEV@TRYFRONTDESK.APP")).toBeTruthy();
+  });
+
+  it("rejects lookalike domains and malformed mailboxes", () => {
+    expect(isInternalDeveloperEmail("dev@tryfrontdesk.app.evil")).toBeFalsy();
+    expect(isInternalDeveloperEmail("dev@nottryfrontdesk.app")).toBeFalsy();
+    expect(isInternalDeveloperEmail("dev@@tryfrontdesk.app")).toBeFalsy();
+    expect(isInternalDeveloperEmail("dev@tryfrontdesk.app ")).toBeFalsy();
+  });
+});
+
+describe("developer-action authorization gate", () => {
+  it("allows a verified internal member without an owner role", () => {
+    const actor = authorizeDeveloperAction(workspaceRequest(), organizationId, {
+      action: "github.pr_replay",
+      environment: "production",
+    });
+
+    expect(actor).toStrictEqual({ userId: "user-a", userName: "Dev User" });
+  });
+
+  it("keeps local development broad for authenticated organization members", () => {
+    const actor = authorizeDeveloperAction(
+      workspaceRequest({
+        user: {
+          email: "developer@example.com",
+          emailVerified: false,
+          name: "Local Developer",
+        },
+      }),
+      organizationId,
+      { environment: "development" }
+    );
+
+    expect(actor).toStrictEqual({
+      userId: "user-a",
+      userName: "Local Developer",
+    });
+  });
+
+  it("denies an unverified internal address in production", () => {
+    const event = expectDenied(
+      workspaceRequest({
+        user: {
+          email: "dev@tryfrontdesk.app",
+          emailVerified: false,
+        },
+      }),
+      { action: "github.pr_replay", environment: "production" }
+    );
+
+    expect(event).toMatchObject({
+      action: "github.pr_replay",
+      actorUserId: "user-a",
+      event: "developer_action.authorization_denied",
+      organizationId,
+      reason: "unverified_email",
+    });
+  });
+
+  it("denies a verified external address in production", () => {
+    const event = expectDenied(
+      workspaceRequest({
+        user: {
+          email: "dev@example.com",
+          emailVerified: true,
+        },
+      }),
+      { environment: "production" }
+    );
+
+    expect(event.reason).toBe("non_internal_email");
+  });
+
+  it("denies unauthenticated and non-member requests", () => {
+    const unauthenticated = expectDenied(
+      { context: { orgUsers: [] } },
+      { environment: "production" }
+    );
+    expect(unauthenticated.reason).toBe("missing_session");
+
+    const nonMember = expectDenied(
+      workspaceRequest({
+        orgUsers: [{ organizationId: "org-b", role: "owner" }],
+      }),
+      { environment: "production" }
+    );
+    expect(nonMember.reason).toBe("not_organization_member");
+  });
+
+  it("does not let connector or public credentials satisfy the gate", () => {
+    const internalKey = expectDenied(
+      workspaceRequest({ internalApiKey: "internal-secret" }),
+      { environment: "production" }
+    );
+    expect(internalKey.reason).toBe("missing_session");
+
+    const publicKey = expectDenied(
+      workspaceRequest({
+        publicApiKey: { ownerId: organizationId },
+      }),
+      { environment: "development" }
+    );
+    expect(publicKey.reason).toBe("missing_session");
+  });
+});

--- a/apps/api/src/lib/authorize.test.ts
+++ b/apps/api/src/lib/authorize.test.ts
@@ -119,6 +119,31 @@ describe("developer-action authorization gate", () => {
     expect(event.reason).toBe("non_internal_email");
   });
 
+  it("fails closed when NODE_ENV is unset", () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    delete process.env.NODE_ENV;
+
+    try {
+      const event = expectDenied(
+        workspaceRequest({
+          user: {
+            email: "developer@example.com",
+            emailVerified: true,
+          },
+        }),
+        { action: "github.pr_replay" }
+      );
+
+      expect(event.reason).toBe("non_internal_email");
+    } finally {
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+    }
+  });
+
   it("denies unauthenticated and non-member requests", () => {
     const unauthenticated = expectDenied(
       { context: { orgUsers: [] } },

--- a/apps/api/src/lib/authorize.ts
+++ b/apps/api/src/lib/authorize.ts
@@ -24,7 +24,11 @@ export interface AuthorizationContext {
   publicApiKey?: { ownerId: string };
   orgUsers?: { organizationId: string; role: string }[];
   session?: { userId?: string } | null;
-  user?: { name?: string; email?: string } | null;
+  user?: {
+    email?: string;
+    emailVerified?: boolean;
+    name?: string;
+  } | null;
   portalSession?: PortalSession | null;
   /** Organization resolved from the portal request origin (subdomain or /support/{slug}). */
   portalOrganizationId?: string;
@@ -50,6 +54,143 @@ export interface AuthorizeOptions {
   /** When `true`, only {@link AuthorizationContext.internalApiKey} satisfies auth. */
   internalApiKeyOnly?: boolean;
 }
+
+export type DeveloperActionDenialReason =
+  | "missing_session"
+  | "non_internal_email"
+  | "unverified_email"
+  | "not_organization_member";
+
+export interface DeveloperActionDeniedEvent {
+  action: string;
+  actorUserId: string | null;
+  event: "developer_action.authorization_denied";
+  organizationId: string;
+  reason: DeveloperActionDenialReason;
+}
+
+export interface DeveloperActionAuthorizationOptions {
+  /** Stable, known-ahead action name for structured denial logs. */
+  action?: string;
+  /** Override the runtime environment in tests or an embedding server. */
+  environment?: string;
+  /** Test/host hook; the default writes a JSON event to stderr. */
+  onDenied?: (event: DeveloperActionDeniedEvent) => void;
+}
+
+const INTERNAL_DEVELOPER_DOMAIN = "tryfrontdesk.app";
+const LOCAL_DEVELOPMENT_ENVIRONMENTS = new Set([
+  "development",
+  "local",
+  "test",
+]);
+
+/**
+ * The domain check is deliberately an exact mailbox-domain comparison. A
+ * suffix check would accept lookalikes such as `tryfrontdesk.app.evil`.
+ */
+export const isInternalDeveloperEmail = (email?: string): boolean => {
+  if (!email) {
+    return false;
+  }
+
+  const firstAt = email.indexOf("@");
+  const lastAt = email.lastIndexOf("@");
+  if (firstAt <= 0 || firstAt !== lastAt) {
+    return false;
+  }
+
+  const localPart = email.slice(0, firstAt);
+  const domain = email.slice(firstAt + 1);
+
+  return (
+    !/\s/.test(localPart) && domain.toLowerCase() === INTERNAL_DEVELOPER_DOMAIN
+  );
+};
+
+const isLocalDevelopment = (environment = process.env.NODE_ENV): boolean =>
+  environment === undefined ||
+  LOCAL_DEVELOPMENT_ENVIRONMENTS.has(environment.toLowerCase());
+
+const logDeveloperActionDenied = (
+  event: DeveloperActionDeniedEvent,
+  onDenied?: (event: DeveloperActionDeniedEvent) => void
+): void => {
+  if (onDenied) {
+    onDenied(event);
+    return;
+  }
+
+  console.warn(JSON.stringify(event));
+};
+
+/**
+ * Authorize a dev-exclusive action against one organization.
+ *
+ * Every environment requires a workspace session and organization membership.
+ * Local development intentionally keeps the existing broad member workflow;
+ * production-like environments additionally require a verified,
+ * exact-domain FrontDesk email. Call this before resolving integrations,
+ * looking up targets, invoking connectors, or enqueueing work.
+ */
+export const authorizeDeveloperAction = (
+  req: AuthorizeReq,
+  organizationId: string,
+  options: DeveloperActionAuthorizationOptions = {}
+): { userId: string; userName: string | null } => {
+  const context = req.context ?? {};
+  const actorUserId = getWorkspaceUserId(context) ?? null;
+  const action = options.action ?? "unknown";
+
+  const deny = (reason: DeveloperActionDenialReason): never => {
+    logDeveloperActionDenied(
+      {
+        action,
+        actorUserId,
+        event: "developer_action.authorization_denied",
+        organizationId,
+        reason,
+      },
+      options.onDenied
+    );
+    throw new Error("UNAUTHORIZED");
+  };
+
+  // Developer actions are for workspace users, not connector keys, public
+  // API keys, or portal customer sessions. Keeping this check explicit also
+  // prevents an internal bot key from bypassing the production predicate.
+  if (
+    !actorUserId ||
+    context.internalApiKey ||
+    context.publicApiKey ||
+    getPortalUserId(context) !== undefined
+  ) {
+    deny("missing_session");
+  }
+
+  if (!isLocalDevelopment(options.environment)) {
+    if (context.user?.emailVerified !== true) {
+      deny("unverified_email");
+    }
+
+    if (!isInternalDeveloperEmail(context.user?.email)) {
+      deny("non_internal_email");
+    }
+  }
+
+  try {
+    // Use the existing organization authorization path and intentionally omit
+    // a role requirement: internal developers do not need owner/admin access.
+    authorize(req, {
+      allowInternalApiKey: false,
+      organizationId,
+    });
+  } catch {
+    deny("not_organization_member");
+  }
+
+  return getWorkspaceActor(req);
+};
 
 export interface ThreadCreateAuthInput {
   organizationId: string;

--- a/apps/api/src/lib/authorize.ts
+++ b/apps/api/src/lib/authorize.ts
@@ -109,7 +109,7 @@ export const isInternalDeveloperEmail = (email?: string): boolean => {
 };
 
 const isLocalDevelopment = (environment = process.env.NODE_ENV): boolean =>
-  environment === undefined ||
+  environment !== undefined &&
   LOCAL_DEVELOPMENT_ENVIRONMENTS.has(environment.toLowerCase());
 
 const logDeveloperActionDenied = (


### PR DESCRIPTION
## Summary

- Add a reusable server-side developer-action authorization boundary.
- Require verified `@tryfrontdesk.app` membership in production-like environments while preserving local authenticated member access.
- Reuse organization authorization without imposing an owner/admin role.
- Emit structured denial events without email, secrets, or connector configuration.
- Add coverage for exact-domain matching, auth failures, local development, and cross-organization isolation.

Shared procedures such as `thread.create` and existing unrelated worktree changes are untouched.

## Verification

- `bun run --cwd apps/api typecheck`
- `bun run --cwd apps/api build`
- `bunx oxlint apps/api/src/lib/authorize.ts apps/api/src/lib/authorize.test.ts`
- `bunx oxfmt --check apps/api/src/lib/authorize.ts apps/api/src/lib/authorize.test.ts`
- `bunx vitest run apps/api/src/lib/authorize.test.ts`

Refs FRO-209

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate developer-only API actions behind a server-side authorization boundary that requires verified `@tryfrontdesk.app` membership in production, while keeping development/test/local open to authenticated org members; fails closed when `NODE_ENV` is unset. Implements FRO-209.

- **New Features**
  - Added `authorizeDeveloperAction` to require a workspace session and org membership; production also requires a verified exact-domain internal email.
  - Blocked connector/internal/public API keys and portal sessions; only workspace users can pass.
  - Reused organization authorization without owner/admin roles.
  - Emitted structured denial events with `action`, `organizationId`, `actorUserId`, and `reason`.
  - Introduced `isInternalDeveloperEmail` for strict, case-insensitive domain checks; added tests for domain matching, production vs local behavior, unauth/non-member blocks, cross-org isolation, key/session denial, and fail-closed when `NODE_ENV` is unset.

<sup>Written for commit 76af383d4dd8abc857feef1acad1b9cbb142db9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added stricter authorization checks for developer actions.
  - Access now requires an authenticated workspace session, organization membership, and a verified internal email address outside local environments.
  - API keys, portal sessions, unauthenticated requests, and non-members are denied.
  - Improved handling of malformed, lookalike, and case-variant email domains.
  - Added structured denial logging to support clearer security monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->