### PR TITLE
feat(api): notify Discord on waitlist signup

### DIFF
--- a/apps/api/.env.local.example
+++ b/apps/api/.env.local.example
@@ -4,6 +4,8 @@ BASE_FRONTEND_URL=
 
 # This is a key shared between the API, Discord bot, and local fd devtool CLI
 DISCORD_BOT_KEY=
+# Optional webhook for notifications about new public waitlist signups
+DISCORD_WAITLIST_WEBHOOK_URL=
 RESEND_API_KEY=
 
 # Google OAuth

--- a/apps/api/src/lib/waitlist-discord.test.ts
+++ b/apps/api/src/lib/waitlist-discord.test.ts
@@ -1,0 +1,90 @@
+import type { EarlyAccessRequestInput } from "@workspace/schemas/early-access";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { notifyWaitlistSignup } from "./waitlist-discord";
+
+const signup: EarlyAccessRequestInput & { createdAt: Date } = {
+  autonomy: "routine_autonomous",
+  channels: ["slack", "discord"],
+  createdAt: new Date("2026-08-05T12:00:00.000Z"),
+  email: "founder@example.com",
+  volume: "50_200",
+};
+
+describe("waitlist Discord notifications", () => {
+  const previousWebhookUrl = process.env.DISCORD_WAITLIST_WEBHOOK_URL;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    if (previousWebhookUrl === undefined) {
+      delete process.env.DISCORD_WAITLIST_WEBHOOK_URL;
+    } else {
+      process.env.DISCORD_WAITLIST_WEBHOOK_URL = previousWebhookUrl;
+    }
+  });
+
+  it("does nothing when the webhook is not configured", async () => {
+    delete process.env.DISCORD_WAITLIST_WEBHOOK_URL;
+    const fetchMock = vi.fn<() => void>();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await notifyWaitlistSignup(signup);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("sends the signup details as a Discord embed", async () => {
+    process.env.DISCORD_WAITLIST_WEBHOOK_URL =
+      "https://discord.com/api/webhooks/test/token";
+    const fetchMock = vi.fn<
+      (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+    >(() => Promise.resolve(new Response(null, { status: 204 })));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await notifyWaitlistSignup(signup);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://discord.com/api/webhooks/test/token",
+      expect.objectContaining({
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      })
+    );
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    expect(JSON.parse(String(init?.body))).toStrictEqual({
+      allowed_mentions: { parse: [] },
+      embeds: [
+        {
+          color: 0x5865f2,
+          fields: [
+            { name: "Email", value: "founder@example.com" },
+            { name: "Support channels", value: "Slack, Discord" },
+            { name: "Weekly volume", value: "50 – 200" },
+            {
+              name: "Autonomy",
+              value: "Reply on its own to routine questions",
+            },
+          ],
+          timestamp: "2026-08-05T12:00:00.000Z",
+          title: "New waitlist signup",
+        },
+      ],
+    });
+  });
+
+  it("throws when Discord rejects the webhook", async () => {
+    process.env.DISCORD_WAITLIST_WEBHOOK_URL =
+      "https://discord.com/api/webhooks/test/token";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<() => Promise<Response>>(() =>
+        Promise.resolve(new Response(null, { status: 400 }))
+      )
+    );
+
+    await expect(notifyWaitlistSignup(signup)).rejects.toThrow(
+      "Discord waitlist webhook failed with status 400"
+    );
+  });
+});

