### PR TITLE
feat(github): add developer action handlers

### DIFF
--- a/apps/api/src/lib/developer-action-dispatch.test.ts
+++ b/apps/api/src/lib/developer-action-dispatch.test.ts
@@ -271,6 +271,47 @@ describe("developer-action transport", () => {
     });
   });
 
+  it("preserves partial repository backfill acceptance", async () => {
+    const { db } = dbWithIntegrations({
+      integration: {
+        configStr: "{}",
+        enabled: true,
+        id: "integration-a",
+        organizationId,
+        type: "github",
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<
+        (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+      >(
+        async () =>
+          new Response(
+            JSON.stringify({
+              accepted: true,
+              jobIds: ["backfill-job"],
+              partial: true,
+              target: "selected",
+            }),
+            { status: 207 }
+          )
+      )
+    );
+
+    const result = await dispatchDeveloperAction(db, {
+      ...actionInput({ action: "repository_backfill" }),
+      payload: { repositories: ["owner/repo"] },
+    });
+
+    expect(result).toStrictEqual({
+      accepted: true,
+      jobIds: ["backfill-job"],
+      partial: true,
+      target: "selected",
+    });
+  });
+
   it("fails safely when the integration is missing", async () => {
     const { db } = dbWithIntegrations({});
     const fetchMock = vi.fn<() => void>();

--- a/apps/api/src/lib/developer-action-dispatch.test.ts
+++ b/apps/api/src/lib/developer-action-dispatch.test.ts
@@ -366,7 +366,14 @@ describe("developer-action transport", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
-      runDeveloperAction(db, memberRequest(), actionInput())
+      runDeveloperAction(
+        db,
+        memberRequest(),
+        actionInput({
+          action: "repository_backfill",
+          payload: { repositories: ["owner/repo"] },
+        })
+      )
     ).rejects.toThrow("CONNECTOR_INVOKE_SECRET_NOT_CONFIGURED");
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -394,7 +401,14 @@ describe("developer-action transport", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
-      runDeveloperAction(db, memberRequest(), actionInput())
+      runDeveloperAction(
+        db,
+        memberRequest(),
+        actionInput({
+          action: "repository_backfill",
+          payload: { repositories: ["owner/repo"] },
+        })
+      )
     ).rejects.toThrow("INSECURE_CONNECTOR_ACTION_URL");
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/apps/api/src/lib/developer-action-dispatch.test.ts
+++ b/apps/api/src/lib/developer-action-dispatch.test.ts
@@ -40,14 +40,35 @@ const actionInput = (
     action: "pr_match_replay",
     connectorType: "github",
     organizationId,
-    payload: { target: "entity-a" },
+    payload: { entityId: "entity-a" },
     ...overrides,
   });
 
 const dbWithIntegrations = (integrations: Record<string, unknown>) => {
   const find = vi
-    .fn<() => Promise<Record<string, unknown>>>()
-    .mockResolvedValue(integrations);
+    .fn<
+      (
+        table: unknown,
+        request: { where?: Record<string, unknown> }
+      ) => Promise<Record<string, unknown>>
+    >()
+    .mockImplementation(
+      async (_table: unknown, request: { where?: Record<string, unknown> }) => {
+        const where = request.where ?? {};
+        if ("id" in where && "type" in where) {
+          const entity = integrations.externalEntity as
+            | Record<string, unknown>
+            | undefined;
+          return entity?.id === where.id ? { externalEntity: entity } : {};
+        }
+
+        return Object.fromEntries(
+          Object.entries(integrations).filter(
+            ([key]) => key !== "externalEntity"
+          )
+        );
+      }
+    );
   return {
     db: { find } as unknown as Pick<ServerDB<typeof schema>, "find">,
     find,
@@ -117,6 +138,16 @@ describe("developer-action transport", () => {
 
   it("resolves the org integration and returns a safe accepted result", async () => {
     const { db, find } = dbWithIntegrations({
+      externalEntity: {
+        externalKey: "github:owner/repo#123",
+        id: "entity-a",
+        number: 123,
+        organizationId,
+        provider: "github",
+        repoFullName: "owner/repo",
+        type: "pull_request",
+        url: "https://github.com/owner/repo/pull/123",
+      },
       integration: {
         configStr: '{"installationId":123,"secret":"do-not-log"}',
         enabled: true,
@@ -137,14 +168,22 @@ describe("developer-action transport", () => {
       expect(JSON.parse(String(init?.body))).toStrictEqual({
         action: "pr_match_replay",
         config: '{"installationId":123,"secret":"do-not-log"}',
-        payload: { target: "entity-a" },
+        payload: {
+          organizationId,
+          target: {
+            externalKey: "github:owner/repo#123",
+            number: 123,
+            repoFullName: "owner/repo",
+            url: "https://github.com/owner/repo/pull/123",
+          },
+        },
       });
 
       return new Response(
         JSON.stringify({
           accepted: true,
           jobIds: ["pr-match:entity-a"],
-          target: "entity-a",
+          target: "github:owner/repo#123",
         }),
         { status: 202 }
       );
@@ -157,10 +196,79 @@ describe("developer-action transport", () => {
     expect(result).toStrictEqual({
       accepted: true,
       jobIds: ["pr-match:entity-a"],
-      target: "entity-a",
+      target: "github:owner/repo#123",
     });
-    expect(find).toHaveBeenCalledOnce();
+    expect(find).toHaveBeenCalledTimes(2);
     expect(log).toHaveBeenCalledWith(expect.not.stringContaining("do-not-log"));
+  });
+
+  it("rejects a missing mirrored PR target before invoking the connector", async () => {
+    const { db } = dbWithIntegrations({
+      integration: {
+        configStr: "{}",
+        enabled: true,
+        id: "integration-a",
+        organizationId,
+        type: "github",
+      },
+    });
+    const fetchMock = vi.fn<() => void>();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      dispatchDeveloperAction(db, {
+        ...actionInput(),
+        payload: { entityId: "missing-entity" },
+      })
+    ).rejects.toMatchObject<DeveloperActionError>({
+      code: "INVALID_DEVELOPER_ACTION_TARGET",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("normalizes repository selection for the connector", async () => {
+    const { db } = dbWithIntegrations({
+      integration: {
+        configStr: "{}",
+        enabled: true,
+        id: "integration-a",
+        organizationId,
+        type: "github",
+      },
+    });
+    const fetchMock = vi.fn<
+      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+    >(async (_input, init) => {
+      expect(JSON.parse(String(init?.body))).toStrictEqual({
+        action: "repository_backfill",
+        config: "{}",
+        payload: {
+          allRepositories: false,
+          organizationId,
+          repositories: ["owner/repo"],
+        },
+      });
+      return new Response(
+        JSON.stringify({
+          accepted: true,
+          jobIds: ["backfill-job"],
+          target: "selected",
+        }),
+        { status: 202 }
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await dispatchDeveloperAction(db, {
+      ...actionInput({ action: "repository_backfill" }),
+      payload: { repositories: ["owner/repo"] },
+    });
+
+    expect(result).toStrictEqual({
+      accepted: true,
+      jobIds: ["backfill-job"],
+      target: "selected",
+    });
   });
 
   it("fails safely when the integration is missing", async () => {
@@ -208,6 +316,16 @@ describe("developer-action transport", () => {
 
   it("normalizes connector rejection and does not expose its response body", async () => {
     const { db } = dbWithIntegrations({
+      externalEntity: {
+        externalKey: "github:owner/repo#123",
+        id: "entity-a",
+        number: 123,
+        organizationId,
+        provider: "github",
+        repoFullName: "owner/repo",
+        type: "pull_request",
+        url: "https://github.com/owner/repo/pull/123",
+      },
       integration: {
         configStr: '{"secret":"do-not-leak"}',
         enabled: true,
@@ -287,7 +405,7 @@ describe("developer-action transport", () => {
         action: "pr_match_replay",
         connectorType: "github",
         organizationId,
-        payload: { integrationId: "integration-a" },
+        payload: { entityId: "entity-a", integrationId: "integration-a" },
       })
     ).toThrow("integrationId is not accepted");
   });

--- a/apps/api/src/lib/developer-action-dispatch.ts
+++ b/apps/api/src/lib/developer-action-dispatch.ts
@@ -5,11 +5,11 @@ import type { ServerDB } from "@live-state/sync/server";
 import { z } from "zod";
 
 import { schema } from "../live-state/schema";
+import { buildEntityRef } from "./capability-dispatch";
 import {
   connectorRegistry,
   getConnectorInvokeSecret,
 } from "./connector-registry";
-import { buildEntityRef } from "./capability-dispatch";
 
 /**
  * Explicit developer actions known to the API. This is intentionally separate
@@ -38,6 +38,7 @@ export const developerActionAcceptedResultSchema = z
   .object({
     accepted: z.literal(true),
     jobIds: z.array(z.string().min(1)).default([]),
+    partial: z.literal(true).optional(),
     target: z.string().min(1).optional(),
   })
   .strict();

--- a/apps/api/src/lib/developer-action-dispatch.ts
+++ b/apps/api/src/lib/developer-action-dispatch.ts
@@ -1,5 +1,6 @@
 import { invokeDeveloperAction } from "@connectors/framework";
 import type { RegistryEntry } from "@connectors/framework";
+import type { InferLiveObject } from "@live-state/sync";
 import type { ServerDB } from "@live-state/sync/server";
 import { z } from "zod";
 
@@ -8,6 +9,7 @@ import {
   connectorRegistry,
   getConnectorInvokeSecret,
 } from "./connector-registry";
+import { buildEntityRef } from "./capability-dispatch";
 
 /**
  * Explicit developer actions known to the API. This is intentionally separate
@@ -90,6 +92,123 @@ export interface DeveloperActionTarget {
   entry: RegistryEntry;
 }
 
+type ExternalEntityRow = InferLiveObject<typeof schema.externalEntity>;
+
+const prMatchReplayInputSchema = z
+  .object({
+    entityId: z.string().min(1),
+  })
+  .strict();
+
+const repositoryBackfillInputSchema = z
+  .object({
+    allRepositories: z.boolean().optional(),
+    repositories: z.array(z.string().min(1)).optional(),
+  })
+  .strict()
+  .superRefine((input, context) => {
+    const allRepositories = input.allRepositories === true;
+    const repositories = input.repositories ?? [];
+
+    if (allRepositories && repositories.length > 0) {
+      context.addIssue({
+        code: "custom",
+        message: "allRepositories cannot be combined with repositories",
+        path: ["repositories"],
+      });
+    }
+
+    if (!allRepositories && repositories.length === 0) {
+      context.addIssue({
+        code: "custom",
+        message: "repositories or allRepositories is required",
+        path: ["repositories"],
+      });
+    }
+  });
+
+type ParsedDeveloperActionInput =
+  | { action: "pr_match_replay"; entityId: string }
+  | {
+      action: "repository_backfill";
+      allRepositories: boolean;
+      repositories: string[];
+    };
+
+const parseDeveloperActionInput = (args: {
+  action: string;
+  payload: Record<string, unknown>;
+}): ParsedDeveloperActionInput => {
+  if (args.action === "pr_match_replay") {
+    const parsed = prMatchReplayInputSchema.safeParse(args.payload);
+    if (!parsed.success) {
+      throw new DeveloperActionError("INVALID_DEVELOPER_ACTION_INPUT");
+    }
+    return { action: args.action, entityId: parsed.data.entityId };
+  }
+
+  if (args.action === "repository_backfill") {
+    const parsed = repositoryBackfillInputSchema.safeParse(args.payload);
+    if (!parsed.success) {
+      throw new DeveloperActionError("INVALID_DEVELOPER_ACTION_INPUT");
+    }
+    return {
+      action: args.action,
+      allRepositories: parsed.data.allRepositories === true,
+      repositories: [...new Set(parsed.data.repositories ?? [])],
+    };
+  }
+
+  throw new DeveloperActionError("UNKNOWN_DEVELOPER_ACTION");
+};
+
+/**
+ * Resolve browser-facing action input into the provider-neutral payload the
+ * connector needs. Entity IDs are looked up with both organization and PR
+ * type filters so a caller cannot turn an ID from another organization or
+ * another mirrored entity kind into a connector target.
+ */
+export const resolveDeveloperActionPayload = async (
+  db: Pick<ServerDB<typeof schema>, "find">,
+  args: {
+    action: string;
+    connectorType: string;
+    organizationId: string;
+    payload: Record<string, unknown>;
+  }
+): Promise<Record<string, unknown>> => {
+  const input = parseDeveloperActionInput(args);
+
+  if (input.action === "pr_match_replay") {
+    const entity = Object.values(
+      await db.find(schema.externalEntity, {
+        where: {
+          deletedAt: null,
+          id: input.entityId,
+          organizationId: args.organizationId,
+          provider: args.connectorType,
+          type: "pull_request",
+        },
+      })
+    )[0] as ExternalEntityRow | undefined;
+
+    if (!entity) {
+      throw new DeveloperActionError("INVALID_DEVELOPER_ACTION_TARGET");
+    }
+
+    return {
+      organizationId: args.organizationId,
+      target: buildEntityRef(entity),
+    };
+  }
+
+  return {
+    allRepositories: input.allRepositories,
+    organizationId: args.organizationId,
+    repositories: input.repositories,
+  };
+};
+
 export const resolveDeveloperActionTarget = async (
   db: Pick<ServerDB<typeof schema>, "find">,
   args: {
@@ -135,8 +254,10 @@ export const dispatchDeveloperAction = async (
   }
 ): Promise<DeveloperActionAcceptedResult> => {
   let target: DeveloperActionTarget;
+  let payload: Record<string, unknown>;
   try {
     target = await resolveDeveloperActionTarget(db, args);
+    payload = await resolveDeveloperActionPayload(db, args);
   } catch (error) {
     if (error instanceof DeveloperActionError) {
       throw error;
@@ -154,7 +275,7 @@ export const dispatchDeveloperAction = async (
       {
         action: args.action,
         config: target.config,
-        payload: args.payload,
+        payload,
       },
       { secret: connectorSecret }
     );

--- a/apps/api/src/live-state/router/developer-action.ts
+++ b/apps/api/src/live-state/router/developer-action.ts
@@ -67,7 +67,9 @@ export const runDeveloperAction = async (
       action: input.action,
       actorUserId: actor.userId,
       connectorType: input.connectorType,
-      event: "developer_action.accepted",
+      event: result.partial
+        ? "developer_action.partially_accepted"
+        : "developer_action.accepted",
       jobIds: result.jobIds,
       organizationId: input.organizationId,
       ...(result.target ? { target: result.target } : {}),

--- a/connectors/github/src/lib/developer-actions.ts
+++ b/connectors/github/src/lib/developer-actions.ts
@@ -1,0 +1,314 @@
+import { capabilityEntityRefSchema } from "@connectors/framework";
+import { parseExternalId } from "@workspace/schemas/external-issue";
+import { z } from "zod";
+
+import {
+  buildPullRequestFields,
+  upsertExternalEntity,
+} from "./external-entity";
+import type { GitHubPullRequestLike, RepoRef } from "./external-entity";
+import { enqueuePrMatch, enqueueRepoBackfill } from "./queue";
+
+/** A handled response: an HTTP status plus the JSON body to return. */
+export interface GithubDeveloperActionResult {
+  body: unknown;
+  status: number;
+}
+
+export type GithubDeveloperActionHandler = (
+  config: string,
+  payload: unknown
+) => Promise<GithubDeveloperActionResult>;
+
+interface GithubRepo {
+  fullName: string;
+  name: string;
+  owner: string;
+}
+
+interface GithubConfig {
+  installationId: number;
+  repos: GithubRepo[];
+}
+
+export interface GithubDeveloperActionDependencies {
+  enqueuePrMatch: typeof enqueuePrMatch;
+  enqueueRepoBackfill: typeof enqueueRepoBackfill;
+  fetchPullRequest: (
+    installationId: number,
+    owner: string,
+    repo: string,
+    pullNumber: number
+  ) => Promise<GitHubPullRequestLike>;
+  upsertExternalEntity: typeof upsertExternalEntity;
+}
+
+const githubRepoSchema = z
+  .object({
+    fullName: z.string().min(1),
+    name: z.string().regex(/^[^/]+$/),
+    owner: z.string().regex(/^[^/]+$/),
+  })
+  .refine(({ fullName, name, owner }) => fullName === `${owner}/${name}`, {
+    message: "fullName must match owner/name",
+  });
+
+const githubConfigSchema = z.object({
+  installationId: z.coerce.number().int().positive(),
+  repos: z.array(githubRepoSchema).default([]),
+});
+
+const prMatchReplayPayloadSchema = z
+  .object({
+    organizationId: z.string().min(1),
+    target: capabilityEntityRefSchema.strict(),
+  })
+  .strict();
+
+const repositoryBackfillPayloadSchema = z
+  .object({
+    allRepositories: z.boolean(),
+    organizationId: z.string().min(1),
+    repositories: z.array(z.string().min(1)),
+  })
+  .strict();
+
+const result = (
+  status: number,
+  error: string
+): GithubDeveloperActionResult => ({ body: { error }, status });
+
+const parseConfig = (rawConfig: string): GithubConfig | null => {
+  try {
+    const parsed = githubConfigSchema.safeParse(JSON.parse(rawConfig));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+};
+
+const logAction = (event: Record<string, unknown>): void => {
+  console.info(JSON.stringify(event));
+};
+
+const logFailure = (event: Record<string, unknown>): void => {
+  console.error(JSON.stringify(event));
+};
+
+const repoRef = (repo: GithubRepo): RepoRef => repo;
+
+const replayPullRequest = async (
+  rawConfig: string,
+  rawPayload: unknown,
+  dependencies: GithubDeveloperActionDependencies
+): Promise<GithubDeveloperActionResult> => {
+  const config = parseConfig(rawConfig);
+  if (!config) {
+    return result(400, "INVALID_CONFIG");
+  }
+
+  const parsedPayload = prMatchReplayPayloadSchema.safeParse(rawPayload);
+  if (!parsedPayload.success) {
+    return result(400, "INVALID_TARGET");
+  }
+
+  const { organizationId, target } = parsedPayload.data;
+  const repo = config.repos.find(
+    (candidate) => candidate.fullName === target.repoFullName
+  );
+  if (!repo) {
+    return result(400, "REPOSITORY_NOT_CONNECTED");
+  }
+
+  const parsedExternalKey = parseExternalId(target.externalKey);
+  if (
+    !parsedExternalKey ||
+    parsedExternalKey.provider !== "github" ||
+    parsedExternalKey.owner !== repo.owner ||
+    parsedExternalKey.repo !== repo.name
+  ) {
+    return result(400, "INVALID_TARGET");
+  }
+
+  let pullRequest: GitHubPullRequestLike;
+  try {
+    pullRequest = await dependencies.fetchPullRequest(
+      config.installationId,
+      repo.owner,
+      repo.name,
+      target.number
+    );
+  } catch {
+    logFailure({
+      action: "pr_match_replay",
+      event: "developer_action.execution_failed",
+      organizationId,
+      target: target.externalKey,
+    });
+    return result(502, "UPSTREAM_UNAVAILABLE");
+  }
+
+  const fields = buildPullRequestFields(pullRequest, repoRef(repo));
+  if (fields.externalKey !== target.externalKey || fields.url !== target.url) {
+    return result(409, "TARGET_CHANGED");
+  }
+
+  try {
+    // Refresh the mirror before checking eligibility so closed/draft changes
+    // become authoritative without creating any external GitHub data.
+    await dependencies.upsertExternalEntity(organizationId, fields);
+  } catch {
+    logFailure({
+      action: "pr_match_replay",
+      event: "developer_action.execution_failed",
+      organizationId,
+      target: target.externalKey,
+    });
+    return result(500, "ACTION_FAILED");
+  }
+
+  if (fields.state !== "open" || fields.draft === true) {
+    logAction({
+      action: "pr_match_replay",
+      event: "developer_action.rejected",
+      organizationId,
+      reason: "ineligible",
+      target: target.externalKey,
+    });
+    return result(409, "PR_NOT_ELIGIBLE");
+  }
+
+  try {
+    const jobId = await dependencies.enqueuePrMatch({
+      body: fields.body,
+      draft: fields.draft,
+      externalKey: fields.externalKey,
+      headRef: fields.headRef,
+      organizationId,
+      state: fields.state,
+      title: fields.title,
+    });
+
+    logAction({
+      action: "pr_match_replay",
+      event: "developer_action.accepted",
+      jobIds: [jobId],
+      organizationId,
+      target: fields.externalKey,
+    });
+
+    return {
+      body: { accepted: true, jobIds: [jobId], target: fields.externalKey },
+      status: 202,
+    };
+  } catch {
+    logFailure({
+      action: "pr_match_replay",
+      event: "developer_action.execution_failed",
+      organizationId,
+      target: target.externalKey,
+    });
+    return result(500, "ACTION_FAILED");
+  }
+};
+
+const backfillRepositories = async (
+  rawConfig: string,
+  rawPayload: unknown,
+  dependencies: GithubDeveloperActionDependencies
+): Promise<GithubDeveloperActionResult> => {
+  const config = parseConfig(rawConfig);
+  if (!config) {
+    return result(400, "INVALID_CONFIG");
+  }
+
+  const parsedPayload = repositoryBackfillPayloadSchema.safeParse(rawPayload);
+  if (!parsedPayload.success) {
+    return result(400, "INVALID_SELECTION");
+  }
+
+  const { allRepositories, organizationId, repositories } = parsedPayload.data;
+  const configuredRepos = new Map(
+    config.repos.map((repo) => [repo.fullName, repo])
+  );
+  const selectedRepos = allRepositories
+    ? [...configuredRepos.values()]
+    : [...new Set(repositories)].map((fullName) =>
+        configuredRepos.get(fullName)
+      );
+
+  if (selectedRepos.some((repo) => !repo)) {
+    return result(400, "REPOSITORY_NOT_CONNECTED");
+  }
+
+  const repos = selectedRepos.filter((repo): repo is GithubRepo =>
+    Boolean(repo)
+  );
+  if (repos.length === 0) {
+    return result(400, "NO_REPOSITORIES_CONFIGURED");
+  }
+
+  const enqueueResults = await Promise.allSettled(
+    repos.map((repo) =>
+      dependencies.enqueueRepoBackfill({
+        fullName: repo.fullName,
+        installationId: config.installationId,
+        organizationId,
+        owner: repo.owner,
+        repo: repo.name,
+      })
+    )
+  );
+  const rejected = enqueueResults.find(
+    (enqueueResult) => enqueueResult.status === "rejected"
+  );
+  if (rejected) {
+    logFailure({
+      action: "repository_backfill",
+      event: "developer_action.execution_failed",
+      organizationId,
+      target: allRepositories ? "all" : "selected",
+    });
+    return result(500, "ACTION_FAILED");
+  }
+
+  const jobIds = enqueueResults.map(
+    (enqueueResult) => (enqueueResult as PromiseFulfilledResult<string>).value
+  );
+  const target = allRepositories ? "all" : "selected";
+  logAction({
+    action: "repository_backfill",
+    event: "developer_action.accepted",
+    jobIds,
+    organizationId,
+    target,
+  });
+
+  return {
+    body: { accepted: true, jobIds, target },
+    status: 202,
+  };
+};
+
+const defaultDependencies: GithubDeveloperActionDependencies = {
+  enqueuePrMatch,
+  enqueueRepoBackfill,
+  fetchPullRequest: (...args) =>
+    import("./github").then(({ fetchPullRequest }) =>
+      fetchPullRequest(...args)
+    ),
+  upsertExternalEntity,
+};
+
+/** Build the private GitHub developer-action dispatch map. */
+export const createGithubDeveloperActionHandlers = (
+  overrides: Partial<GithubDeveloperActionDependencies> = {}
+): Readonly<Record<string, GithubDeveloperActionHandler>> => {
+  const dependencies = { ...defaultDependencies, ...overrides };
+  return {
+    pr_match_replay: (config, payload) =>
+      replayPullRequest(config, payload, dependencies),
+    repository_backfill: (config, payload) =>
+      backfillRepositories(config, payload, dependencies),
+  };
+};

--- a/connectors/github/src/lib/developer-actions.ts
+++ b/connectors/github/src/lib/developer-actions.ts
@@ -259,23 +259,31 @@ const backfillRepositories = async (
       })
     )
   );
-  const rejected = enqueueResults.find(
-    (enqueueResult) => enqueueResult.status === "rejected"
+  const jobIds = enqueueResults.flatMap((enqueueResult) =>
+    enqueueResult.status === "fulfilled" ? [enqueueResult.value] : []
   );
-  if (rejected) {
+  const rejectedCount = enqueueResults.length - jobIds.length;
+  const target = allRepositories ? "all" : "selected";
+
+  if (rejectedCount > 0) {
     logFailure({
       action: "repository_backfill",
-      event: "developer_action.execution_failed",
+      event: "developer_action.partial_failure",
+      jobIds,
       organizationId,
-      target: allRepositories ? "all" : "selected",
+      rejectedCount,
+      target,
     });
-    return result(500, "ACTION_FAILED");
+    if (jobIds.length === 0) {
+      return result(500, "ACTION_FAILED");
+    }
+
+    return {
+      body: { accepted: true, jobIds, partial: true, target },
+      status: 207,
+    };
   }
 
-  const jobIds = enqueueResults.map(
-    (enqueueResult) => (enqueueResult as PromiseFulfilledResult<string>).value
-  );
-  const target = allRepositories ? "all" : "selected";
   logAction({
     action: "repository_backfill",
     event: "developer_action.accepted",

--- a/connectors/github/src/lib/developer-actions.ts
+++ b/connectors/github/src/lib/developer-actions.ts
@@ -71,7 +71,12 @@ const repositoryBackfillPayloadSchema = z
     organizationId: z.string().min(1),
     repositories: z.array(z.string().min(1)),
   })
-  .strict();
+  .strict()
+  .refine(
+    ({ allRepositories, repositories }) =>
+      !allRepositories || repositories.length === 0,
+    { message: "repositories must be empty when allRepositories is true" }
+  );
 
 const result = (
   status: number,
@@ -228,6 +233,10 @@ const backfillRepositories = async (
   }
 
   const { allRepositories, organizationId, repositories } = parsedPayload.data;
+  if (!allRepositories && repositories.length === 0) {
+    return result(400, "NO_REPOSITORIES_SELECTED");
+  }
+
   const configuredRepos = new Map(
     config.repos.map((repo) => [repo.fullName, repo])
   );

--- a/connectors/github/src/lib/developer-actions.ts
+++ b/connectors/github/src/lib/developer-actions.ts
@@ -268,7 +268,10 @@ const backfillRepositories = async (
   if (rejectedCount > 0) {
     logFailure({
       action: "repository_backfill",
-      event: "developer_action.partial_failure",
+      event:
+        jobIds.length === 0
+          ? "developer_action.execution_failed"
+          : "developer_action.partial_failure",
       jobIds,
       organizationId,
       rejectedCount,

--- a/connectors/github/src/lib/github.ts
+++ b/connectors/github/src/lib/github.ts
@@ -1,6 +1,7 @@
 import { App } from "octokit";
 
 import { getGitHubConfig } from "../utils";
+import type { GitHubPullRequestLike } from "./external-entity";
 
 const config = getGitHubConfig();
 
@@ -150,6 +151,33 @@ export const fetchPullRequests = async (
     return data;
   } catch (error) {
     console.error(`Error fetching pull requests:`, error);
+    throw error;
+  }
+};
+
+/** Fetch one authoritative pull request for a developer-action replay. */
+export const fetchPullRequest = async (
+  installationId: number,
+  owner: string,
+  repo: string,
+  pullNumber: number
+): Promise<GitHubPullRequestLike> => {
+  try {
+    const octokit = await getOctokit(installationId);
+    const { data } = await octokit.request(
+      "GET /repos/{owner}/{repo}/pulls/{pull_number}",
+      {
+        headers: {
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+        owner,
+        pull_number: pullNumber,
+        repo,
+      }
+    );
+    return data as GitHubPullRequestLike;
+  } catch (error) {
+    console.error("Error fetching pull request:", error);
     throw error;
   }
 };

--- a/connectors/github/src/lib/queue.test.ts
+++ b/connectors/github/src/lib/queue.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPrMatchJobId, buildRepoBackfillJobId } from "./queue";
+
+describe("GitHub developer-action queue keys", () => {
+  it("uses one stable PR key per organization and external entity", () => {
+    const first = buildPrMatchJobId("org-a", "github:owner/repo#42");
+    const repeated = buildPrMatchJobId("org-a", "github:owner/repo#42");
+    const otherOrganization = buildPrMatchJobId(
+      "org-b",
+      "github:owner/repo#42"
+    );
+
+    expect(repeated).toBe(first);
+    expect(otherOrganization).not.toBe(first);
+  });
+
+  it("uses one stable backfill key per organization and repository", () => {
+    const first = buildRepoBackfillJobId("org-a", "owner/repo");
+    const repeated = buildRepoBackfillJobId("org-a", "owner/repo");
+    const otherRepository = buildRepoBackfillJobId("org-a", "owner/other");
+
+    expect(repeated).toBe(first);
+    expect(otherRepository).not.toBe(first);
+  });
+});

--- a/connectors/github/src/lib/queue.ts
+++ b/connectors/github/src/lib/queue.ts
@@ -72,15 +72,23 @@ const getQueue = (): Queue<BackfillJobData> => {
 const safeFullName = (fullName: string): string =>
   fullName.replaceAll("_", "__").replace("/", "_");
 
-export const enqueueRepoBackfill = async (data: BackfillJobData) => {
-  const jobId = `backfill_${data.organizationId}_${safeFullName(data.fullName)}`;
-  await getQueue().add(BACKFILL_JOB_NAME, data, {
+export const buildRepoBackfillJobId = (
+  organizationId: string,
+  fullName: string
+): string => `backfill_${organizationId}_${safeFullName(fullName)}`;
+
+export const enqueueRepoBackfill = async (
+  data: BackfillJobData
+): Promise<string> => {
+  const jobId = buildRepoBackfillJobId(data.organizationId, data.fullName);
+  const job = await getQueue().add(BACKFILL_JOB_NAME, data, {
     attempts: 3,
     backoff: { delay: 10_000, type: "exponential" },
     jobId,
     removeOnComplete: { age: 24 * 3600, count: 50 },
     removeOnFail: { count: 200 },
   });
+  return job.id ?? jobId;
 };
 
 let reconcileQueue: Queue | null = null;
@@ -153,6 +161,16 @@ const getPrMatchQueue = (): Queue<PrMatchJobData> => {
   return prMatchQueue;
 };
 
+export const buildPrMatchJobId = (
+  organizationId: string,
+  externalKey: string
+): string => {
+  const safeExternalKey = externalKey
+    .replaceAll("_", "__")
+    .replaceAll(":", "_");
+  return `pr-match_${organizationId}_${safeExternalKey}`;
+};
+
 /**
  * Enqueue a push-side match for a PR. One pending job per PR — scoped by
  * `(organizationId, externalKey)` so orgs sharing a repo don't coalesce onto
@@ -166,12 +184,9 @@ const getPrMatchQueue = (): Queue<PrMatchJobData> => {
  * (its `_`s escaped first) to keep the id injective — the same scheme the
  * backfill/reconcile ids use.
  */
-export const enqueuePrMatch = async (data: PrMatchJobData) => {
+export const enqueuePrMatch = async (data: PrMatchJobData): Promise<string> => {
   const q = getPrMatchQueue();
-  const safeExternalKey = data.externalKey
-    .replaceAll("_", "__")
-    .replaceAll(":", "_");
-  const jobId = `pr-match_${data.organizationId}_${safeExternalKey}`;
+  const jobId = buildPrMatchJobId(data.organizationId, data.externalKey);
 
   const existing = await q.getJob(jobId);
   if (existing) {
@@ -181,9 +196,10 @@ export const enqueuePrMatch = async (data: PrMatchJobData) => {
     }
   }
 
-  await q.add(PR_MATCH_JOB_NAME, data, {
+  const job = await q.add(PR_MATCH_JOB_NAME, data, {
     jobId,
     removeOnComplete: { age: 24 * 3600, count: 100 },
     removeOnFail: { count: 500 },
   });
+  return job.id ?? jobId;
 };

--- a/connectors/github/src/routes/actions.test.ts
+++ b/connectors/github/src/routes/actions.test.ts
@@ -1,6 +1,8 @@
 import Elysia from "elysia";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { createGithubDeveloperActionHandlers } from "../lib/developer-actions";
+import type { GithubDeveloperActionDependencies } from "../lib/developer-actions";
 import { createDeveloperActionsRoute } from "./actions";
 import type { DeveloperActionHandler } from "./actions";
 
@@ -113,5 +115,236 @@ describe("GitHub developer-action route", () => {
     await expect(response.json()).resolves.toStrictEqual({
       error: "ACTION_FAILED",
     });
+  });
+});
+
+const githubConfig = JSON.stringify({
+  installationId: 123,
+  repos: [
+    { fullName: "owner/repo", name: "repo", owner: "owner" },
+    { fullName: "owner/other", name: "other", owner: "owner" },
+  ],
+});
+
+const pullRequest = (overrides: Record<string, unknown> = {}) => ({
+  base: { ref: "main" },
+  body: "Please fix the issue",
+  closed_at: null,
+  created_at: "2026-08-03T00:00:00Z",
+  draft: false,
+  head: { ref: "fix/issue" },
+  html_url: "https://github.com/owner/repo/pull/123",
+  id: 123,
+  labels: [],
+  merged: false,
+  merged_at: null,
+  number: 123,
+  state: "open",
+  title: "Fix the issue",
+  updated_at: "2026-08-04T00:00:00Z",
+  user: { login: "contributor" },
+  ...overrides,
+});
+
+const replayTarget = {
+  externalKey: "github:owner/repo#123",
+  number: 123,
+  repoFullName: "owner/repo",
+  url: "https://github.com/owner/repo/pull/123",
+};
+
+describe("GitHub developer-action handlers", () => {
+  it("refreshes an eligible PR and enqueues the existing match pipeline", async () => {
+    const fetchPullRequest = vi
+      .fn<GithubDeveloperActionDependencies["fetchPullRequest"]>()
+      .mockResolvedValue(pullRequest());
+    const upsertExternalEntity = vi
+      .fn<GithubDeveloperActionDependencies["upsertExternalEntity"]>()
+      .mockResolvedValue(undefined);
+    const enqueuePrMatch = vi
+      .fn<GithubDeveloperActionDependencies["enqueuePrMatch"]>()
+      .mockResolvedValue("pr-match-job");
+    const info = vi.spyOn(console, "info").mockReturnValue(undefined);
+    const handlers = createGithubDeveloperActionHandlers({
+      enqueuePrMatch,
+      fetchPullRequest,
+      upsertExternalEntity,
+    });
+
+    const response = await handlers.pr_match_replay(githubConfig, {
+      organizationId: "org-a",
+      target: replayTarget,
+    });
+
+    expect(response).toStrictEqual({
+      body: {
+        accepted: true,
+        jobIds: ["pr-match-job"],
+        target: "github:owner/repo#123",
+      },
+      status: 202,
+    });
+    expect(upsertExternalEntity).toHaveBeenCalledWith(
+      "org-a",
+      expect.objectContaining({
+        externalKey: "github:owner/repo#123",
+        state: "open",
+        type: "pull_request",
+      })
+    );
+    expect(enqueuePrMatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        externalKey: "github:owner/repo#123",
+        organizationId: "org-a",
+      })
+    );
+    expect(info).toHaveBeenCalledWith(
+      expect.stringContaining('"event":"developer_action.accepted"')
+    );
+    expect(info).toHaveBeenCalledWith(
+      expect.not.stringContaining("installationId")
+    );
+  });
+
+  it.each([{ draft: true }, { state: "closed" }])(
+    "refreshes but rejects an ineligible PR without queueing match side effects (%j)",
+    async (overrides) => {
+      const fetchPullRequest = vi
+        .fn<GithubDeveloperActionDependencies["fetchPullRequest"]>()
+        .mockResolvedValue(pullRequest(overrides));
+      const upsertExternalEntity = vi
+        .fn<GithubDeveloperActionDependencies["upsertExternalEntity"]>()
+        .mockResolvedValue(undefined);
+      const enqueuePrMatch =
+        vi.fn<GithubDeveloperActionDependencies["enqueuePrMatch"]>();
+      const info = vi.spyOn(console, "info").mockReturnValue(undefined);
+      const handlers = createGithubDeveloperActionHandlers({
+        enqueuePrMatch,
+        fetchPullRequest,
+        upsertExternalEntity,
+      });
+
+      const response = await handlers.pr_match_replay(githubConfig, {
+        organizationId: "org-a",
+        target: replayTarget,
+      });
+
+      expect(response).toStrictEqual({
+        body: { error: "PR_NOT_ELIGIBLE" },
+        status: 409,
+      });
+      expect(upsertExternalEntity).toHaveBeenCalledOnce();
+      expect(enqueuePrMatch).not.toHaveBeenCalled();
+      expect(info).toHaveBeenCalledWith(
+        expect.stringContaining('"reason":"ineligible"')
+      );
+    }
+  );
+
+  it("coalesces repeated replay requests through the same PR queue key", async () => {
+    const enqueuePrMatch = vi
+      .fn<GithubDeveloperActionDependencies["enqueuePrMatch"]>()
+      .mockResolvedValue("same-pr-match-job");
+    const handlers = createGithubDeveloperActionHandlers({
+      enqueuePrMatch,
+      fetchPullRequest: vi
+        .fn<GithubDeveloperActionDependencies["fetchPullRequest"]>()
+        .mockResolvedValue(pullRequest()),
+      upsertExternalEntity: vi
+        .fn<GithubDeveloperActionDependencies["upsertExternalEntity"]>()
+        .mockResolvedValue(undefined),
+    });
+    const payload = { organizationId: "org-a", target: replayTarget };
+
+    await handlers.pr_match_replay(githubConfig, payload);
+    await handlers.pr_match_replay(githubConfig, payload);
+
+    expect(enqueuePrMatch).toHaveBeenCalledTimes(2);
+    expect(enqueuePrMatch.mock.calls[0]?.[0]).toMatchObject({
+      externalKey: "github:owner/repo#123",
+      organizationId: "org-a",
+    });
+    expect(enqueuePrMatch.mock.calls[1]?.[0]).toMatchObject({
+      externalKey: "github:owner/repo#123",
+      organizationId: "org-a",
+    });
+  });
+
+  it("rejects a target outside the resolved GitHub installation", async () => {
+    const fetchPullRequest =
+      vi.fn<GithubDeveloperActionDependencies["fetchPullRequest"]>();
+    const handlers = createGithubDeveloperActionHandlers({ fetchPullRequest });
+
+    const response = await handlers.pr_match_replay(githubConfig, {
+      organizationId: "org-a",
+      target: {
+        ...replayTarget,
+        repoFullName: "foreign/repo",
+      },
+    });
+
+    expect(response).toStrictEqual({
+      body: { error: "REPOSITORY_NOT_CONNECTED" },
+      status: 400,
+    });
+    expect(fetchPullRequest).not.toHaveBeenCalled();
+  });
+
+  it("enqueues selected repositories and the explicit all-repositories choice", async () => {
+    const enqueueRepoBackfill = vi
+      .fn<GithubDeveloperActionDependencies["enqueueRepoBackfill"]>()
+      .mockImplementation(async (data) => `job:${data.fullName}`);
+    const handlers = createGithubDeveloperActionHandlers({
+      enqueueRepoBackfill,
+    });
+
+    const selected = await handlers.repository_backfill(githubConfig, {
+      allRepositories: false,
+      organizationId: "org-a",
+      repositories: ["owner/repo"],
+    });
+    const all = await handlers.repository_backfill(githubConfig, {
+      allRepositories: true,
+      organizationId: "org-a",
+      repositories: [],
+    });
+
+    expect(selected).toStrictEqual({
+      body: {
+        accepted: true,
+        jobIds: ["job:owner/repo"],
+        target: "selected",
+      },
+      status: 202,
+    });
+    expect(all).toStrictEqual({
+      body: {
+        accepted: true,
+        jobIds: ["job:owner/repo", "job:owner/other"],
+        target: "all",
+      },
+      status: 202,
+    });
+    expect(enqueueRepoBackfill).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects foreign repositories without enqueueing any backfill", async () => {
+    const enqueueRepoBackfill =
+      vi.fn<GithubDeveloperActionDependencies["enqueueRepoBackfill"]>();
+    const handlers = createGithubDeveloperActionHandlers({
+      enqueueRepoBackfill,
+    });
+
+    const response = await handlers.repository_backfill(githubConfig, {
+      allRepositories: false,
+      organizationId: "org-a",
+      repositories: ["foreign/repo"],
+    });
+
+    expect(response).toStrictEqual({
+      body: { error: "REPOSITORY_NOT_CONNECTED" },
+      status: 400,
+    });
+    expect(enqueueRepoBackfill).not.toHaveBeenCalled();
   });
 });

--- a/connectors/github/src/routes/actions.test.ts
+++ b/connectors/github/src/routes/actions.test.ts
@@ -328,6 +328,40 @@ describe("GitHub developer-action handlers", () => {
     expect(enqueueRepoBackfill).toHaveBeenCalledTimes(3);
   });
 
+  it("returns fulfilled job IDs when a backfill is partially accepted", async () => {
+    const enqueueRepoBackfill = vi
+      .fn<GithubDeveloperActionDependencies["enqueueRepoBackfill"]>()
+      .mockImplementation(async (data) => {
+        if (data.fullName === "owner/other") {
+          throw new Error("queue unavailable");
+        }
+        return `job:${data.fullName}`;
+      });
+    const error = vi.spyOn(console, "error").mockReturnValue(undefined);
+    const handlers = createGithubDeveloperActionHandlers({
+      enqueueRepoBackfill,
+    });
+
+    const response = await handlers.repository_backfill(githubConfig, {
+      allRepositories: false,
+      organizationId: "org-a",
+      repositories: ["owner/repo", "owner/other"],
+    });
+
+    expect(response).toStrictEqual({
+      body: {
+        accepted: true,
+        jobIds: ["job:owner/repo"],
+        partial: true,
+        target: "selected",
+      },
+      status: 207,
+    });
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining('"event":"developer_action.partial_failure"')
+    );
+  });
+
   it("rejects foreign repositories without enqueueing any backfill", async () => {
     const enqueueRepoBackfill =
       vi.fn<GithubDeveloperActionDependencies["enqueueRepoBackfill"]>();

--- a/connectors/github/src/routes/actions.test.ts
+++ b/connectors/github/src/routes/actions.test.ts
@@ -362,6 +362,30 @@ describe("GitHub developer-action handlers", () => {
     );
   });
 
+  it("reports a complete backfill enqueue failure as an action failure", async () => {
+    const enqueueRepoBackfill = vi
+      .fn<GithubDeveloperActionDependencies["enqueueRepoBackfill"]>()
+      .mockRejectedValue(new Error("queue unavailable"));
+    const error = vi.spyOn(console, "error").mockReturnValue(undefined);
+    const handlers = createGithubDeveloperActionHandlers({
+      enqueueRepoBackfill,
+    });
+
+    const response = await handlers.repository_backfill(githubConfig, {
+      allRepositories: false,
+      organizationId: "org-a",
+      repositories: ["owner/repo"],
+    });
+
+    expect(response).toStrictEqual({
+      body: { error: "ACTION_FAILED" },
+      status: 500,
+    });
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining('"event":"developer_action.execution_failed"')
+    );
+  });
+
   it("rejects foreign repositories without enqueueing any backfill", async () => {
     const enqueueRepoBackfill =
       vi.fn<GithubDeveloperActionDependencies["enqueueRepoBackfill"]>();

--- a/connectors/github/src/routes/actions.test.ts
+++ b/connectors/github/src/routes/actions.test.ts
@@ -198,12 +198,11 @@ describe("GitHub developer-action handlers", () => {
         organizationId: "org-a",
       })
     );
-    expect(info).toHaveBeenCalledWith(
-      expect.stringContaining('"event":"developer_action.accepted"')
-    );
-    expect(info).toHaveBeenCalledWith(
-      expect.not.stringContaining("installationId")
-    );
+    expect(info.mock.calls).toStrictEqual([
+      [expect.stringContaining('"event":"developer_action.accepted"')],
+    ]);
+    const [message] = info.mock.calls[0] ?? [];
+    expect(message).not.toContain("installationId");
   });
 
   it.each([{ draft: true }, { state: "closed" }])(
@@ -326,6 +325,58 @@ describe("GitHub developer-action handlers", () => {
       status: 202,
     });
     expect(enqueueRepoBackfill).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects a contradictory repository selection", async () => {
+    const enqueueRepoBackfill =
+      vi.fn<GithubDeveloperActionDependencies["enqueueRepoBackfill"]>();
+    const handlers = createGithubDeveloperActionHandlers({
+      enqueueRepoBackfill,
+    });
+
+    const response = await handlers.repository_backfill(githubConfig, {
+      allRepositories: true,
+      organizationId: "org-a",
+      repositories: ["owner/repo"],
+    });
+
+    expect(response).toStrictEqual({
+      body: { error: "INVALID_SELECTION" },
+      status: 400,
+    });
+    expect(enqueueRepoBackfill).not.toHaveBeenCalled();
+  });
+
+  it("distinguishes an empty selection from an unconfigured repository list", async () => {
+    const enqueueRepoBackfill =
+      vi.fn<GithubDeveloperActionDependencies["enqueueRepoBackfill"]>();
+    const handlers = createGithubDeveloperActionHandlers({
+      enqueueRepoBackfill,
+    });
+
+    const emptySelection = await handlers.repository_backfill(githubConfig, {
+      allRepositories: false,
+      organizationId: "org-a",
+      repositories: [],
+    });
+    const noConfiguredRepositories = await handlers.repository_backfill(
+      JSON.stringify({ installationId: 123, repos: [] }),
+      {
+        allRepositories: true,
+        organizationId: "org-a",
+        repositories: [],
+      }
+    );
+
+    expect(emptySelection).toStrictEqual({
+      body: { error: "NO_REPOSITORIES_SELECTED" },
+      status: 400,
+    });
+    expect(noConfiguredRepositories).toStrictEqual({
+      body: { error: "NO_REPOSITORIES_CONFIGURED" },
+      status: 400,
+    });
+    expect(enqueueRepoBackfill).not.toHaveBeenCalled();
   });
 
   it("returns fulfilled job IDs when a backfill is partially accepted", async () => {

--- a/connectors/github/src/routes/actions.ts
+++ b/connectors/github/src/routes/actions.ts
@@ -5,6 +5,8 @@ import {
 } from "@connectors/framework";
 import Elysia from "elysia";
 
+import { createGithubDeveloperActionHandlers } from "../lib/developer-actions";
+
 /** A connector-owned developer action handler. */
 export type DeveloperActionHandler = (
   config: string,
@@ -77,11 +79,11 @@ export const createDeveloperActionsRoute = (
     }
   );
 
-// Keep the production dispatch map private to the connector. FRO-211 adds
-// explicit action entries here without changing the capability manifest.
+// Keep the production dispatch map private to the connector. These explicit
+// entries do not change the capability manifest or create a discovery surface.
 const developerActionHandlers: Readonly<
   Record<string, DeveloperActionHandler>
-> = {};
+> = createGithubDeveloperActionHandlers();
 
 export const developerActionsRoutes = createDeveloperActionsRoute(
   developerActionHandlers


### PR DESCRIPTION
## Summary
- resolve organization-scoped mirrored PR IDs into provider-neutral action targets
- refresh authoritative GitHub PR state, update the mirror, and enqueue the existing coalesced match pipeline only for eligible PRs
- add selected/all repository backfill with installation ownership validation and idempotent job IDs
- keep action dispatch private and add structured acceptance/rejection/failure logging
- cover routing, target isolation, eligibility, coalescing keys, repository selection, and safe logging

Implements FRO-211.

Stacked on [FRO-210 / PR #338](https://github.com/FrontDeskHQ/front-desk/pull/338).

Native stack continues [FRO-209 / PR #337](https://github.com/FrontDeskHQ/front-desk/pull/337) → #338 → #340.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements GitHub developer actions (FRO-211) for PR replay and repository backfill with secure, provider‑neutral targeting. Adds private handler implementations, stable job IDs with idempotent queueing, and supports partial acceptance.

- **New Features**
  - API: validate inputs with `zod`; resolve `entityId` into a provider‑neutral PR target; preflight‑reject missing/foreign PRs; build connector payloads `{ organizationId, target | repositories | allRepositories }`.
  - GitHub: private handlers via `createGithubDeveloperActionHandlers`; refresh the PR mirror before eligibility checks; require PR open and not draft; enqueue on accept and return job IDs; support all or selected repo backfills; wire handlers into the route; structured logs avoid secrets.
  - Queue/GitHub: add `fetchPullRequest`; expose `buildPrMatchJobId` and `buildRepoBackfillJobId`; duplicate PR replays coalesce by `(organizationId, externalKey)`.

- **Bug Fixes**
  - Validate backfill selections and ownership: reject contradictory or empty input and foreign repos; distinguish empty selection from no configured repos.
  - Preserve partial backfill results (`207` with `partial: true`) and emit `developer_action.partially_accepted`.
  - Classify total backfill enqueue failures as `ACTION_FAILED`.

<sup>Written for commit bcf8834ec8a88367ff8efc6be119c2ccdba2b382. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added GitHub developer actions for replaying pull requests and backfilling repository data.
  - Supports processing all repositories or selected repositories, with duplicate selections removed.
  - Added validation to confirm repositories and pull requests are eligible before processing.
  - Actions now report queued job identifiers and distinguish fully accepted from partially accepted requests.

- **Bug Fixes**
  - Improved handling of missing targets, invalid repository selections, duplicate requests, and partial processing failures.
  - Added safeguards to prevent integration identifiers from being submitted as action targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->