### PR TITLE
feat(web): move developer tools into Command K

### DIFF
--- a/apps/api/src/lib/developer-action-dispatch.test.ts
+++ b/apps/api/src/lib/developer-action-dispatch.test.ts
@@ -59,13 +59,24 @@ const dbWithIntegrations = (integrations: Record<string, unknown>) => {
           const entity = integrations.externalEntity as
             | Record<string, unknown>
             | undefined;
-          return entity?.id === where.id ? { externalEntity: entity } : {};
+          const matches =
+            entity &&
+            Object.entries(where).every(
+              ([key, value]) => entity[key] === value
+            );
+          return matches ? { externalEntity: entity } : {};
         }
 
         return Object.fromEntries(
-          Object.entries(integrations).filter(
-            ([key]) => key !== "externalEntity"
-          )
+          Object.entries(integrations).filter(([key, value]) => {
+            if (key === "externalEntity") {
+              return false;
+            }
+            return Object.entries(where).every(
+              ([whereKey, whereValue]) =>
+                (value as Record<string, unknown>)[whereKey] === whereValue
+            );
+          })
         );
       }
     );
@@ -139,6 +150,7 @@ describe("developer-action transport", () => {
   it("resolves the org integration and returns a safe accepted result", async () => {
     const { db, find } = dbWithIntegrations({
       externalEntity: {
+        deletedAt: null,
         externalKey: "github:owner/repo#123",
         id: "entity-a",
         number: 123,
@@ -223,6 +235,42 @@ describe("developer-action transport", () => {
     ).rejects.toMatchObject<DeveloperActionError>({
       code: "INVALID_DEVELOPER_ACTION_TARGET",
     });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not resolve a mirrored target from another organization", async () => {
+    const { db, find } = dbWithIntegrations({
+      externalEntity: {
+        deletedAt: null,
+        externalKey: "github:owner/repo#123",
+        id: "entity-a",
+        number: 123,
+        organizationId: "org-b",
+        provider: "github",
+        repoFullName: "owner/repo",
+        type: "pull_request",
+        url: "https://github.com/owner/repo/pull/123",
+      },
+      integration: {
+        configStr: "{}",
+        enabled: true,
+        id: "integration-a",
+        organizationId,
+        type: "github",
+      },
+    });
+    const fetchMock = vi.fn<() => void>();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      dispatchDeveloperAction(db, {
+        ...actionInput(),
+        payload: { entityId: "entity-a" },
+      })
+    ).rejects.toMatchObject<DeveloperActionError>({
+      code: "INVALID_DEVELOPER_ACTION_TARGET",
+    });
+    expect(find).toHaveBeenCalledTimes(2);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -358,6 +406,7 @@ describe("developer-action transport", () => {
   it("normalizes connector rejection and does not expose its response body", async () => {
     const { db } = dbWithIntegrations({
       externalEntity: {
+        deletedAt: null,
         externalKey: "github:owner/repo#123",
         id: "entity-a",
         number: 123,

--- a/apps/web/src/components/command-menu.tsx
+++ b/apps/web/src/components/command-menu.tsx
@@ -12,16 +12,18 @@ import {
   CommandTrail,
 } from "@workspace/ui/components/command";
 import { Keybind } from "@workspace/ui/components/keybind";
+import { useAtom } from "jotai/react";
 import { Check, ChevronRight } from "lucide-react";
 import { motion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
 import { useCommandMenu } from "~/lib/commands/hooks";
+import { commandMenuOpenAtom } from "~/lib/commands/registry";
 import type { Command, DirectCommand, PageCommand } from "~/lib/commands/types";
 
 export const CommandMenu = () => {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useAtom(commandMenuOpenAtom);
   const [animationKey, setAnimationKey] = useState(0);
   const prevPageIdRef = useRef<string | null>(null);
   const {
@@ -80,7 +82,9 @@ export const CommandMenu = () => {
       setSearch("");
     } else {
       (command as DirectCommand).onSelect();
-      setOpen(false);
+      if (!command.keepOpen) {
+        setOpen(false);
+      }
     }
   };
 

--- a/apps/web/src/components/command-menu.tsx
+++ b/apps/web/src/components/command-menu.tsx
@@ -68,6 +68,12 @@ export const CommandMenu = () => {
     }
   }, [open, resetNavigation, setSearch]);
 
+  useEffect(() => {
+    return () => {
+      setOpen(false);
+    };
+  }, [setOpen]);
+
   // Trigger animation on navigation
   useEffect(() => {
     if (prevPageIdRef.current !== currentPageId && open) {

--- a/apps/web/src/components/devtools/developer-commands.tsx
+++ b/apps/web/src/components/devtools/developer-commands.tsx
@@ -1,0 +1,563 @@
+"use client";
+
+import { useLiveQuery } from "@live-state/sync/client";
+import { useNavigate } from "@tanstack/react-router";
+import { githubIntegrationSchema } from "@workspace/schemas/integration/github";
+import {
+  Archive,
+  Bug,
+  EyeOff,
+  Flag,
+  GitPullRequest,
+  Github,
+  ListRestart,
+  RefreshCw,
+  ScanSearch,
+  Terminal,
+  Wrench,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import { useCommand, useCommandPage } from "~/lib/commands/hooks";
+import type { Command, CommandPage } from "~/lib/commands/types";
+import { reflagClient } from "~/lib/feature-flag";
+import { fetchClient, query } from "~/lib/live-state";
+import { buildThreadParam } from "~/utils/thread";
+
+import { CreateThreadDialog } from "./devtools-menu/create-thread-dialog";
+import { duplicateThreadFromParam } from "./devtools-menu/duplicate-thread-command";
+import type { DuplicatedThread } from "./devtools-menu/duplicate-thread-command";
+import { useThreadRouteRawParam } from "./devtools-menu/thread-route-for-devtools";
+import { useReactScanEnabled } from "./react-scan";
+
+const DEVELOPER_TOOLS_PAGE_ID = "developer-tools";
+const DEVELOPER_THREADS_PAGE_ID = "developer-tools.threads";
+const DEVELOPER_GITHUB_PAGE_ID = "developer-tools.github";
+const DEVELOPER_GITHUB_PR_PAGE_ID = "developer-tools.github.prs";
+const DEVELOPER_GITHUB_BACKFILL_PAGE_ID = "developer-tools.github.backfill";
+const DEVELOPER_SIGNALS_PAGE_ID = "developer-tools.signals";
+const DEVELOPER_FLAGS_PAGE_ID = "developer-tools.flags";
+
+interface DeveloperToolsCommandsProps {
+  onHideToolbar: (mode: "temporary" | "section") => void;
+  onOpenLiveStateLog: () => void;
+  organizationId: string;
+}
+
+interface GithubRepo {
+  fullName: string;
+  name: string;
+  owner: string;
+}
+
+interface FlagState {
+  flagKey: string;
+  isEnabled: boolean;
+}
+
+export const DeveloperToolsCommands = ({
+  onHideToolbar,
+  onOpenLiveStateLog,
+  organizationId,
+}: DeveloperToolsCommandsProps) => {
+  const navigate = useNavigate();
+  const rawThreadParam = useThreadRouteRawParam();
+  const [createThreadOpen, setCreateThreadOpen] = useState(false);
+  const [reactScanEnabled, setReactScanEnabled] = useReactScanEnabled();
+  const [selectedRepositories, setSelectedRepositories] = useState<string[]>(
+    []
+  );
+  const [flags, setFlags] = useState<Record<string, FlagState>>({});
+  const [flagsLoading, setFlagsLoading] = useState(import.meta.env.DEV);
+
+  const githubIntegration = useLiveQuery(
+    query.integration.first({
+      enabled: true,
+      organizationId,
+      type: "github",
+    })
+  );
+
+  const mirroredPullRequests = useLiveQuery(
+    query.externalEntity.where({
+      deletedAt: null,
+      organizationId,
+      type: "pull_request",
+    })
+  );
+
+  const githubRepos = useMemo<GithubRepo[]>(() => {
+    if (!githubIntegration?.configStr) {
+      return [];
+    }
+
+    try {
+      const parsed = githubIntegrationSchema.safeParse(
+        JSON.parse(githubIntegration.configStr)
+      );
+      if (!parsed.success) {
+        return [];
+      }
+
+      return [...(parsed.data.repos ?? [])].toSorted((a, b) =>
+        a.fullName.localeCompare(b.fullName)
+      );
+    } catch {
+      return [];
+    }
+  }, [githubIntegration?.configStr]);
+
+  const eligiblePullRequests = useMemo(
+    () =>
+      (mirroredPullRequests ?? [])
+        .filter((pullRequest) => {
+          return pullRequest.state === "open" && pullRequest.draft !== true;
+        })
+        .toSorted((a, b) => {
+          const repositoryOrder = a.repoFullName.localeCompare(b.repoFullName);
+          return repositoryOrder || a.number - b.number;
+        }),
+    [mirroredPullRequests]
+  );
+
+  const selectedRepositorySet = useMemo(
+    () => new Set(selectedRepositories),
+    [selectedRepositories]
+  );
+
+  const loadFlags = useCallback(() => {
+    if (!import.meta.env.DEV) {
+      setFlagsLoading(false);
+      return;
+    }
+
+    try {
+      const flagsState: Record<string, FlagState> = {};
+      for (const [flagKey, flag] of Object.entries(reflagClient.getFlags())) {
+        flagsState[flagKey] = {
+          flagKey,
+          isEnabled: (flag.isEnabled || flag.isEnabledOverride) ?? false,
+        };
+      }
+      setFlags(flagsState);
+    } catch (error) {
+      console.error("Failed to load feature flags:", error);
+    } finally {
+      setFlagsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) {
+      return;
+    }
+
+    loadFlags();
+    const unsubscribeFlagsUpdated = reflagClient.on("flagsUpdated", loadFlags);
+    const unsubscribeStateUpdated = reflagClient.on("stateUpdated", loadFlags);
+
+    return () => {
+      if (typeof unsubscribeFlagsUpdated === "function") {
+        unsubscribeFlagsUpdated();
+      }
+      if (typeof unsubscribeStateUpdated === "function") {
+        unsubscribeStateUpdated();
+      }
+    };
+  }, [loadFlags]);
+
+  useEffect(() => {
+    setSelectedRepositories([]);
+  }, [organizationId]);
+
+  const invokeGithubAction = useCallback(
+    async ({
+      action,
+      payload,
+      successMessage,
+    }: {
+      action: "pr_match_replay" | "repository_backfill";
+      payload: Record<string, unknown>;
+      successMessage: string;
+    }) => {
+      try {
+        const result = await fetchClient.mutate.developerAction.invoke({
+          action,
+          connectorType: "github",
+          organizationId,
+          payload,
+        });
+
+        console.info("[Developer tools] GitHub action accepted", {
+          action,
+          jobIds: result.jobIds,
+          organizationId,
+          target: result.target,
+        });
+        toast.success(successMessage);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : "unknown";
+        console.error("[Developer tools] GitHub action failed", {
+          action,
+          error: errorMessage,
+          organizationId,
+        });
+        toast.error("GitHub developer action failed");
+      }
+    },
+    [organizationId]
+  );
+
+  const handleDuplicateThread = useCallback(() => {
+    void duplicateThreadFromParam({
+      activeOrganizationId: organizationId,
+      onSuccess: (thread: DuplicatedThread) => {
+        navigate({
+          params: { id: buildThreadParam(thread) },
+          to: "/app/threads/$id",
+        });
+      },
+      rawParam: rawThreadParam,
+    });
+  }, [navigate, organizationId, rawThreadParam]);
+
+  const threadsPage: CommandPage = {
+    commands: [
+      {
+        icon: <Terminal />,
+        id: "developer-tools.create-thread",
+        label: "Create thread",
+        onSelect: () => setCreateThreadOpen(true),
+      },
+      {
+        disabled: !rawThreadParam,
+        icon: <Archive />,
+        id: "developer-tools.duplicate-thread",
+        label: "Duplicate current thread",
+        onSelect: handleDuplicateThread,
+      },
+    ],
+    icon: <Terminal />,
+    id: DEVELOPER_THREADS_PAGE_ID,
+    label: "Threads",
+  };
+
+  const githubPrPage: CommandPage = {
+    commands:
+      eligiblePullRequests.length > 0
+        ? eligiblePullRequests.map((pullRequest) => ({
+            group: pullRequest.repoFullName,
+            icon: <GitPullRequest />,
+            id: `developer-tools.github.replay.${pullRequest.id}`,
+            keywords: [
+              "github",
+              "replay",
+              pullRequest.repoFullName,
+              `#${pullRequest.number}`,
+            ],
+            label: `#${pullRequest.number} ${pullRequest.title || "Untitled pull request"}`,
+            onSelect: () => {
+              void invokeGithubAction({
+                action: "pr_match_replay",
+                payload: { entityId: pullRequest.id },
+                successMessage: `Accepted replay for ${pullRequest.repoFullName}#${pullRequest.number}`,
+              });
+            },
+          }))
+        : [
+            {
+              disabled: true,
+              icon: <GitPullRequest />,
+              id: "developer-tools.github.replay.empty",
+              label: "No eligible open, non-draft mirrored pull requests",
+              onSelect: () => undefined,
+            },
+          ],
+    icon: <GitPullRequest />,
+    id: DEVELOPER_GITHUB_PR_PAGE_ID,
+    label: "Replay GitHub PR match",
+  };
+
+  const githubBackfillPage: CommandPage = {
+    commands:
+      githubRepos.length > 0
+        ? [
+            {
+              disabled: selectedRepositories.length === 0,
+              icon: <RefreshCw />,
+              id: "developer-tools.github.backfill.selected",
+              label: `Run selected backfill (${selectedRepositories.length})`,
+              onSelect: () => {
+                const repositories = [...selectedRepositories].toSorted();
+                void invokeGithubAction({
+                  action: "repository_backfill",
+                  payload: { allRepositories: false, repositories },
+                  successMessage: `Accepted backfill for ${repositories.length} repositor${repositories.length === 1 ? "y" : "ies"}`,
+                });
+                setSelectedRepositories([]);
+              },
+            },
+            {
+              icon: <ListRestart />,
+              id: "developer-tools.github.backfill.all",
+              label: "Backfill all repositories",
+              onSelect: () => {
+                void invokeGithubAction({
+                  action: "repository_backfill",
+                  payload: { allRepositories: true },
+                  successMessage: "Accepted backfill for all repositories",
+                });
+              },
+            },
+            ...githubRepos.map((repo) => ({
+              checked: selectedRepositorySet.has(repo.fullName),
+              group: "Select repositories",
+              icon: <Github />,
+              id: `developer-tools.github.backfill.${repo.fullName}`,
+              keywords: ["github", "backfill", repo.owner, repo.name],
+              keepOpen: true,
+              label: repo.fullName,
+              onSelect: () => {
+                setSelectedRepositories((current) =>
+                  current.includes(repo.fullName)
+                    ? current.filter((fullName) => fullName !== repo.fullName)
+                    : [...current, repo.fullName]
+                );
+              },
+            })),
+          ]
+        : [
+            {
+              disabled: true,
+              icon: <Github />,
+              id: "developer-tools.github.backfill.empty",
+              label: "No connected GitHub repositories",
+              onSelect: () => undefined,
+            },
+          ],
+    icon: <RefreshCw />,
+    id: DEVELOPER_GITHUB_BACKFILL_PAGE_ID,
+    label: "Backfill GitHub repositories",
+  };
+
+  const githubPage: CommandPage = {
+    commands: [
+      {
+        icon: <GitPullRequest />,
+        id: "developer-tools.github.replay",
+        label: "Replay GitHub PR match...",
+        pageId: DEVELOPER_GITHUB_PR_PAGE_ID,
+      },
+      {
+        icon: <RefreshCw />,
+        id: "developer-tools.github.backfill",
+        label: "Backfill GitHub repositories...",
+        pageId: DEVELOPER_GITHUB_BACKFILL_PAGE_ID,
+      },
+    ],
+    icon: <Github />,
+    id: DEVELOPER_GITHUB_PAGE_ID,
+    label: "GitHub",
+  };
+
+  const signalsPage: CommandPage = {
+    commands: import.meta.env.DEV
+      ? [
+          {
+            icon: <Bug />,
+            id: "developer-tools.signals.seed",
+            label: "Seed leverage actions",
+            onSelect: async () => {
+              try {
+                const result =
+                  await fetchClient.mutate.autonomousAction.seedFake({
+                    count: 8,
+                    organizationId,
+                  });
+                toast.success(`Seeded ${result.inserted} autonomous actions`);
+              } catch (error) {
+                console.error("Failed to seed autonomous actions:", error);
+                toast.error("Failed to seed autonomous actions");
+              }
+            },
+          },
+          {
+            icon: <Bug />,
+            id: "developer-tools.signals.clear",
+            label: "Clear leverage actions",
+            onSelect: async () => {
+              try {
+                const result =
+                  await fetchClient.mutate.autonomousAction.clearFake({
+                    organizationId,
+                  });
+                toast.success(`Cleared ${result.cleared} autonomous actions`);
+              } catch (error) {
+                console.error("Failed to clear autonomous actions:", error);
+                toast.error("Failed to clear autonomous actions");
+              }
+            },
+          },
+        ]
+      : [],
+    icon: <Bug />,
+    id: DEVELOPER_SIGNALS_PAGE_ID,
+    label: "Signals (local only)",
+  };
+
+  const flagCommands: Command[] = flagsLoading
+    ? [
+        {
+          disabled: true,
+          icon: <Flag />,
+          id: "developer-tools.flags.loading",
+          label: "Loading feature flags...",
+          onSelect: () => undefined,
+        },
+      ]
+    : Object.values(flags)
+        .toSorted((a, b) => a.flagKey.localeCompare(b.flagKey))
+        .map((flag) => ({
+          checked: flag.isEnabled,
+          icon: <Flag />,
+          id: `developer-tools.flags.${flag.flagKey}`,
+          keepOpen: true,
+          label: flag.flagKey,
+          onSelect: () => {
+            try {
+              reflagClient
+                .getFlag(flag.flagKey)
+                .setIsEnabledOverride(!flag.isEnabled);
+              loadFlags();
+            } catch (error) {
+              console.error(
+                `Failed to toggle feature flag ${flag.flagKey}:`,
+                error
+              );
+              toast.error("Failed to toggle feature flag");
+            }
+          },
+        }));
+
+  const flagsPage: CommandPage = {
+    commands:
+      flagCommands.length > 0
+        ? flagCommands
+        : [
+            {
+              disabled: true,
+              icon: <Flag />,
+              id: "developer-tools.flags.empty",
+              label: "No feature flags available",
+              onSelect: () => undefined,
+            },
+          ],
+    icon: <Flag />,
+    id: DEVELOPER_FLAGS_PAGE_ID,
+    label: "Feature flags (local only)",
+  };
+
+  const developerToolsPage: CommandPage = {
+    commands: [
+      {
+        icon: <Terminal />,
+        id: "developer-tools.threads",
+        label: "Threads...",
+        pageId: DEVELOPER_THREADS_PAGE_ID,
+      },
+      {
+        icon: <Github />,
+        id: "developer-tools.github",
+        label: "GitHub...",
+        pageId: DEVELOPER_GITHUB_PAGE_ID,
+      },
+      ...(import.meta.env.DEV
+        ? [
+            {
+              icon: <Bug />,
+              id: "developer-tools.signals",
+              label: "Signals...",
+              pageId: DEVELOPER_SIGNALS_PAGE_ID,
+            } satisfies Command,
+            {
+              icon: <Flag />,
+              id: "developer-tools.flags",
+              label: "Feature flags...",
+              pageId: DEVELOPER_FLAGS_PAGE_ID,
+            } satisfies Command,
+          ]
+        : []),
+      {
+        icon: <EyeOff />,
+        id: "developer-tools.hide-toolbar",
+        label: "Hide toolbar temporarily",
+        onSelect: () => onHideToolbar("temporary"),
+      },
+      {
+        icon: <EyeOff />,
+        id: "developer-tools.hide-toolbar-section",
+        label: "Hide toolbar for this section",
+        onSelect: () => onHideToolbar("section"),
+      },
+      {
+        icon: <ListRestart />,
+        id: "developer-tools.live-state-log",
+        label: "Open live-state log",
+        onSelect: onOpenLiveStateLog,
+      },
+      {
+        checked: reactScanEnabled,
+        icon: <ScanSearch />,
+        id: "developer-tools.react-scan",
+        keepOpen: true,
+        label: "React Scan",
+        onSelect: () => setReactScanEnabled(!reactScanEnabled),
+      },
+    ],
+    icon: <Wrench />,
+    id: DEVELOPER_TOOLS_PAGE_ID,
+    label: "Developer tools",
+  };
+
+  useCommandPage(() => threadsPage, [handleDuplicateThread, rawThreadParam]);
+  useCommandPage(
+    () => githubPrPage,
+    [eligiblePullRequests, invokeGithubAction]
+  );
+  useCommandPage(
+    () => githubBackfillPage,
+    [
+      githubRepos,
+      selectedRepositories,
+      selectedRepositorySet,
+      invokeGithubAction,
+    ]
+  );
+  useCommandPage(() => githubPage, []);
+  useCommandPage(() => signalsPage, [organizationId]);
+  useCommandPage(() => flagsPage, [flags, flagsLoading, loadFlags]);
+  useCommandPage(
+    () => developerToolsPage,
+    [onHideToolbar, onOpenLiveStateLog, reactScanEnabled]
+  );
+
+  useCommand(
+    () => ({
+      group: "Developer",
+      icon: <Wrench />,
+      id: "developer-tools.open",
+      keywords: ["devtools", "developer", "command k"],
+      label: "Developer tools...",
+      pageId: DEVELOPER_TOOLS_PAGE_ID,
+    }),
+    []
+  );
+
+  return (
+    <CreateThreadDialog
+      open={createThreadOpen}
+      onOpenChange={setCreateThreadOpen}
+    />
+  );
+};

--- a/apps/web/src/components/devtools/developer-commands.tsx
+++ b/apps/web/src/components/devtools/developer-commands.tsx
@@ -134,7 +134,7 @@ export const DeveloperToolsCommands = ({
       for (const [flagKey, flag] of Object.entries(reflagClient.getFlags())) {
         flagsState[flagKey] = {
           flagKey,
-          isEnabled: (flag.isEnabled || flag.isEnabledOverride) ?? false,
+          isEnabled: flag.isEnabledOverride ?? flag.isEnabled ?? false,
         };
       }
       setFlags(flagsState);

--- a/apps/web/src/components/devtools/developer-commands.tsx
+++ b/apps/web/src/components/devtools/developer-commands.tsx
@@ -21,6 +21,11 @@ import { toast } from "sonner";
 
 import { useCommand, useCommandPage } from "~/lib/commands/hooks";
 import type { Command, CommandPage } from "~/lib/commands/types";
+import {
+  buildRepositoryBackfillPayload,
+  getEligibleDeveloperPullRequests,
+  toggleRepositorySelection,
+} from "~/lib/developer-tools/github-selection";
 import { reflagClient } from "~/lib/feature-flag";
 import { fetchClient, query } from "~/lib/live-state";
 import { buildThreadParam } from "~/utils/thread";
@@ -109,15 +114,7 @@ export const DeveloperToolsCommands = ({
   }, [githubIntegration?.configStr]);
 
   const eligiblePullRequests = useMemo(
-    () =>
-      (mirroredPullRequests ?? [])
-        .filter((pullRequest) => {
-          return pullRequest.state === "open" && pullRequest.draft !== true;
-        })
-        .toSorted((a, b) => {
-          const repositoryOrder = a.repoFullName.localeCompare(b.repoFullName);
-          return repositoryOrder || a.number - b.number;
-        }),
+    () => getEligibleDeveloperPullRequests(mirroredPullRequests ?? []),
     [mirroredPullRequests]
   );
 
@@ -289,11 +286,17 @@ export const DeveloperToolsCommands = ({
               id: "developer-tools.github.backfill.selected",
               label: `Run selected backfill (${selectedRepositories.length})`,
               onSelect: () => {
-                const repositories = [...selectedRepositories].toSorted();
+                const payload = buildRepositoryBackfillPayload({
+                  allRepositories: false,
+                  selectedRepositories,
+                });
+                if (payload.allRepositories) {
+                  return;
+                }
                 void invokeGithubAction({
                   action: "repository_backfill",
-                  payload: { allRepositories: false, repositories },
-                  successMessage: `Accepted backfill for ${repositories.length} repositor${repositories.length === 1 ? "y" : "ies"}`,
+                  payload,
+                  successMessage: `Accepted backfill for ${payload.repositories.length} repositor${payload.repositories.length === 1 ? "y" : "ies"}`,
                 });
                 setSelectedRepositories([]);
               },
@@ -320,9 +323,7 @@ export const DeveloperToolsCommands = ({
               label: repo.fullName,
               onSelect: () => {
                 setSelectedRepositories((current) =>
-                  current.includes(repo.fullName)
-                    ? current.filter((fullName) => fullName !== repo.fullName)
-                    : [...current, repo.fullName]
+                  toggleRepositorySelection(current, repo.fullName)
                 );
               },
             })),

--- a/apps/web/src/components/devtools/devtools-menu/duplicate-thread-command.tsx
+++ b/apps/web/src/components/devtools/devtools-menu/duplicate-thread-command.tsx
@@ -21,6 +21,79 @@ const parseThreadMessage = (content: string | undefined) => {
   }
 };
 
+export type DuplicatedThread = Awaited<
+  ReturnType<typeof fetchClient.mutate.thread.create>
+>;
+
+export const duplicateThreadFromParam = async ({
+  activeOrganizationId,
+  onSuccess,
+  rawParam,
+}: {
+  activeOrganizationId?: string;
+  onSuccess?: (thread: DuplicatedThread) => void;
+  rawParam: string | null;
+}): Promise<void> => {
+  if (!rawParam) {
+    toast.error("Open a thread first to duplicate it");
+    return;
+  }
+
+  const parsed = parseThreadParam(rawParam);
+  if (!parsed) {
+    toast.error("Invalid thread");
+    return;
+  }
+
+  try {
+    let where: { id: string } | { shortId: number; organizationId: string };
+    if (parsed.kind === "ulid") {
+      where = { id: parsed.id };
+    } else {
+      if (!activeOrganizationId) {
+        toast.error("No active organization");
+        return;
+      }
+      where = { organizationId: activeOrganizationId, shortId: parsed.shortId };
+    }
+    const thread = await fetchClient.query.thread.detail(where);
+
+    if (!thread) {
+      toast.error("Thread not found");
+      return;
+    }
+
+    const messages = thread.messages ?? [];
+    const sortedMessages = [...messages].toSorted(
+      (a, b) =>
+        new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+    );
+    const firstMessage = sortedMessages[0];
+
+    const authorName = thread.author?.name ?? "Unknown";
+    const authorMetaId =
+      thread.author?.metaId ??
+      thread.author?.userId ??
+      `duplicate-${thread.authorId}`;
+
+    const newThread = await fetchClient.mutate.thread.create({
+      author: {
+        id: authorMetaId,
+        name: authorName,
+      },
+      message: parseThreadMessage(firstMessage?.content),
+      organizationId: thread.organizationId,
+      title: thread.name,
+    });
+
+    toast.success("Thread duplicated");
+    onSuccess?.(newThread);
+  } catch (error) {
+    console.error("Failed to duplicate thread:", error);
+    toast.error("Failed to duplicate thread");
+  }
+};
+
 export const DuplicateThreadMenuItem = () => {
   const navigate = useNavigate();
   const { id: rawParam } = (() => {
@@ -31,70 +104,17 @@ export const DuplicateThreadMenuItem = () => {
     }
   })();
 
-  const handleDuplicateThread = async () => {
-    if (!rawParam) {
-      toast.error("Open a thread first to duplicate it");
-      return;
-    }
-
-    const parsed = parseThreadParam(rawParam);
-    if (!parsed) {
-      toast.error("Invalid thread");
-      return;
-    }
-
-    try {
-      let where: { id: string } | { shortId: number; organizationId: string };
-      if (parsed.kind === "ulid") {
-        where = { id: parsed.id };
-      } else {
-        const activeOrgId = getDefaultStore().get(activeOrganizationAtom)?.id;
-        if (!activeOrgId) {
-          toast.error("No active organization");
-          return;
-        }
-        where = { organizationId: activeOrgId, shortId: parsed.shortId };
-      }
-      const thread = await fetchClient.query.thread.detail(where);
-
-      if (!thread) {
-        toast.error("Thread not found");
-        return;
-      }
-
-      const messages = thread.messages ?? [];
-      const sortedMessages = [...messages].toSorted(
-        (a, b) =>
-          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-      );
-      const firstMessage = sortedMessages[0];
-
-      const authorName = thread.author?.name ?? "Unknown";
-      const authorMetaId =
-        thread.author?.metaId ??
-        thread.author?.userId ??
-        `duplicate-${thread.authorId}`;
-
-      const newThread = await fetchClient.mutate.thread.create({
-        author: {
-          id: authorMetaId,
-          name: authorName,
-        },
-        message: parseThreadMessage(firstMessage?.content),
-        organizationId: thread.organizationId,
-        title: thread.name,
-      });
-
-      toast.success("Thread duplicated");
-      navigate({
-        params: { id: buildThreadParam(newThread) },
-        to: "/app/threads/$id",
-      });
-    } catch (error) {
-      console.error("Failed to duplicate thread:", error);
-      toast.error("Failed to duplicate thread");
-    }
-  };
+  const handleDuplicateThread = () =>
+    duplicateThreadFromParam({
+      activeOrganizationId: getDefaultStore().get(activeOrganizationAtom)?.id,
+      onSuccess: (thread) => {
+        navigate({
+          params: { id: buildThreadParam(thread) },
+          to: "/app/threads/$id",
+        });
+      },
+      rawParam,
+    });
 
   return (
     <MenuItem

--- a/apps/web/src/components/devtools/live-state-log.tsx
+++ b/apps/web/src/components/devtools/live-state-log.tsx
@@ -38,9 +38,19 @@ interface EventLogEntry {
   data?: unknown;
 }
 
-export const LiveStateLog = () => {
+interface LiveStateLogProps {
+  onOpenChange?: (open: boolean) => void;
+  open?: boolean;
+}
+
+export const LiveStateLog = ({
+  onOpenChange,
+  open: controlledOpen,
+}: LiveStateLogProps = {}) => {
   const [events, setEvents] = useState<EventLogEntry[]>([]);
-  const [isOpen, setIsOpen] = useState(false);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const isOpen = controlledOpen ?? uncontrolledOpen;
+  const setIsOpen = onOpenChange ?? setUncontrolledOpen;
   const [expandedEvents, setExpandedEvents] = useState<Set<string>>(new Set());
   const parentRef = useRef<HTMLDivElement>(null);
   const eventIdRef = useRef(0);

--- a/apps/web/src/components/devtools/toolbar.tsx
+++ b/apps/web/src/components/devtools/toolbar.tsx
@@ -1,17 +1,37 @@
 "use client";
 
+import { getRouteApi } from "@tanstack/react-router";
+import { Button } from "@workspace/ui/components/button";
+import { useAtomValue, useSetAtom } from "jotai/react";
+import { Command as CommandIcon } from "lucide-react";
 import { useState } from "react";
 
-import { DevtoolsMenu } from "./devtools-menu/devtools-menu";
+import { activeOrganizationAtom } from "~/lib/atoms";
+import { commandMenuOpenAtom } from "~/lib/commands/registry";
+import { hasDeveloperToolAccess } from "~/lib/developer-tools/access";
+import { useOrganizationSwitcher } from "~/lib/hooks/query/use-organization-switcher";
+
+import { DeveloperToolsCommands } from "./developer-commands";
 import { FpsMeter } from "./fps-meter";
 import { LiveStateLog } from "./live-state-log";
 import { ReactScan } from "./react-scan";
-import { ReflagFlagsMenu } from "./reflag-flags-menu";
 
 type HideMode = "temporary" | "section" | null;
 
 export const Toolbar = () => {
   const [hideMode, setHideMode] = useState<HideMode>(null);
+  const [liveStateLogOpen, setLiveStateLogOpen] = useState(false);
+  const setCommandMenuOpen = useSetAtom(commandMenuOpenAtom);
+  const currentOrganization = useAtomValue(activeOrganizationAtom);
+  const { organizationUsers } = useOrganizationSwitcher();
+  const { user } = getRouteApi("/app").useRouteContext();
+
+  const hasAccess = hasDeveloperToolAccess({
+    isDevelopment: import.meta.env.DEV,
+    organizationId: currentOrganization?.id,
+    organizationUsers,
+    user,
+  });
 
   const handleHideToolbar = (mode: "temporary" | "section") => {
     setHideMode(mode);
@@ -21,7 +41,7 @@ export const Toolbar = () => {
     setHideMode(null);
   };
 
-  if (hideMode === "section") {
+  if (!hasAccess || hideMode === "section") {
     return null;
   }
 
@@ -43,12 +63,27 @@ export const Toolbar = () => {
       <div className="w-screen h-6 bg-background-secondary border-t shrink-0 flex font-mono text-xs gap-2 items-center px-8 z-10">
         <FpsMeter />
         <div className="bg-border w-px h-4" />
-        <DevtoolsMenu onHideToolbar={handleHideToolbar} />
+        <Button
+          aria-label="Open developer tools command menu"
+          className="h-5 px-2 rounded-sm font-mono text-xs"
+          onClick={() => setCommandMenuOpen(true)}
+          size="sm"
+          variant="ghost"
+        >
+          <CommandIcon />
+          Command K
+        </Button>
         <div className="bg-border w-px h-4" />
-        <ReflagFlagsMenu />
-        <div className="bg-border w-px h-4" />
-        <LiveStateLog />
+        <LiveStateLog
+          onOpenChange={setLiveStateLogOpen}
+          open={liveStateLogOpen}
+        />
       </div>
+      <DeveloperToolsCommands
+        onHideToolbar={handleHideToolbar}
+        onOpenLiveStateLog={() => setLiveStateLogOpen(true)}
+        organizationId={currentOrganization?.id ?? ""}
+      />
       <ReactScan />
     </>
   );

--- a/apps/web/src/components/devtools/toolbar.tsx
+++ b/apps/web/src/components/devtools/toolbar.tsx
@@ -23,12 +23,13 @@ export const Toolbar = () => {
   const [liveStateLogOpen, setLiveStateLogOpen] = useState(false);
   const setCommandMenuOpen = useSetAtom(commandMenuOpenAtom);
   const currentOrganization = useAtomValue(activeOrganizationAtom);
+  const organizationId = currentOrganization?.id;
   const { organizationUsers } = useOrganizationSwitcher();
   const { user } = getRouteApi("/app").useRouteContext();
 
   const hasAccess = hasDeveloperToolAccess({
     isDevelopment: import.meta.env.DEV,
-    organizationId: currentOrganization?.id,
+    organizationId,
     organizationUsers,
     user,
   });
@@ -41,7 +42,7 @@ export const Toolbar = () => {
     setHideMode(null);
   };
 
-  if (!hasAccess || hideMode === "section") {
+  if (!hasAccess || !organizationId || hideMode === "section") {
     return null;
   }
 
@@ -82,7 +83,7 @@ export const Toolbar = () => {
       <DeveloperToolsCommands
         onHideToolbar={handleHideToolbar}
         onOpenLiveStateLog={() => setLiveStateLogOpen(true)}
-        organizationId={currentOrganization?.id ?? ""}
+        organizationId={organizationId}
       />
       <ReactScan />
     </>

--- a/apps/web/src/lib/commands/registry.ts
+++ b/apps/web/src/lib/commands/registry.ts
@@ -21,6 +21,7 @@ const initialState: CommandRegistryState = {
 };
 
 export const commandRegistryAtom = atom<CommandRegistryState>(initialState);
+export const commandMenuOpenAtom = atom(false);
 
 export const commandRegistryActions = {
   getAvailableCommands: (state: CommandRegistryState): Command[] => {

--- a/apps/web/src/lib/commands/types.ts
+++ b/apps/web/src/lib/commands/types.ts
@@ -12,6 +12,8 @@ interface BaseCommand {
   shortcut?: string;
   contextId?: ContextId; // If set, only shows in this context
   disabled?: boolean;
+  /** Keep the palette open after selecting this command (e.g. multi-select). */
+  keepOpen?: boolean;
   group?: string; // Optional group label for organizing commands
   visible?: boolean | ((state: CommandRegistryState) => boolean);
   checked?: boolean;

--- a/apps/web/src/lib/developer-tools/access.test.ts
+++ b/apps/web/src/lib/developer-tools/access.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { hasDeveloperToolAccess, isInternalDeveloperEmail } from "./access";
+
+const organizationUsers = [{ organizationId: "org-a" }];
+
+describe("developer tool visibility", () => {
+  it("matches the production internal mailbox predicate", () => {
+    expect(isInternalDeveloperEmail("dev@tryfrontdesk.app")).toBeTruthy();
+    expect(isInternalDeveloperEmail("DEV@TRYFRONTDESK.APP")).toBeTruthy();
+    expect(isInternalDeveloperEmail("dev@tryfrontdesk.app.evil")).toBeFalsy();
+    expect(isInternalDeveloperEmail("dev@@tryfrontdesk.app")).toBeFalsy();
+    expect(isInternalDeveloperEmail("dev @tryfrontdesk.app")).toBeFalsy();
+  });
+
+  it.each([
+    [
+      "local authenticated member",
+      { isDevelopment: true, user: { email: "local@example.com" } },
+      true,
+    ],
+    [
+      "verified internal production member",
+      {
+        isDevelopment: false,
+        user: { email: "dev@tryfrontdesk.app", emailVerified: true },
+      },
+      true,
+    ],
+    [
+      "unverified internal production member",
+      {
+        isDevelopment: false,
+        user: { email: "dev@tryfrontdesk.app", emailVerified: false },
+      },
+      false,
+    ],
+    [
+      "external production member",
+      {
+        isDevelopment: false,
+        user: { email: "dev@example.com", emailVerified: true },
+      },
+      false,
+    ],
+    [
+      "non-member internal user",
+      {
+        isDevelopment: false,
+        organizationUsers: [{ organizationId: "org-b" }],
+        user: { email: "dev@tryfrontdesk.app", emailVerified: true },
+      },
+      false,
+    ],
+    ["unauthenticated request", { isDevelopment: false, user: null }, false],
+  ] satisfies readonly [
+    string,
+    {
+      isDevelopment: boolean;
+      organizationUsers?: { organizationId: string }[];
+      user: { email: string; emailVerified?: boolean } | null;
+    },
+    boolean,
+  ][])("returns expected visibility for %s", (_name, input, expected) => {
+    const memberOrganizations =
+      "organizationUsers" in input
+        ? input.organizationUsers
+        : organizationUsers;
+    expect(
+      hasDeveloperToolAccess({
+        organizationId: "org-a",
+        organizationUsers: memberOrganizations,
+        isDevelopment: input.isDevelopment,
+        user: input.user,
+      })
+    ).toBe(expected);
+  });
+});

--- a/apps/web/src/lib/developer-tools/access.test.ts
+++ b/apps/web/src/lib/developer-tools/access.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { hasDeveloperToolAccess, isInternalDeveloperEmail } from "./access";
 
-const organizationUsers = [{ organizationId: "org-a" }];
+const organizationUsers = [{ enabled: true, organizationId: "org-a" }];
 
 describe("developer tool visibility", () => {
   it("matches the production internal mailbox predicate", () => {
@@ -47,7 +47,16 @@ describe("developer tool visibility", () => {
       "non-member internal user",
       {
         isDevelopment: false,
-        organizationUsers: [{ organizationId: "org-b" }],
+        organizationUsers: [{ enabled: true, organizationId: "org-b" }],
+        user: { email: "dev@tryfrontdesk.app", emailVerified: true },
+      },
+      false,
+    ],
+    [
+      "disabled production member",
+      {
+        isDevelopment: false,
+        organizationUsers: [{ enabled: false, organizationId: "org-a" }],
         user: { email: "dev@tryfrontdesk.app", emailVerified: true },
       },
       false,
@@ -57,7 +66,7 @@ describe("developer tool visibility", () => {
     string,
     {
       isDevelopment: boolean;
-      organizationUsers?: { organizationId: string }[];
+      organizationUsers?: { enabled: boolean; organizationId: string }[];
       user: { email: string; emailVerified?: boolean } | null;
     },
     boolean,

--- a/apps/web/src/lib/developer-tools/access.ts
+++ b/apps/web/src/lib/developer-tools/access.ts
@@ -4,6 +4,7 @@ export interface DeveloperToolUser {
 }
 
 export interface DeveloperToolOrganizationUser {
+  enabled: boolean;
   organizationId: string;
 }
 
@@ -45,7 +46,9 @@ export const hasDeveloperToolAccess = ({
   }
 
   const isMember = organizationUsers.some(
-    (organizationUser) => organizationUser.organizationId === organizationId
+    (organizationUser) =>
+      organizationUser.organizationId === organizationId &&
+      organizationUser.enabled
   );
   if (!isMember) {
     return false;

--- a/apps/web/src/lib/developer-tools/access.ts
+++ b/apps/web/src/lib/developer-tools/access.ts
@@ -1,0 +1,58 @@
+export interface DeveloperToolUser {
+  email?: string | null;
+  emailVerified?: boolean;
+}
+
+export interface DeveloperToolOrganizationUser {
+  organizationId: string;
+}
+
+/** Keep the client-side visibility check identical to the server predicate. */
+export const isInternalDeveloperEmail = (email?: string | null): boolean => {
+  if (!email) {
+    return false;
+  }
+
+  const firstAt = email.indexOf("@");
+  const lastAt = email.lastIndexOf("@");
+  if (firstAt <= 0 || firstAt !== lastAt) {
+    return false;
+  }
+
+  const localPart = email.slice(0, firstAt);
+  const domain = email.slice(firstAt + 1);
+  return !/\s/.test(localPart) && domain.toLowerCase() === "tryfrontdesk.app";
+};
+
+/**
+ * UI visibility only. The developer-action API remains the authorization
+ * boundary; this prevents the production toolbar from advertising controls to
+ * users who cannot use them while preserving the broad local workflow.
+ */
+export const hasDeveloperToolAccess = ({
+  isDevelopment,
+  organizationId,
+  organizationUsers,
+  user,
+}: {
+  isDevelopment: boolean;
+  organizationId?: string;
+  organizationUsers: DeveloperToolOrganizationUser[];
+  user: DeveloperToolUser | null | undefined;
+}): boolean => {
+  if (!organizationId) {
+    return false;
+  }
+
+  const isMember = organizationUsers.some(
+    (organizationUser) => organizationUser.organizationId === organizationId
+  );
+  if (!isMember) {
+    return false;
+  }
+
+  return (
+    isDevelopment ||
+    (user?.emailVerified === true && isInternalDeveloperEmail(user.email))
+  );
+};

--- a/apps/web/src/lib/developer-tools/github-selection.test.ts
+++ b/apps/web/src/lib/developer-tools/github-selection.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildRepositoryBackfillPayload,
+  getEligibleDeveloperPullRequests,
+  toggleRepositorySelection,
+} from "./github-selection";
+
+describe("developer GitHub selection", () => {
+  it("keeps only open, non-draft mirrored pull requests in stable order", () => {
+    const eligible = getEligibleDeveloperPullRequests([
+      {
+        draft: false,
+        id: "repo-b-2",
+        number: 2,
+        repoFullName: "owner/beta",
+        state: "open",
+      },
+      {
+        draft: true,
+        id: "repo-a-1",
+        number: 1,
+        repoFullName: "owner/alpha",
+        state: "open",
+      },
+      {
+        draft: false,
+        id: "repo-a-3",
+        number: 3,
+        repoFullName: "owner/alpha",
+        state: "open",
+      },
+      {
+        draft: false,
+        id: "repo-a-4",
+        number: 4,
+        repoFullName: "owner/alpha",
+        state: "closed",
+      },
+    ]);
+
+    expect(eligible.map(({ id }) => id)).toStrictEqual([
+      "repo-a-3",
+      "repo-b-2",
+    ]);
+  });
+
+  it("toggles repository selection without allowing duplicate entries", () => {
+    expect(
+      toggleRepositorySelection(["owner/alpha"], "owner/beta")
+    ).toStrictEqual(["owner/alpha", "owner/beta"]);
+    expect(
+      toggleRepositorySelection(["owner/alpha", "owner/beta"], "owner/alpha")
+    ).toStrictEqual(["owner/beta"]);
+    expect(
+      toggleRepositorySelection(["owner/alpha"], "owner/alpha")
+    ).toStrictEqual([]);
+  });
+
+  it("keeps selected backfills explicit and represents all as a separate choice", () => {
+    expect(
+      buildRepositoryBackfillPayload({
+        allRepositories: false,
+        selectedRepositories: ["owner/beta", "owner/alpha", "owner/beta"],
+      })
+    ).toStrictEqual({
+      allRepositories: false,
+      repositories: ["owner/alpha", "owner/beta"],
+    });
+    expect(
+      buildRepositoryBackfillPayload({
+        allRepositories: true,
+        selectedRepositories: ["owner/alpha"],
+      })
+    ).toStrictEqual({ allRepositories: true });
+  });
+});

--- a/apps/web/src/lib/developer-tools/github-selection.ts
+++ b/apps/web/src/lib/developer-tools/github-selection.ts
@@ -1,0 +1,50 @@
+export interface DeveloperPullRequestCandidate {
+  draft: boolean | null | undefined;
+  id: string;
+  number: number;
+  repoFullName: string;
+  state: string;
+}
+
+export const isEligibleDeveloperPullRequest = ({
+  draft,
+  state,
+}: Pick<DeveloperPullRequestCandidate, "draft" | "state">): boolean =>
+  state === "open" && draft !== true;
+
+export const getEligibleDeveloperPullRequests = <
+  Candidate extends DeveloperPullRequestCandidate,
+>(
+  pullRequests: readonly Candidate[]
+): Candidate[] =>
+  [...pullRequests].filter(isEligibleDeveloperPullRequest).toSorted((a, b) => {
+    const repositoryOrder = a.repoFullName.localeCompare(b.repoFullName);
+    return repositoryOrder || a.number - b.number;
+  });
+
+export const toggleRepositorySelection = (
+  selectedRepositories: readonly string[],
+  repository: string
+): string[] =>
+  selectedRepositories.includes(repository)
+    ? selectedRepositories.filter((selected) => selected !== repository)
+    : [...selectedRepositories, repository];
+
+export const buildRepositoryBackfillPayload = ({
+  allRepositories,
+  selectedRepositories,
+}: {
+  allRepositories: boolean;
+  selectedRepositories: readonly string[];
+}):
+  | { allRepositories: true }
+  | { allRepositories: false; repositories: string[] } => {
+  if (allRepositories) {
+    return { allRepositories: true };
+  }
+
+  return {
+    allRepositories: false,
+    repositories: [...new Set(selectedRepositories)].toSorted(),
+  };
+};

--- a/apps/web/src/routes/app/_workspace/route.tsx
+++ b/apps/web/src/routes/app/_workspace/route.tsx
@@ -275,7 +275,7 @@ function RouteComponent() {
           </Dialog>
           <Outlet />
         </SidebarProvider>
-        {import.meta.env.DEV && <Toolbar />}
+        <Toolbar />
       </ReflagClientProvider>
     </div>
   );

--- a/apps/web/src/routes/app/_workspace/route.tsx
+++ b/apps/web/src/routes/app/_workspace/route.tsx
@@ -17,15 +17,21 @@ import type { schema } from "api/schema";
 import { addDays, isAfter } from "date-fns";
 import { useAtomValue } from "jotai/react";
 import { usePostHog } from "posthog-js/react";
-import { useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 
-import { Toolbar } from "~/components/devtools/toolbar";
 import { activeOrganizationAtom } from "~/lib/atoms";
+import { hasDeveloperToolAccess } from "~/lib/developer-tools/access";
 import { reflagClient } from "~/lib/feature-flag";
 import { useOrganizationPlan } from "~/lib/hooks/query/use-organization-plan";
 import { useOrganizationSwitcher } from "~/lib/hooks/query/use-organization-switcher";
 import { fetchClient, query } from "~/lib/live-state";
 import { createCheckoutSession } from "~/lib/server-funcs/payment";
+
+const LazyToolbar = lazy(() =>
+  import("~/components/devtools/toolbar").then(({ Toolbar }) => ({
+    default: Toolbar,
+  }))
+);
 
 export type WindowWithCachedOrgUsers = Window & {
   cachedOrgUsers?: {
@@ -79,6 +85,12 @@ function RouteComponent() {
   const posthog = usePostHog();
 
   const currentOrg = useAtomValue(activeOrganizationAtom);
+  const showDeveloperToolbar = hasDeveloperToolAccess({
+    isDevelopment: import.meta.env.DEV,
+    organizationId: currentOrg?.id,
+    organizationUsers,
+    user,
+  });
 
   useEffect(() => {
     if (user?.id) {
@@ -275,7 +287,11 @@ function RouteComponent() {
           </Dialog>
           <Outlet />
         </SidebarProvider>
-        <Toolbar />
+        {showDeveloperToolbar && (
+          <Suspense fallback={null}>
+            <LazyToolbar />
+          </Suspense>
+        )}
       </ReflagClientProvider>
     </div>
   );

--- a/connectors/framework/src/invoke.test.ts
+++ b/connectors/framework/src/invoke.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ACTION_INVOKE_SECRET_HEADER,
+  ACTION_INVOKE_TIMEOUT_MS,
+  invokeDeveloperAction,
+} from "./invoke";
+
+const envelope = {
+  action: "pr_match_replay",
+  config: "opaque-config",
+  payload: { organizationId: "org-a", target: "owner/repo#1" },
+};
+
+describe("developer-action connector transport", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("sends the private secret and returns the accepted result", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ accepted: true, jobIds: ["job-1"] }), {
+        status: 202,
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      invokeDeveloperAction(
+        "https://github.example/api/actions/invoke",
+        envelope,
+        {
+          secret: "connector-secret",
+        }
+      )
+    ).resolves.toStrictEqual({ accepted: true, jobIds: ["job-1"] });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://github.example/api/actions/invoke",
+      expect.objectContaining({
+        body: JSON.stringify(envelope),
+        headers: {
+          "Content-Type": "application/json",
+          [ACTION_INVOKE_SECRET_HEADER]: "connector-secret",
+        },
+        method: "POST",
+        signal: expect.any(AbortSignal),
+      })
+    );
+  });
+
+  it("normalizes connector errors without returning the response body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify({ secret: "must-not-leak" }), {
+          status: 502,
+        })
+      )
+    );
+
+    await expect(
+      invokeDeveloperAction(
+        "https://github.example/api/actions/invoke",
+        envelope
+      )
+    ).rejects.toThrow("DEVELOPER_ACTION_INVOKE_FAILED: 502");
+    await expect(
+      invokeDeveloperAction(
+        "https://github.example/api/actions/invoke",
+        envelope
+      )
+    ).rejects.not.toThrow("must-not-leak");
+  });
+
+  it("turns an unresponsive connector into a bounded timeout error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<typeof fetch>()
+        .mockRejectedValue(new DOMException("timed out", "TimeoutError"))
+    );
+
+    await expect(
+      invokeDeveloperAction(
+        "https://github.example/api/actions/invoke",
+        envelope
+      )
+    ).rejects.toThrow(
+      `DEVELOPER_ACTION_INVOKE_TIMEOUT: no response after ${ACTION_INVOKE_TIMEOUT_MS}ms`
+    );
+  });
+});

--- a/docs/plans/developer-actions-rollout.md
+++ b/docs/plans/developer-actions-rollout.md
@@ -1,0 +1,93 @@
+# Developer actions production rollout
+
+This checklist covers FRO-213 / FRO-208. It verifies the internal developer
+path without creating GitHub repositories, pull requests, issues, comments, or
+other external test data.
+
+## Security boundary
+
+The Command K and toolbar checks are visibility checks only. The API must still
+authorize every invocation before it resolves an integration, looks up a
+mirrored entity, invokes a connector, or queues work.
+
+| Caller | Local development | Production-like environment |
+| --- | --- | --- |
+| Authenticated member with a verified `@tryfrontdesk.app` address | Visible and accepted | Visible and accepted |
+| Authenticated member with an unverified internal address | Visible and accepted | Hidden and denied |
+| Authenticated member with an external address | Visible and accepted | Hidden and denied |
+| Unauthenticated request | Hidden and denied | Hidden and denied |
+| Authenticated user who is not a member of the selected organization | Hidden and denied | Hidden and denied |
+
+For a denied request, verify the structured denial reason is one of
+`missing_session`, `unverified_email`, `non_internal_email`, or
+`not_organization_member`. The denial must happen before integration or target
+lookup.
+
+## Automated verification ledger
+
+Run the focused suites from the repository root:
+
+```sh
+bunx vitest run \
+  apps/api/src/lib/authorize.test.ts \
+  apps/api/src/lib/developer-action-dispatch.test.ts \
+  connectors/framework/src/invoke.test.ts \
+  connectors/github/src/routes/actions.test.ts \
+  connectors/github/src/lib/queue.test.ts \
+  apps/web/src/lib/developer-tools/access.test.ts \
+  apps/web/src/lib/developer-tools/github-selection.test.ts
+```
+
+The suites protect:
+
+- exact internal-email matching, verification, membership, missing-session,
+  and local-development behavior;
+- organization-scoped integration and mirror-target resolution;
+- unknown actions, missing integrations, invalid/foreign targets, connector
+  failures, bounded connector timeouts, and redacted transport errors;
+- open/non-draft PR eligibility, refresh-before-eligibility, replay queue
+  coalescing, selected/all repository validation, and idempotent queue keys;
+- Command K visibility, PR filtering, repository selection, and the explicit
+  all-repositories payload.
+
+## Production smoke test
+
+Use an existing open, non-draft PR in an already connected GitHub repository.
+Do not create or modify GitHub test data.
+
+1. Sign in as a verified internal member and select the organization that owns
+   the GitHub installation.
+2. Open Command K with `mod+k`. Confirm the Developer tools entry and compact
+   toolbar are visible. Confirm the active organization is the only source of
+   PRs and repositories shown.
+3. Open `Developer tools → GitHub → Replay GitHub PR match`. Confirm the picker
+   contains only mirrored `open` and non-draft PRs. Select the existing PR.
+4. Confirm the UI reports an accepted result with a queue identifier. Confirm
+   core and connector logs include actor/organization/action/target/job context
+   but never include the opaque integration configuration, installation secret,
+   connector secret, or unrelated organization data.
+5. Repeat the same replay. Confirm it uses the existing per-PR coalescing key
+   and does not create a GitHub PR or historical webhook event.
+6. Open `Developer tools → GitHub → Backfill GitHub repositories`. Select one
+   configured repository and run the selected backfill. Confirm one accepted
+   job is returned. Repeat it and confirm the deterministic repository key
+   prevents duplicate pending work.
+7. Run the explicit `Backfill all repositories` command only if the connected
+   installation has multiple repositories. Confirm the result is marked
+   `all`, and that each configured repository receives one idempotent job.
+8. If a safe existing PR can be moved out of eligibility by normal workflow,
+   verify a closed or draft PR refreshes the mirror but does not enqueue the
+   match pipeline. Do not make a GitHub-only change solely for this checklist.
+9. Sign out or switch to a non-member/external account. Confirm the toolbar and
+   developer commands disappear; separately verify a direct API call is denied.
+
+## Rollout exit criteria
+
+- Focused automated suites pass.
+- Web typecheck/build and connector typecheck/build pass.
+- The internal-member and non-member visibility matrix is observed in the
+  target environment.
+- One existing PR replay and one repository backfill are accepted and visible
+  in structured logs without secret leakage.
+- No external test data was created and the shared `thread.create` procedure
+  remains unchanged.


### PR DESCRIPTION
## Summary
- move the developer controls into the shared Command K registry
- add production-safe access visibility for verified @tryfrontdesk.app members
- add org-scoped mirrored GitHub PR replay and repository backfill pickers
- keep signals and feature flags local-only while retaining diagnostics in the compact toolbar

## Verification
- bun run --cwd apps/web typecheck
- bun run --cwd apps/web build
- bunx oxlint <changed web files>
- git diff --check

Implements FRO-212.

Stacked on #340 in native GitHub stack #339.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves developer tools into the Command K palette with org-scoped GitHub actions and production-safe visibility (FRO-212). Adds a toolbar “Command K” button, `keepOpen` multi-select for repo backfill, thread tools, and a controllable live-state log.

- **New Features**
  - Command K > Developer tools: Threads (create, duplicate), GitHub PR replay (open, non-draft mirrored PRs in active org), repository backfill (select repos or “all”, multi-select with `keepOpen`), Live-state log, React Scan, and toolbar hide.
  - Toolbar: adds a “Command K” button; developer tools registered via `DeveloperToolsCommands`; Live-state log supports a controlled open state.

- **Refactors**
  - Access gating: show only for members of the active org and either in local dev or verified `@tryfrontdesk.app` users; applied in route and toolbar via `hasDeveloperToolAccess`; mirrors server predicate.
  - Command menu: global open state via `commandMenuOpenAtom`, closes on unmount, respects `keepOpen`.
  - Tests/docs: org-scoped target validation (reject cross-org mirrors), GitHub selection and connector invoke tests (secret header, timeouts, redacted errors), and a production rollout plan.

<sup>Written for commit 4fa7c304fd9d22a5f36294261c5e95d9f6c3cf63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an expanded developer tools command menu for creating or duplicating threads, replaying pull requests, managing repositories, toggling feature flags, and accessing diagnostics.
  * Added controls for toolbar visibility, live-state logging, React Scan, and multi-step command selection.

* **Improvements**
  * Developer tools now appear only for authorized users and environments.
  * Improved developer-action feedback and thread duplication navigation.
  * Added safer repository and pull-request selection workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->