--- a/apps/api/src/lib/waitlist-discord.ts
+++ b/apps/api/src/lib/waitlist-discord.ts
@@ -1,0 +1,72 @@
+import type { EarlyAccessRequestInput } from "@workspace/schemas/early-access";
+import {
+  AUTONOMY_APPETITE_OPTIONS,
+  CONVERSATION_VOLUME_OPTIONS,
+  SUPPORT_CHANNEL_OPTIONS,
+} from "@workspace/schemas/early-access";
+
+const DISCORD_WAITLIST_WEBHOOK_TIMEOUT_MS = 5000;
+
+type WaitlistSignup = EarlyAccessRequestInput & {
+  createdAt: Date;
+};
+
+const labelFor = <Value extends string>(
+  options: readonly { label: string; value: Value }[],
+  value: Value
+) => options.find((option) => option.value === value)?.label ?? value;
+
+/**
+ * Notify the internal Discord channel about a new waitlist signup.
+ *
+ * The webhook is optional so local environments can submit the form without
+ * needing Discord configured. Callers decide how to handle delivery errors so
+ * a notification outage cannot reject a successful signup.
+ */
+export async function notifyWaitlistSignup(
+  signup: WaitlistSignup
+): Promise<void> {
+  const webhookUrl = process.env.DISCORD_WAITLIST_WEBHOOK_URL;
+  if (!webhookUrl) {
+    return;
+  }
+
+  const response = await fetch(webhookUrl, {
+    body: JSON.stringify({
+      allowed_mentions: { parse: [] },
+      embeds: [
+        {
+          color: 0x5865f2,
+          fields: [
+            { name: "Email", value: signup.email },
+            {
+              name: "Support channels",
+              value: signup.channels
+                .map((channel) => labelFor(SUPPORT_CHANNEL_OPTIONS, channel))
+                .join(", "),
+            },
+            {
+              name: "Weekly volume",
+              value: labelFor(CONVERSATION_VOLUME_OPTIONS, signup.volume),
+            },
+            {
+              name: "Autonomy",
+              value: labelFor(AUTONOMY_APPETITE_OPTIONS, signup.autonomy),
+            },
+          ],
+          timestamp: signup.createdAt.toISOString(),
+          title: "New waitlist signup",
+        },
+      ],
+    }),
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+    signal: AbortSignal.timeout(DISCORD_WAITLIST_WEBHOOK_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Discord waitlist webhook failed with status ${response.status}`
+    );
+  }
+}

--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -959,17 +959,17 @@ export const router = createRouter({
           }
 
           // Repeat submissions update the existing qualification data and do
-          // not create another notification. Discord delivery is best-effort;
-          // the waitlist signup has already been persisted successfully.
+          // not create another notification. Discord delivery is best-effort
+          // and detached so it cannot delay the successful signup response.
           if (createdAt) {
-            try {
-              await notifyWaitlistSignup({ ...fields, createdAt });
-            } catch (error) {
-              console.error(
-                "Failed to notify Discord about waitlist signup:",
-                error
-              );
-            }
+            void notifyWaitlistSignup({ ...fields, createdAt }).catch(
+              (error) => {
+                console.error(
+                  "Failed to notify Discord about waitlist signup:",
+                  error
+                );
+              }
+            );
           }
 
           return { success: true };

--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -28,6 +28,7 @@ import {
 import { connectorRegistry } from "../lib/connector-registry";
 import { dodopayments } from "../lib/payment";
 import { resend } from "../lib/resend";
+import { notifyWaitlistSignup } from "../lib/waitlist-discord";
 import { sendWelcomeEmail } from "../trigger/send-welcome-email";
 import { privateRoute, publicRoute } from "./factories";
 import { agentChatRoute } from "./router/agent-chat";
@@ -926,6 +927,7 @@ export const router = createRouter({
             email,
             volume: req.input.volume,
           };
+          let createdAt: Date | undefined;
 
           const findExisting = async () =>
             Object.values(
@@ -938,11 +940,13 @@ export const router = createRouter({
             await db.earlyAccessRequest.update(existing.id, fields);
           } else {
             try {
+              const insertedAt = new Date();
               await db.earlyAccessRequest.insert({
                 ...fields,
-                createdAt: new Date(),
+                createdAt: insertedAt,
                 id: ulid().toLowerCase(),
               });
+              createdAt = insertedAt;
             } catch {
               // Concurrent first submission won the unique(email) race — fold
               // this one into the row it just created so the last write wins.
@@ -951,6 +955,20 @@ export const router = createRouter({
                 throw new Error("EARLY_ACCESS_SUBMIT_FAILED");
               }
               await db.earlyAccessRequest.update(raced.id, fields);
+            }
+          }
+
+          // Repeat submissions update the existing qualification data and do
+          // not create another notification. Discord delivery is best-effort;
+          // the waitlist signup has already been persisted successfully.
+          if (createdAt) {
+            try {
+              await notifyWaitlistSignup({ ...fields, createdAt });
+            } catch (error) {
+              console.error(
+                "Failed to notify Discord about waitlist signup:",
+                error
+              );
             }
           }
 

--- a/packages/schemas/src/early-access.test.ts
+++ b/packages/schemas/src/early-access.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { earlyAccessRequestSchema } from "./early-access";
+
+const requestWithEmail = (email: string) => ({
+  autonomy: "routine_autonomous" as const,
+  channels: ["slack" as const],
+  email,
+  volume: "under_10" as const,
+});
+
+describe("early-access request schema", () => {
+  it("limits email addresses to 254 characters", () => {
+    const atLimit = `${"a".repeat(242)}@example.com`;
+    const overLimit = `${"a".repeat(243)}@example.com`;
+
+    expect(
+      earlyAccessRequestSchema.safeParse(requestWithEmail(atLimit)).success
+    ).toBeTruthy();
+    expect(
+      earlyAccessRequestSchema.safeParse(requestWithEmail(overLimit)).success
+    ).toBeFalsy();
+  });
+});

--- a/packages/schemas/src/early-access.ts
+++ b/packages/schemas/src/early-access.ts
@@ -79,7 +79,9 @@ export const earlyAccessRequestSchema = z.object({
     .refine((values) => new Set(values).size === values.length, {
       message: "Channels must not repeat.",
     }),
-  email: z.email(),
+  // RFC 5321's maximum mailbox length also keeps this within Discord's embed
+  // field limit when the signup is forwarded to the notification webhook.
+  email: z.email().max(254),
   volume: conversationVolumeSchema,
 });
 


### PR DESCRIPTION
## Summary

- Send a Discord embed when a new public waitlist signup is inserted.
- Include the signup email and qualification details.
- Keep webhook delivery best-effort and document `DISCORD_WAITLIST_WEBHOOK_URL`.

## Validation

- `bun run --filter api test`
- `bun run --filter api typecheck`
- `bun run --filter api build`
- Ultracite formatting check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send a Discord embed when a new public waitlist signup is created, with email and qualification details. The webhook is optional and best-effort, so signups are never blocked.

- **New Features**
  - Added `notifyWaitlistSignup` to post a Discord embed (email, support channels, weekly volume, autonomy, timestamp).
  - Notify only on first insert; repeat submissions update without notifying.
  - 5s timeout; library throws on non-2xx, router catches and logs to avoid failing the request.
  - Enforced 254-char email max in the request schema to fit Discord embeds; tests cover this, plus no-webhook, success, and Discord rejection.

- **Migration**
  - Set `DISCORD_WAITLIST_WEBHOOK_URL` in `apps/api` env to enable notifications. Leave unset for local dev.

<sup>Written for commit 9a6d2860c458fb54f606e2ee69a47cd82bf144f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

