### PR TITLE
fix(web): avoid conditional hooks when reading thread route params

### DIFF
--- a/apps/web/src/components/devtools/devtools-menu/duplicate-thread-command.tsx
+++ b/apps/web/src/components/devtools/devtools-menu/duplicate-thread-command.tsx
@@ -114,6 +114,7 @@ export const DuplicateThreadMenuItem = () => {
 
   return (
     <MenuItem
+      disabled={!rawParam}
       onClick={handleDuplicateThread}
       aria-label="Duplicate current thread (title, first message and author)"
     >

--- a/apps/web/src/components/devtools/devtools-menu/duplicate-thread-command.tsx
+++ b/apps/web/src/components/devtools/devtools-menu/duplicate-thread-command.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { getRouteApi, useNavigate } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import { MenuItem } from "@workspace/ui/components/menu";
 import { getDefaultStore } from "jotai/vanilla";
 import { toast } from "sonner";
@@ -8,6 +8,8 @@ import { toast } from "sonner";
 import { activeOrganizationAtom } from "~/lib/atoms";
 import { fetchClient } from "~/lib/live-state";
 import { buildThreadParam, parseThreadParam } from "~/utils/thread";
+
+import { useThreadRouteRawParam } from "./thread-route-for-devtools";
 
 const parseThreadMessage = (content: string | undefined) => {
   if (!content) {
@@ -96,13 +98,7 @@ export const duplicateThreadFromParam = async ({
 
 export const DuplicateThreadMenuItem = () => {
   const navigate = useNavigate();
-  const { id: rawParam } = (() => {
-    try {
-      return getRouteApi("/app/_workspace/_main/threads/$id/").useParams();
-    } catch {
-      return { id: null };
-    }
-  })();
+  const rawParam = useThreadRouteRawParam();
 
   const handleDuplicateThread = () =>
     duplicateThreadFromParam({

--- a/apps/web/src/components/devtools/devtools-menu/thread-route-for-devtools.tsx
+++ b/apps/web/src/components/devtools/devtools-menu/thread-route-for-devtools.tsx
@@ -1,18 +1,23 @@
 "use client";
 
-import { getRouteApi } from "@tanstack/react-router";
+import { useParams } from "@tanstack/react-router";
 import { getDefaultStore } from "jotai/vanilla";
 
 import { activeOrganizationAtom } from "~/lib/atoms";
 import { fetchClient } from "~/lib/live-state";
 import { parseThreadParam } from "~/utils/thread";
 
+const THREAD_DETAIL_ROUTE = "/app/_workspace/_main/threads/$id/";
+
 export const useThreadRouteRawParam = (): string | null => {
-  try {
-    return getRouteApi("/app/_workspace/_main/threads/$id/").useParams().id;
-  } catch {
-    return null;
-  }
+  // Always call useParams unconditionally. shouldThrow:false returns undefined
+  // when the thread detail route is not matched, instead of throwing mid-hooks.
+  const params = useParams({
+    from: THREAD_DETAIL_ROUTE,
+    shouldThrow: false,
+  });
+
+  return params?.id ?? null;
 };
 
 export const resolveThreadUlid = async (


### PR DESCRIPTION
## Summary
- Fix React hooks-order crash in `DeveloperToolsCommands` when navigating away from a thread detail route
- Replace try/catch around `useParams()` with `useParams({ shouldThrow: false })` so hooks always complete
- Reuse the same safe helper in `DuplicateThreadMenuItem`

## Test plan
- [ ] Open `/app/threads` (inbox) and confirm the developer toolbar loads without console errors
- [ ] Open a thread detail route, then navigate back to the inbox
- [ ] Confirm no “change in the order of Hooks” / “Should have a queue” errors appear
- [ ] From Command K → Developer tools, confirm “Duplicate current thread” is disabled off a thread and works on a thread


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in Developer Tools when leaving a thread detail page by reading route params safely. Explicitly disables the “Duplicate current thread” command off-thread.

- **Bug Fixes**
  - Replaced conditional `useParams()` with `useParams({ from: "/app/_workspace/_main/threads/$id/", shouldThrow: false })` to prevent mid-render throws and React hook-order violations.
  - Added `useThreadRouteRawParam` and used it in `DuplicateThreadMenuItem`; the item is now disabled off-thread (`disabled={!rawParam}`) and the handler remains guarded.

<sup>Written for commit fcba9c815a437defa031ff7a1d95ab6371665965. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread navigation in developer tools.
  * Thread links now resolve more reliably, including when accessed through alternate route formats.
  * Prevented navigation errors when thread route information is unavailable or incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->