### PR TITLE
Add multi-select labels to the command menu

### DIFF
--- a/apps/web/src/components/command-menu.tsx
+++ b/apps/web/src/components/command-menu.tsx
@@ -7,6 +7,7 @@ import {
   CommandGroup,
   CommandInput,
   CommandItem,
+  CommandItemCheckbox,
   CommandList,
   CommandShortcut,
   CommandTrail,
@@ -196,16 +197,39 @@ export const CommandMenu = () => {
     a.localeCompare(b)
   );
 
+  const isMultiSelectPage = currentPage?.multiple ?? false;
+  const selectedValues = isMultiSelectPage
+    ? commands.filter((command) => command.checked).map((command) => command.id)
+    : undefined;
+
   const renderCommand = (command: Command) => (
     <CommandItem
       key={command.id}
       disabled={command.disabled}
+      value={isMultiSelectPage ? command.id : undefined}
+      keywords={
+        isMultiSelectPage
+          ? [
+              ...(typeof command.label === "string" ? [command.label] : []),
+              ...(command.keywords ?? []),
+            ]
+          : command.keywords
+      }
       onSelect={() => handleCommandSelect(command)}
     >
+      {isMultiSelectPage && (
+        <CommandItemCheckbox
+          aria-label={`Toggle ${
+            typeof command.label === "string" ? command.label : command.id
+          }`}
+        />
+      )}
       {command.icon}
       <span>{command.label}</span>
       <CommandTrail>
-        {command.checked && <Check className="text-foreground-secondary" />}
+        {!isMultiSelectPage && command.checked && (
+          <Check className="text-foreground-secondary" />
+        )}
         {command.shortcut && <CommandShortcut keybind={command.shortcut} />}
         {(command as PageCommand).pageId && <ChevronRight />}
       </CommandTrail>
@@ -214,8 +238,10 @@ export const CommandMenu = () => {
 
   return (
     <CommandDialog
+      multiple={isMultiSelectPage}
       open={open}
       onOpenChange={setOpen}
+      value={selectedValues}
       render={
         <motion.div
           key={animationKey}
@@ -300,9 +326,20 @@ export const CommandMenu = () => {
               <Keybind keybind="backspace" /> Go back
             </div>
           )}
-          <div className="flex items-center gap-1">
-            <Keybind keybind="enter" /> Select
-          </div>
+          {isMultiSelectPage ? (
+            <>
+              <div className="flex items-center gap-1">
+                <Keybind keybind="space" /> Toggle
+              </div>
+              <div className="flex items-center gap-1">
+                <Keybind keybind="enter" /> Toggle and close
+              </div>
+            </>
+          ) : (
+            <div className="flex items-center gap-1">
+              <Keybind keybind="enter" /> Select
+            </div>
+          )}
         </div>
       </CommandFooter>
     </CommandDialog>

--- a/apps/web/src/lib/commands/commands/thread/index.tsx
+++ b/apps/web/src/lib/commands/commands/thread/index.tsx
@@ -8,6 +8,7 @@ import { query } from "~/lib/live-state";
 
 import { useCommandContext } from "../..";
 import { createAssignmentCommands } from "./assignment";
+import { createLabelCommands } from "./labels";
 import { createPriorityCommands } from "./priority";
 import { createStatusCommands } from "./status";
 
@@ -29,6 +30,22 @@ export const ThreadCommands = ({ threadId }: { threadId: string }) => {
     query.thread.first({ id: threadId }).include({
       assignedUser: true,
     })
+  );
+
+  const labels = useLiveQuery(
+    query.label.where({
+      enabled: true,
+      organizationId: activeOrganization?.id,
+    })
+  );
+
+  const threadLabels = useLiveQuery(
+    query.threadLabel
+      .where({
+        label: { enabled: true },
+        threadId,
+      })
+      .include({ label: true })
   );
 
   useCommandContext(
@@ -54,12 +71,18 @@ export const ThreadCommands = ({ threadId }: { threadId: string }) => {
           threadId,
           user,
         });
+      const { commands: labelCommands, labelsPage } = createLabelCommands({
+        labels,
+        threadId,
+        threadLabels,
+      });
 
       return {
         commands: [
           ...assignmentCommands,
           ...statusCommands,
           ...priorityCommands,
+          ...labelCommands,
           {
             id: "copy-link",
             label: "Copy Link",
@@ -79,6 +102,7 @@ export const ThreadCommands = ({ threadId }: { threadId: string }) => {
         label: "Thread",
         pages: {
           "assign-user": assignUserPage,
+          labels: labelsPage,
           priority: priorityPage,
           status: statusPage,
         },
@@ -86,7 +110,15 @@ export const ThreadCommands = ({ threadId }: { threadId: string }) => {
     },
     {
       active: Boolean(organizationId),
-      deps: [threadId, organizationId, thread, user, orgUsers],
+      deps: [
+        threadId,
+        organizationId,
+        thread,
+        user,
+        orgUsers,
+        labels,
+        threadLabels,
+      ],
     }
   );
 

--- a/apps/web/src/lib/commands/commands/thread/index.tsx
+++ b/apps/web/src/lib/commands/commands/thread/index.tsx
@@ -72,9 +72,9 @@ export const ThreadCommands = ({ threadId }: { threadId: string }) => {
           user,
         });
       const { commands: labelCommands, labelsPage } = createLabelCommands({
-        labels,
+        labels: labels ?? null,
         threadId,
-        threadLabels,
+        threadLabels: threadLabels ?? null,
       });
 
       return {

--- a/apps/web/src/lib/commands/commands/thread/labels.tsx
+++ b/apps/web/src/lib/commands/commands/thread/labels.tsx
@@ -1,0 +1,91 @@
+import { Tag } from "lucide-react";
+import { ulid } from "ulid";
+
+import { mutate } from "~/lib/live-state";
+
+import type { Command, CommandPage } from "../../types";
+
+interface LabelRecord {
+  color: string;
+  id: string;
+  name: string;
+}
+
+interface ThreadLabelRecord {
+  enabled: boolean;
+  id: string;
+  label: {
+    id: string;
+  };
+}
+
+interface LabelCommandsParams {
+  labels: LabelRecord[] | null;
+  threadId: string;
+  threadLabels: ThreadLabelRecord[] | null;
+}
+
+export const createLabelCommands = ({
+  labels,
+  threadId,
+  threadLabels,
+}: LabelCommandsParams): {
+  commands: Command[];
+  labelsPage: CommandPage;
+} => {
+  const threadLabelByLabelId = new Map(
+    threadLabels?.map((threadLabel) => [threadLabel.label.id, threadLabel]) ??
+      []
+  );
+
+  const commands: Command[] = [
+    {
+      icon: <Tag />,
+      id: "change-labels",
+      label: "Change labels...",
+      pageId: "labels",
+      shortcut: "l",
+    },
+  ];
+
+  const labelsPage: CommandPage = {
+    commands:
+      labels?.map((label) => {
+        const threadLabel = threadLabelByLabelId.get(label.id);
+
+        return {
+          checked: threadLabel?.enabled ?? false,
+          icon: (
+            <span
+              className="size-2 shrink-0 rounded-full"
+              style={{ backgroundColor: label.color }}
+            />
+          ),
+          id: label.id,
+          keepOpen: true,
+          keywords: [label.name, "label"],
+          label: label.name,
+          onSelect: () => {
+            if (threadLabel?.enabled) {
+              mutate.label.detachFromThread({
+                threadLabelId: threadLabel.id,
+              });
+              return;
+            }
+
+            mutate.label.attachToThread({
+              id: ulid().toLowerCase(),
+              labelId: label.id,
+              threadId,
+            });
+          },
+        } satisfies Command;
+      }) ?? [],
+    icon: <Tag />,
+    id: "labels",
+    label: "Change labels",
+    multiple: true,
+  };
+
+  return { commands, labelsPage };
+};

--- a/apps/web/src/lib/commands/commands/thread/labels.tsx
+++ b/apps/web/src/lib/commands/commands/thread/labels.tsx
@@ -1,3 +1,5 @@
+import type { InferLiveObject } from "@live-state/sync";
+import type { schema } from "api/schema";
 import { Tag } from "lucide-react";
 import { ulid } from "ulid";
 
@@ -5,19 +7,11 @@ import { mutate } from "~/lib/live-state";
 
 import type { Command, CommandPage } from "../../types";
 
-interface LabelRecord {
-  color: string;
-  id: string;
-  name: string;
-}
-
-interface ThreadLabelRecord {
-  enabled: boolean;
-  id: string;
-  label: {
-    id: string;
-  };
-}
+type LabelRecord = InferLiveObject<typeof schema.label>;
+type ThreadLabelRecord = InferLiveObject<
+  typeof schema.threadLabel,
+  { label: true }
+>;
 
 interface LabelCommandsParams {
   labels: LabelRecord[] | null;

--- a/apps/web/src/lib/commands/hooks.ts
+++ b/apps/web/src/lib/commands/hooks.ts
@@ -1,5 +1,5 @@
 import { useAtomValue, useSetAtom } from "jotai/react";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { commandRegistryActions, commandRegistryAtom } from "./registry";
 import type { Command, CommandContext, CommandPage } from "./types";
@@ -74,20 +74,43 @@ export const useCommandContext = (
 ) => {
   const { active = true, deps } = options;
   const setRegistry = useSetAtom(commandRegistryAtom);
+  const contextRef = useRef<CommandContext | null>(null);
 
   useEffect(() => {
     const context = factory();
+    const previousContext = contextRef.current;
+    contextRef.current = context;
 
-    // Atomic batch: register + optionally activate
     setRegistry((state) => {
-      let newState = commandRegistryActions.registerContext(state, context);
-      if (active) {
-        newState = commandRegistryActions.setContext(newState, context.id);
+      let newState = state;
+
+      if (previousContext && previousContext.id !== context.id) {
+        newState = commandRegistryActions.unregisterContext(
+          newState,
+          previousContext.id
+        );
       }
+
+      newState = commandRegistryActions.registerContext(newState, context);
+
+      if (active && newState.currentContextId !== context.id) {
+        newState = commandRegistryActions.setContext(newState, context.id);
+      } else if (!active && newState.currentContextId === context.id) {
+        newState = commandRegistryActions.setContext(newState, null);
+      }
+
       return newState;
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [setRegistry, active, ...deps]);
 
-    return () => {
+  useEffect(
+    () => () => {
+      const context = contextRef.current;
+      if (!context) {
+        return;
+      }
+
       setRegistry((state) => {
         let newState = state;
         if (state.currentContextId === context.id) {
@@ -95,9 +118,9 @@ export const useCommandContext = (
         }
         return commandRegistryActions.unregisterContext(newState, context.id);
       });
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [setRegistry, active, ...deps]);
+    },
+    [setRegistry]
+  );
 };
 
 /**

--- a/apps/web/src/lib/commands/hooks.ts
+++ b/apps/web/src/lib/commands/hooks.ts
@@ -75,16 +75,27 @@ export const useCommandContext = (
   const { active = true, deps } = options;
   const setRegistry = useSetAtom(commandRegistryAtom);
   const contextRef = useRef<CommandContext | null>(null);
+  const activeRef = useRef(active);
 
   useEffect(() => {
     const context = factory();
     const previousContext = contextRef.current;
+    const previousActive = activeRef.current;
+    const contextChanged =
+      previousContext !== null && previousContext.id !== context.id;
     contextRef.current = context;
+    activeRef.current = active;
 
     setRegistry((state) => {
       let newState = state;
+      const wasPreviousContextActive =
+        previousContext !== null &&
+        state.currentContextId === previousContext.id;
 
-      if (previousContext && previousContext.id !== context.id) {
+      if (previousContext && contextChanged) {
+        if (wasPreviousContextActive) {
+          newState = commandRegistryActions.setContext(newState, null);
+        }
         newState = commandRegistryActions.unregisterContext(
           newState,
           previousContext.id
@@ -93,7 +104,13 @@ export const useCommandContext = (
 
       newState = commandRegistryActions.registerContext(newState, context);
 
-      if (active && newState.currentContextId !== context.id) {
+      const shouldActivate =
+        active &&
+        (previousContext === null ||
+          !previousActive ||
+          (contextChanged && wasPreviousContextActive));
+
+      if (shouldActivate && newState.currentContextId !== context.id) {
         newState = commandRegistryActions.setContext(newState, context.id);
       } else if (!active && newState.currentContextId === context.id) {
         newState = commandRegistryActions.setContext(newState, null);
@@ -107,6 +124,8 @@ export const useCommandContext = (
   useEffect(
     () => () => {
       const context = contextRef.current;
+      contextRef.current = null;
+      activeRef.current = true;
       if (!context) {
         return;
       }

--- a/apps/web/src/lib/commands/types.ts
+++ b/apps/web/src/lib/commands/types.ts
@@ -34,6 +34,7 @@ export interface CommandPage {
   label: string;
   icon?: ReactNode;
   commands: Command[];
+  multiple?: boolean;
   onBack?: () => void; // Custom back handler
 }
 

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -20,9 +20,9 @@ function Checkbox({
     >
       <CheckboxPrimitive.Indicator
         data-slot="checkbox-indicator"
-        className="flex items-center justify-center text-current transition-none"
+        className="flex items-center justify-center text-current transition-none size-3.5"
       >
-        <CheckIcon className="size-3.5" />
+        <CheckIcon className="size-3.5 text-current" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   );

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -43,6 +43,7 @@ function Command({
   const handleKeyDown = React.useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       onKeyDown?.(event);
+      const target = event.target as HTMLElement | null;
 
       if (
         event.defaultPrevented ||
@@ -51,9 +52,11 @@ function Command({
         event.altKey ||
         event.ctrlKey ||
         event.metaKey ||
-        event.target instanceof HTMLInputElement ||
-        event.target instanceof HTMLTextAreaElement ||
-        (event.target instanceof HTMLElement && event.target.isContentEditable)
+        (target !== null &&
+          (target.isContentEditable ||
+            target.closest(
+              "input, textarea, select, [contenteditable='true']"
+            )))
       ) {
         return;
       }

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -50,7 +50,10 @@ function Command({
         event.key !== " " ||
         event.altKey ||
         event.ctrlKey ||
-        event.metaKey
+        event.metaKey ||
+        event.target instanceof HTMLInputElement ||
+        event.target instanceof HTMLTextAreaElement ||
+        (event.target instanceof HTMLElement && event.target.isContentEditable)
       ) {
         return;
       }
@@ -287,9 +290,9 @@ function CommandItem({
 
   const handleSelect = React.useCallback(
     (itemValue: string) => {
-      select(itemValue, true);
+      select(value ?? itemValue, true);
     },
-    [select]
+    [select, value]
   );
 
   const itemContext = React.useMemo<CommandItemContextValue>(
@@ -337,12 +340,8 @@ function CommandItemCheckbox({
   const item = React.useContext(CommandItemContext);
   const selection = React.useContext(CommandSelectionContext);
 
-  if (!item) {
-    throw new Error("CommandItemCheckbox must be used within CommandItem.");
-  }
-
   const resolvedChecked =
-    selection?.multiple && item.value !== undefined
+    selection?.multiple && item?.value !== undefined
       ? selection.selectedValues.has(item.value)
       : checked;
 
@@ -350,7 +349,7 @@ function CommandItemCheckbox({
     (nextChecked: boolean | "indeterminate") => {
       onCheckedChange?.(nextChecked);
       if (selection?.multiple) {
-        item.selectWithoutClosing();
+        item?.selectWithoutClosing();
       }
     },
     [item, onCheckedChange, selection]
@@ -365,6 +364,10 @@ function CommandItemCheckbox({
     },
     [onClick]
   );
+
+  if (!item) {
+    throw new Error("CommandItemCheckbox must be used within CommandItem.");
+  }
 
   return (
     <Checkbox

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Checkbox } from "@workspace/ui/components/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -12,10 +13,63 @@ import { cn } from "@workspace/ui/lib/utils";
 import { Command as CommandPrimitive } from "cmdk";
 import * as React from "react";
 
+interface CommandSelectionContextValue {
+  close: () => void;
+  multiple: boolean;
+  selectedValues: Set<string>;
+  toggle: (value: string) => void;
+}
+
+const CommandSelectionContext = React.createContext<
+  CommandSelectionContextValue | undefined
+>(undefined);
+
+interface CommandItemContextValue {
+  selectWithoutClosing: () => void;
+  value?: string;
+}
+
+const CommandItemContext = React.createContext<
+  CommandItemContextValue | undefined
+>(undefined);
+
 function Command({
   className,
+  onKeyDown,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive>) {
+  const selection = React.useContext(CommandSelectionContext);
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      onKeyDown?.(event);
+
+      if (
+        event.defaultPrevented ||
+        !selection?.multiple ||
+        event.key !== " " ||
+        event.altKey ||
+        event.ctrlKey ||
+        event.metaKey
+      ) {
+        return;
+      }
+
+      const selectedItem = event.currentTarget.querySelector<HTMLElement>(
+        '[cmdk-item][aria-selected="true"]'
+      );
+      const checkbox = selectedItem?.querySelector<HTMLButtonElement>(
+        '[data-slot="command-item-checkbox"]'
+      );
+
+      if (checkbox) {
+        event.preventDefault();
+        checkbox.click();
+      }
+    },
+    [onKeyDown, selection]
+  );
+
   return (
     <CommandPrimitive
       data-slot="command"
@@ -23,10 +77,27 @@ function Command({
         "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
         className
       )}
+      onKeyDown={handleKeyDown}
       {...props}
     />
   );
 }
+
+type CommandDialogProps = Omit<
+  React.ComponentProps<typeof Dialog>,
+  "children"
+> & {
+  children?: React.ReactNode;
+  title?: string;
+  description?: string;
+  className?: string;
+  showCloseButton?: boolean;
+  render?: React.ComponentProps<typeof DialogContent>["render"];
+  multiple?: boolean;
+  value?: string[];
+  defaultValue?: string[];
+  onValueChange?: (value: string[]) => void;
+};
 
 function CommandDialog({
   title = "Command Palette",
@@ -35,35 +106,82 @@ function CommandDialog({
   className,
   showCloseButton = false,
   render,
+  multiple = false,
+  value,
+  defaultValue = [],
+  onValueChange,
+  actionsRef,
   ...props
-}: Omit<React.ComponentProps<typeof Dialog>, "children"> & {
-  children?: React.ReactNode;
-  title?: string;
-  description?: string;
-  className?: string;
-  showCloseButton?: boolean;
-  render?: React.ComponentProps<typeof DialogContent>["render"];
-}) {
+}: CommandDialogProps) {
+  const dialogActionsRef = React.useRef<{
+    close: () => void;
+    unmount: () => void;
+  } | null>(null);
+  const [uncontrolledValue, setUncontrolledValue] =
+    React.useState(defaultValue);
+  const selectedValue = value ?? uncontrolledValue;
+  const selectedValues = React.useMemo(
+    () => new Set(selectedValue),
+    [selectedValue]
+  );
+
+  React.useEffect(() => {
+    if (!actionsRef) {
+      return;
+    }
+
+    actionsRef.current = dialogActionsRef.current;
+
+    return () => {
+      actionsRef.current = null;
+    };
+  }, [actionsRef]);
+
+  const close = React.useCallback(() => {
+    dialogActionsRef.current?.close();
+  }, []);
+
+  const toggle = React.useCallback(
+    (itemValue: string) => {
+      const nextValue = selectedValues.has(itemValue)
+        ? selectedValue.filter((entry) => entry !== itemValue)
+        : [...selectedValue, itemValue];
+
+      if (value === undefined) {
+        setUncontrolledValue(nextValue);
+      }
+      onValueChange?.(nextValue);
+    },
+    [onValueChange, selectedValue, selectedValues, value]
+  );
+
+  const selectionContext = React.useMemo<CommandSelectionContextValue>(
+    () => ({ close, multiple, selectedValues, toggle }),
+    [close, multiple, selectedValues, toggle]
+  );
+
   return (
-    <Dialog {...props}>
-      <DialogHeader className="sr-only">
-        <DialogTitle>{title}</DialogTitle>
-        <DialogDescription>{description}</DialogDescription>
-      </DialogHeader>
-      <DialogContent
-        className={cn(
-          "overflow-hidden border-0 p-0 sm:max-w-xl shadow-xl rounded-none",
-          className
-        )}
-        showCloseButton={showCloseButton}
-        render={render}
-        hideOverlay
-      >
-        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg:not([class*='size-'])]:size-4 border">
-          {children}
-        </Command>
-      </DialogContent>
-    </Dialog>
+    <CommandSelectionContext.Provider value={selectionContext}>
+      <Dialog actionsRef={dialogActionsRef} {...props}>
+        <DialogHeader className="sr-only">
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogContent
+          className={cn(
+            "overflow-hidden border-0 p-0 sm:max-w-xl shadow-xl rounded-none",
+            className
+          )}
+          showCloseButton={showCloseButton}
+          render={render}
+          hideOverlay
+        >
+          <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg:not([class*='size-'])]:size-4 border">
+            {children}
+          </Command>
+        </DialogContent>
+      </Dialog>
+    </CommandSelectionContext.Provider>
   );
 }
 
@@ -147,13 +265,117 @@ function CommandSeparator({
 
 function CommandItem({
   className,
+  children,
+  onSelect,
+  value,
   ...props
 }: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  const selection = React.useContext(CommandSelectionContext);
+
+  const select = React.useCallback(
+    (itemValue: string, close: boolean) => {
+      if (selection?.multiple) {
+        selection.toggle(itemValue);
+      }
+      onSelect?.(itemValue);
+      if (selection?.multiple && close) {
+        selection.close();
+      }
+    },
+    [onSelect, selection]
+  );
+
+  const handleSelect = React.useCallback(
+    (itemValue: string) => {
+      select(itemValue, true);
+    },
+    [select]
+  );
+
+  const itemContext = React.useMemo<CommandItemContextValue>(
+    () => ({
+      selectWithoutClosing: () => {
+        if (value === undefined) {
+          throw new Error(
+            "CommandItem requires a value when used with CommandItemCheckbox."
+          );
+        }
+        select(value, false);
+      },
+      value,
+    }),
+    [select, value]
+  );
+
   return (
-    <CommandPrimitive.Item
-      data-slot="command-item"
+    <CommandItemContext.Provider value={itemContext}>
+      <CommandPrimitive.Item
+        data-slot="command-item"
+        className={cn(
+          "group/command-item data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-9",
+          className
+        )}
+        onSelect={handleSelect}
+        value={value}
+        {...props}
+      >
+        {children}
+      </CommandPrimitive.Item>
+    </CommandItemContext.Provider>
+  );
+}
+
+function CommandItemCheckbox({
+  "aria-label": ariaLabel,
+  checked,
+  className,
+  onCheckedChange,
+  onClick,
+  tabIndex = -1,
+  ...props
+}: React.ComponentProps<typeof Checkbox>) {
+  const item = React.useContext(CommandItemContext);
+  const selection = React.useContext(CommandSelectionContext);
+
+  if (!item) {
+    throw new Error("CommandItemCheckbox must be used within CommandItem.");
+  }
+
+  const resolvedChecked =
+    selection?.multiple && item.value !== undefined
+      ? selection.selectedValues.has(item.value)
+      : checked;
+
+  const handleCheckedChange = React.useCallback(
+    (nextChecked: boolean | "indeterminate") => {
+      onCheckedChange?.(nextChecked);
+      if (selection?.multiple) {
+        item.selectWithoutClosing();
+      }
+    },
+    [item, onCheckedChange, selection]
+  );
+
+  const handleClick = React.useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      if (!event.defaultPrevented) {
+        event.stopPropagation();
+      }
+    },
+    [onClick]
+  );
+
+  return (
+    <Checkbox
+      data-slot="command-item-checkbox"
+      aria-label={ariaLabel ?? `Toggle ${item.value ?? "item"}`}
+      checked={resolvedChecked}
+      onCheckedChange={handleCheckedChange}
+      onClick={handleClick}
+      tabIndex={tabIndex}
       className={cn(
-        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 h-9",
+        "opacity-0 group-data-[selected=true]/command-item:opacity-100 data-[state=checked]:opacity-100",
         className
       )}
       {...props}
@@ -193,6 +415,7 @@ export {
   CommandGroup,
   CommandInput,
   CommandItem,
+  CommandItemCheckbox,
   CommandList,
   CommandSeparator,
   CommandShortcut,

--- a/packages/ui/src/routes/command.tsx
+++ b/packages/ui/src/routes/command.tsx
@@ -1,15 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import {
-  CalendarIcon,
-  FileIcon,
-  HomeIcon,
-  SearchIcon,
-  SettingsIcon,
-  UserIcon,
-} from "lucide-react";
-import { useState } from "react";
-
-import { Button } from "@/components/button";
+import { Button } from "@workspace/ui/components/button";
 import {
   Command,
   CommandDialog,
@@ -18,480 +8,395 @@ import {
   CommandGroup,
   CommandInput,
   CommandItem,
+  CommandItemCheckbox,
   CommandList,
   CommandSeparator,
   CommandShortcut,
-} from "@/components/command";
-import { Keybind } from "@/components/keybind";
+  CommandTrail,
+} from "@workspace/ui/components/command";
+import { Keybind } from "@workspace/ui/components/keybind";
+import { FileText, Home, Settings, User } from "lucide-react";
+import { useState } from "react";
 
-export const Route = createFileRoute("/command")({
+import {
+  Anatomy,
+  Demo,
+  DocPage,
+  DocSection,
+  PropsTable,
+} from "./-components/doc-kit";
+import type { ComponentMeta } from "./-components/doc-kit";
+
+export const meta: ComponentMeta = {
+  description:
+    "A searchable command list and dialog with grouped actions, keyboard navigation, and an optional checkbox-based multi-select mode.",
+  import:
+    'import { CommandDialog, CommandInput, CommandItem, CommandItemCheckbox } from "@workspace/ui/components/command";',
+  name: "Command",
+  related: ["Dialog", "Combobox", "Select", "Keybind"],
+  status: "stable",
+  whenNotToUse: [
+    "Choosing one value from a fixed form field — use Select or RadioGroup.",
+    "Entering or editing data — use form controls such as Input and Checkbox.",
+    "A short menu without search — use DropdownMenu.",
+  ],
+  whenToUse: [
+    "Running actions or navigating from a searchable command palette.",
+    "Choosing several searchable options where checkbox clicks and Space should keep the dialog open.",
+    "Grouping a longer action set while preserving arrow-key navigation and shortcuts.",
+  ],
+};
+
+export const Route = createFileRoute("/command" as unknown as "/command")({
   component: RouteComponent,
 });
 
-function RouteComponent() {
+function CommandDialogDemo() {
   const [open, setOpen] = useState(false);
 
   return (
-    <div className="flex flex-col gap-8">
-      <div className="text-lg">Command</div>
+    <>
+      <Button onClick={() => setOpen(true)}>Open command palette</Button>
+      <CommandDialog open={open} onOpenChange={setOpen}>
+        <CommandInput placeholder="Search commands..." />
+        <CommandList>
+          <CommandEmpty>No commands found.</CommandEmpty>
+          <CommandGroup heading="Navigation">
+            <CommandItem onSelect={() => setOpen(false)}>
+              <Home />
+              <span>Home</span>
+              <CommandShortcut keybind="mod+h" />
+            </CommandItem>
+            <CommandItem onSelect={() => setOpen(false)}>
+              <Settings />
+              <span>Settings</span>
+              <CommandShortcut keybind="mod+," />
+            </CommandItem>
+          </CommandGroup>
+        </CommandList>
+        <CommandFooter>
+          Press <Keybind keybind="esc" /> to close
+        </CommandFooter>
+      </CommandDialog>
+    </>
+  );
+}
 
-      {/* Basic Command */}
-      <div className="flex flex-col gap-4">
-        <div className="text-sm">Basic Command</div>
-        <div className="border rounded-md p-4 border-dashed">
-          <Command className="max-w-md">
-            <CommandInput placeholder="Type a command or search..." />
-            <CommandList>
-              <CommandEmpty>No results found.</CommandEmpty>
-              <CommandGroup heading="Suggestions">
-                <CommandItem>
-                  <CalendarIcon />
-                  <span>Calendar</span>
-                </CommandItem>
-                <CommandItem>
-                  <FileIcon />
-                  <span>Search Emoji</span>
-                </CommandItem>
-                <CommandItem>
-                  <UserIcon />
-                  <span>Calculator</span>
-                </CommandItem>
-              </CommandGroup>
-              <CommandSeparator />
-              <CommandGroup heading="Settings">
-                <CommandItem>
-                  <SettingsIcon />
-                  <span>Profile</span>
-                  <CommandShortcut keybind="mod+p" />
-                </CommandItem>
-                <CommandItem>
-                  <SettingsIcon />
-                  <span>Mail</span>
-                  <CommandShortcut keybind="mod+b" />
-                </CommandItem>
-                <CommandItem>
-                  <SettingsIcon />
-                  <span>Settings</span>
-                  <CommandShortcut keybind="mod+s" />
-                </CommandItem>
-              </CommandGroup>
-            </CommandList>
-            <CommandFooter>
-              Press <Keybind keybind="esc" /> to close
-            </CommandFooter>
-          </Command>
-        </div>
-      </div>
+function MultiSelectDemo() {
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState(["billing"]);
 
-      {/* Command Dialog */}
-      <div className="flex flex-col gap-4">
-        <div className="text-sm">Command Dialog</div>
-        <div className="border rounded-md p-4 border-dashed flex items-center gap-4">
-          <Button onClick={() => setOpen(true)}>Open Command Palette</Button>
-          <CommandDialog open={open} onOpenChange={setOpen}>
-            <CommandInput placeholder="Type a command or search..." />
-            <CommandList>
-              <CommandEmpty>No results found.</CommandEmpty>
-              <CommandGroup heading="Navigation">
-                <CommandItem>
-                  <HomeIcon />
-                  <span>Home</span>
-                  <CommandShortcut keybind="mod+h" />
-                </CommandItem>
-                <CommandItem>
-                  <SearchIcon />
-                  <span>Search</span>
-                  <CommandShortcut keybind="mod+k" />
-                </CommandItem>
-                <CommandItem>
-                  <FileIcon />
-                  <span>Files</span>
-                  <CommandShortcut keybind="mod+f" />
-                </CommandItem>
-              </CommandGroup>
-              <CommandSeparator />
-              <CommandGroup heading="Account">
-                <CommandItem>
-                  <UserIcon />
-                  <span>Profile</span>
-                  <CommandShortcut keybind="mod+p" />
-                </CommandItem>
-                <CommandItem>
-                  <SettingsIcon />
-                  <span>Settings</span>
-                  <CommandShortcut keybind="mod+s" />
-                </CommandItem>
-              </CommandGroup>
-            </CommandList>
-            <CommandFooter>
-              Press <Keybind keybind="esc" /> to close
-            </CommandFooter>
-          </CommandDialog>
-        </div>
-      </div>
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <Button onClick={() => setOpen(true)}>Assign topics</Button>
+      <span className="text-foreground-secondary text-sm">
+        {selected.length > 0 ? selected.join(", ") : "No topics selected"}
+      </span>
+      <CommandDialog
+        multiple
+        open={open}
+        onOpenChange={setOpen}
+        value={selected}
+        onValueChange={setSelected}
+      >
+        <CommandInput placeholder="Search topics..." />
+        <CommandList>
+          <CommandEmpty>No topics found.</CommandEmpty>
+          <CommandGroup heading="Topics">
+            <CommandItem value="billing">
+              <CommandItemCheckbox aria-label="Toggle Billing" />
+              <span>Billing</span>
+            </CommandItem>
+            <CommandItem value="product">
+              <CommandItemCheckbox aria-label="Toggle Product" />
+              <span>Product</span>
+            </CommandItem>
+            <CommandItem value="security">
+              <CommandItemCheckbox aria-label="Toggle Security" />
+              <span>Security</span>
+            </CommandItem>
+          </CommandGroup>
+        </CommandList>
+        <CommandFooter className="justify-end gap-3">
+          <span className="flex items-center gap-1">
+            <Keybind keybind="space" /> Toggle
+          </span>
+          <span className="flex items-center gap-1">
+            <Keybind keybind="enter" /> Toggle and close
+          </span>
+        </CommandFooter>
+      </CommandDialog>
+    </div>
+  );
+}
 
-      {/* Command with Multiple Groups */}
-      <div className="flex flex-col gap-4">
-        <div className="text-sm">Multiple Groups</div>
-        <div className="border rounded-md p-4 border-dashed">
-          <Command className="max-w-md">
-            <CommandInput placeholder="Search commands..." />
+function RouteComponent() {
+  return (
+    <DocPage meta={meta}>
+      <DocSection
+        title="Inline"
+        description="Compose an inline searchable list from explicit groups, items, trails, and separators."
+      >
+        <Demo
+          code={`<Command className="max-w-md rounded-md border">
+  <CommandInput placeholder="Search files..." />
+  <CommandList>
+    <CommandEmpty>No files found.</CommandEmpty>
+    <CommandGroup heading="Recent">
+      <CommandItem>
+        <FileText />
+        <span>Quarterly report</span>
+        <CommandTrail>
+          <CommandShortcut keybind="mod+1" />
+        </CommandTrail>
+      </CommandItem>
+      <CommandItem disabled>
+        <FileText />
+        <span>Archived notes</span>
+      </CommandItem>
+    </CommandGroup>
+    <CommandSeparator />
+    <CommandGroup heading="People">
+      <CommandItem>
+        <User />
+        <span>Pedro Costa</span>
+      </CommandItem>
+    </CommandGroup>
+  </CommandList>
+</Command>`}
+        >
+          <Command className="max-w-md rounded-md border">
+            <CommandInput placeholder="Search files..." />
             <CommandList>
-              <CommandEmpty>No results found.</CommandEmpty>
+              <CommandEmpty>No files found.</CommandEmpty>
               <CommandGroup heading="Recent">
                 <CommandItem>
-                  <FileIcon />
-                  <span>Document 1</span>
-                </CommandItem>
-                <CommandItem>
-                  <FileIcon />
-                  <span>Document 2</span>
-                </CommandItem>
-              </CommandGroup>
-              <CommandSeparator />
-              <CommandGroup heading="Favorites">
-                <CommandItem>
-                  <HomeIcon />
-                  <span>Dashboard</span>
-                </CommandItem>
-                <CommandItem>
-                  <SettingsIcon />
-                  <span>Configuration</span>
-                </CommandItem>
-              </CommandGroup>
-              <CommandSeparator />
-              <CommandGroup heading="Actions">
-                <CommandItem>
-                  <FileIcon />
-                  <span>New File</span>
-                  <CommandShortcut keybind="mod+n" />
-                </CommandItem>
-                <CommandItem>
-                  <FileIcon />
-                  <span>Open File</span>
-                  <CommandShortcut keybind="mod+o" />
-                </CommandItem>
-              </CommandGroup>
-            </CommandList>
-          </Command>
-        </div>
-      </div>
-
-      {/* Command with Disabled Items */}
-      <div className="flex flex-col gap-4">
-        <div className="text-sm">Disabled Items</div>
-        <div className="border rounded-md p-4 border-dashed">
-          <Command className="max-w-md">
-            <CommandInput placeholder="Type a command or search..." />
-            <CommandList>
-              <CommandEmpty>No results found.</CommandEmpty>
-              <CommandGroup heading="Available">
-                <CommandItem>
-                  <CalendarIcon />
-                  <span>Calendar</span>
+                  <FileText />
+                  <span>Quarterly report</span>
+                  <CommandTrail>
+                    <CommandShortcut keybind="mod+1" />
+                  </CommandTrail>
                 </CommandItem>
                 <CommandItem disabled>
-                  <FileIcon />
-                  <span>Search Emoji (Disabled)</span>
+                  <FileText />
+                  <span>Archived notes</span>
                 </CommandItem>
+              </CommandGroup>
+              <CommandSeparator />
+              <CommandGroup heading="People">
                 <CommandItem>
-                  <UserIcon />
-                  <span>Calculator</span>
+                  <User />
+                  <span>Pedro Costa</span>
                 </CommandItem>
               </CommandGroup>
             </CommandList>
           </Command>
-        </div>
-      </div>
+        </Demo>
+      </DocSection>
 
-      {/* Command Empty State */}
-      <div className="flex flex-col gap-4">
-        <div className="text-sm">Empty State</div>
-        <div className="border rounded-md p-4 border-dashed">
-          <Command className="max-w-md">
-            <CommandInput placeholder="Type 'xyz' to see empty state..." />
-            <CommandList>
-              <CommandEmpty>No results found.</CommandEmpty>
-            </CommandList>
-          </Command>
-        </div>
-      </div>
+      <DocSection
+        title="Dialog"
+        description="Single-select commands keep their existing explicit close behavior: close the controlled dialog from onSelect when the action completes."
+      >
+        <Demo
+          code={`const [open, setOpen] = useState(false);
 
-      {/* Command Footer */}
-      <div className="flex flex-col gap-4">
-        <div className="text-sm">Command Footer</div>
-        <div className="border rounded-md p-4 border-dashed">
-          <Command className="max-w-md">
-            <CommandInput placeholder="Type a command or search..." />
-            <CommandList>
-              <CommandEmpty>No results found.</CommandEmpty>
-              <CommandGroup heading="Navigation">
-                <CommandItem>
-                  <HomeIcon />
-                  <span>Home</span>
-                </CommandItem>
-                <CommandItem>
-                  <SearchIcon />
-                  <span>Search</span>
-                </CommandItem>
-              </CommandGroup>
-            </CommandList>
-            <CommandFooter>
-              <div className="flex items-center justify-between">
-                <span>Use arrow keys to navigate</span>
-                <div className="flex items-center gap-2">
-                  <span>Select:</span>
-                  <CommandShortcut keybind="enter" />
-                </div>
-              </div>
-            </CommandFooter>
-          </Command>
-        </div>
-        <div className="border rounded-md p-4 border-dashed">
-          <Command className="max-w-md">
-            <CommandInput placeholder="Type a command or search..." />
-            <CommandList>
-              <CommandEmpty>No results found.</CommandEmpty>
-              <CommandGroup heading="Actions">
-                <CommandItem>
-                  <FileIcon />
-                  <span>New File</span>
-                  <CommandShortcut keybind="mod+n" />
-                </CommandItem>
-                <CommandItem>
-                  <FileIcon />
-                  <span>Open File</span>
-                  <CommandShortcut keybind="mod+o" />
-                </CommandItem>
-              </CommandGroup>
-            </CommandList>
-            <CommandFooter>
-              Press <Keybind keybind="esc" /> to close •{" "}
-              <Keybind keybind="mod+k" /> to open
-            </CommandFooter>
-          </Command>
-        </div>
-      </div>
+<>
+  <Button onClick={() => setOpen(true)}>Open command palette</Button>
+  <CommandDialog open={open} onOpenChange={setOpen}>
+    <CommandInput placeholder="Search commands..." />
+    <CommandList>
+      <CommandEmpty>No commands found.</CommandEmpty>
+      <CommandGroup heading="Navigation">
+        <CommandItem onSelect={() => setOpen(false)}>
+          <Home />
+          <span>Home</span>
+          <CommandShortcut keybind="mod+h" />
+        </CommandItem>
+        <CommandItem onSelect={() => setOpen(false)}>
+          <Settings />
+          <span>Settings</span>
+          <CommandShortcut keybind="mod+," />
+        </CommandItem>
+      </CommandGroup>
+    </CommandList>
+    <CommandFooter>
+      Press <Keybind keybind="esc" /> to close
+    </CommandFooter>
+  </CommandDialog>
+</>`}
+        >
+          <CommandDialogDemo />
+        </Demo>
+      </DocSection>
 
-      {/* Usage Guidelines */}
-      <div className="flex flex-col gap-4">
-        <div className="text-lg">Usage Guidelines</div>
-        <div className="space-y-6">
-          <div className="space-y-3">
-            <div className="text-sm font-medium">Overview</div>
-            <div className="text-sm space-y-2">
-              <p>
-                The{" "}
-                <code className="px-1 py-0.5 bg-background-tertiary border font-mono rounded text-xs">
-                  Command
-                </code>{" "}
-                component provides a command palette interface for quick actions
-                and navigation. It's built on top of{" "}
-                <code className="px-1 py-0.5 bg-background-tertiary border font-mono rounded text-xs">
-                  cmdk
-                </code>{" "}
-                and offers keyboard navigation, search, and grouping
-                capabilities.
-              </p>
-              <p>
-                Use{" "}
-                <code className="px-1 py-0.5 bg-background-tertiary border font-mono rounded text-xs">
-                  CommandDialog
-                </code>{" "}
-                for modal command palettes that overlay the entire screen, or
-                use{" "}
-                <code className="px-1 py-0.5 bg-background-tertiary border font-mono rounded text-xs">
-                  Command
-                </code>{" "}
-                directly for inline command interfaces.
-              </p>
-            </div>
-          </div>
+      <DocSection
+        title="Multi-select"
+        description="Click an item or press Enter to toggle it and close. Click its checkbox or press Space to toggle it and keep the dialog open. Every checkbox item needs an explicit value."
+      >
+        <Demo
+          code={`const [open, setOpen] = useState(false);
+const [selected, setSelected] = useState(["billing"]);
 
-          <div className="space-y-3">
-            <div className="text-sm font-medium">Component Structure</div>
-            <div className="text-sm space-y-2">
-              <ul className="text-sm space-y-1.5 list-disc list-inside">
-                <li>
-                  <code className="px-1 py-0.5 bg-background-tertiary border font-mono rounded text-xs">
-                    Command
-                  </code>{" "}
-                  - Base container component
-                </li>
-                <li>
-                  <code className="px-1 py-0.5 bg-background-tertiary border font-mono rounded text-xs">
-                    CommandDialog
-                  </code>{" "}
-                  - Dialog wrapper with built-in modal behavior
-                </li>
-                <li>
-                  <code className="px-1 py-0.5 bg-background-tertiary border font-mono rounded text-xs">
-                    CommandInput
-                  </code>{" "}
-                  - Search input field with icon
-                </li>
-                <li>
-                  <code className="px-1 py-0.5 bg-background-tertiary border font-mono rounded text-xs">
-                    CommandList
-                  </code>{" "}
-                  - Scrollable list container
-                </li>
-                <li>
-                  <code className="px-1 py-0.5 bg-background-tertiary border font-mono rounded text-xs">
-                    CommandEmpty
-                  </code>{" "}
-                  - Empty state when no results found
-                </li>
-                <li>
-                  <code className="px-1 py-0.5 bg-background-tertiary border font-mono rounded text-xs">
-                    CommandGroup
-                  </code>{" "}
-                  - Group items with optional heading
-                </li>
-                <li>
-                  <code className="px-1 py-0.5 bg-background-tertiary border font-mono rounded text-xs">
-                    CommandItem
-                  </code>{" "}
-                  - Individual command item
-                </li>
-                <li>
-                  <code className="px-1 py-0.5 bg-background-tertiary border font-mono rounded text-xs">
-                    CommandSeparator
-                  </code>{" "}
-                  - Visual separator between groups
-                </li>
-                <li>
-                  <code className="px-1 py-0.5 bg-background-tertiary border font-mono rounded text-xs">
-                    CommandShortcut
-                  </code>{" "}
-                  - Display keyboard shortcuts
-                </li>
-                <li>
-                  <code className="px-1 py-0.5 bg-background-tertiary border font-mono rounded text-xs">
-                    CommandFooter
-                  </code>{" "}
-                  - Footer section for hints, tips, or additional information
-                </li>
-              </ul>
-            </div>
-          </div>
+<div className="flex flex-wrap items-center gap-3">
+  <Button onClick={() => setOpen(true)}>Assign topics</Button>
+  <span className="text-foreground-secondary text-sm">
+    {selected.length > 0 ? selected.join(", ") : "No topics selected"}
+  </span>
+  <CommandDialog
+    multiple
+    open={open}
+    onOpenChange={setOpen}
+    value={selected}
+    onValueChange={setSelected}
+  >
+    <CommandInput placeholder="Search topics..." />
+    <CommandList>
+      <CommandEmpty>No topics found.</CommandEmpty>
+      <CommandGroup heading="Topics">
+        <CommandItem value="billing">
+          <CommandItemCheckbox aria-label="Toggle Billing" />
+          <span>Billing</span>
+        </CommandItem>
+        <CommandItem value="product">
+          <CommandItemCheckbox aria-label="Toggle Product" />
+          <span>Product</span>
+        </CommandItem>
+        <CommandItem value="security">
+          <CommandItemCheckbox aria-label="Toggle Security" />
+          <span>Security</span>
+        </CommandItem>
+      </CommandGroup>
+    </CommandList>
+    <CommandFooter className="justify-end gap-3">
+      <span className="flex items-center gap-1">
+        <Keybind keybind="space" /> Toggle
+      </span>
+      <span className="flex items-center gap-1">
+        <Keybind keybind="enter" /> Toggle and close
+      </span>
+    </CommandFooter>
+  </CommandDialog>
+</div>`}
+        >
+          <MultiSelectDemo />
+        </Demo>
+      </DocSection>
 
-          <div className="space-y-3">
-            <div className="text-sm font-medium">Do's ✓</div>
-            <ul className="text-sm space-y-1.5 list-disc list-inside">
-              <li>
-                Use CommandDialog for global command palettes (typically
-                triggered by ⌘K or Ctrl+K)
-              </li>
-              <li>
-                Use Command for inline search interfaces (e.g., comboboxes,
-                search bars)
-              </li>
-              <li>
-                Group related commands together using CommandGroup with
-                descriptive headings
-              </li>
-              <li>
-                Use CommandShortcut to display keyboard shortcuts for common
-                actions
-              </li>
-              <li>
-                Use CommandFooter to display helpful hints, keyboard shortcuts,
-                or additional context at the bottom of the command palette
-              </li>
-              <li>
-                Always include CommandEmpty to show a helpful message when no
-                results are found
-              </li>
-              <li>
-                Use icons in CommandItem to provide visual context and improve
-                scanability
-              </li>
-              <li>
-                Use CommandSeparator to visually separate different groups of
-                commands
-              </li>
-              <li>
-                Disable items using the disabled prop rather than hiding them
-                when users should be aware of unavailable actions
-              </li>
-              <li>
-                Provide descriptive placeholder text in CommandInput to guide
-                users
-              </li>
-            </ul>
-          </div>
+      <DocSection
+        title="CommandDialog API"
+        description="Props in addition to the Base UI Dialog root props."
+      >
+        <PropsTable
+          rows={[
+            {
+              default: "false",
+              description:
+                "Enables checkbox multi-selection, Space-to-toggle, and automatic close after item click or Enter.",
+              name: "multiple",
+              type: "boolean",
+            },
+            {
+              description:
+                "Selected item values in controlled multi-select mode.",
+              name: "value",
+              type: "string[]",
+            },
+            {
+              default: "[]",
+              description:
+                "Initially selected item values in uncontrolled multi-select mode.",
+              name: "defaultValue",
+              type: "string[]",
+            },
+            {
+              description:
+                "Called with the next selected value array whenever an item is toggled.",
+              name: "onValueChange",
+              type: "(value: string[]) => void",
+            },
+            {
+              default: '"Command Palette"',
+              description:
+                "Accessible dialog title, visually hidden by default.",
+              name: "title",
+              type: "string",
+            },
+            {
+              default: '"Search for a command to run..."',
+              description:
+                "Accessible dialog description, visually hidden by default.",
+              name: "description",
+              type: "string",
+            },
+            {
+              default: "false",
+              description: "Shows the dialog close button.",
+              name: "showCloseButton",
+              type: "boolean",
+            },
+          ]}
+        />
+      </DocSection>
 
-          <div className="space-y-3">
-            <div className="text-sm font-medium">Don'ts ✗</div>
-            <ul className="text-sm space-y-1.5 list-disc list-inside">
-              <li>
-                Don't use CommandDialog for simple dropdown menus - use Select
-                or Combobox instead
-              </li>
-              <li>
-                Don't nest Command components - use CommandGroup for
-                organization instead
-              </li>
-              <li>
-                Don't use CommandItem without proper keyboard navigation support
-              </li>
-              <li>
-                Don't create overly deep nesting - keep command structure flat
-                and scannable
-              </li>
-              <li>
-                Don't use Command for forms or data entry - it's designed for
-                command execution and navigation
-              </li>
-              <li>
-                Don't forget to handle the onSelect event for CommandItem to
-                execute actions
-              </li>
-              <li>
-                Don't use CommandDialog without proper open/close state
-                management
-              </li>
-              <li>
-                Avoid using too many groups - keep the structure simple and
-                intuitive
-              </li>
-            </ul>
-          </div>
+      <DocSection
+        title="Item API"
+        description="CommandItem and CommandItemCheckbox props in addition to their underlying cmdk Item and Checkbox props."
+      >
+        <PropsTable
+          rows={[
+            {
+              description:
+                "Stable item identifier. Required when the item contains CommandItemCheckbox.",
+              name: "value (CommandItem)",
+              type: "string",
+            },
+            {
+              description:
+                "Runs after selection. In multi-select mode, the value array is updated before this callback.",
+              name: "onSelect (CommandItem)",
+              type: "(value: string) => void",
+            },
+            {
+              default: "false",
+              description:
+                "Excludes the item from pointer and keyboard selection.",
+              name: "disabled (CommandItem)",
+              type: "boolean",
+            },
+            {
+              description:
+                "Accessible name for the checkbox. Defaults to the item value; provide a human-readable label.",
+              name: "aria-label (CommandItemCheckbox)",
+              type: "string",
+            },
+          ]}
+        />
+      </DocSection>
 
-          <div className="space-y-3">
-            <div className="text-sm font-medium">Accessibility</div>
-            <ul className="text-sm space-y-1.5 list-disc list-inside">
-              <li>
-                Command components are fully keyboard accessible - use Arrow
-                keys to navigate, Enter to select, Escape to close
-              </li>
-              <li>
-                Search functionality filters items automatically as you type
-              </li>
-              <li>
-                Focus management is handled automatically when opening
-                CommandDialog
-              </li>
-              <li>
-                Use aria-label on CommandInput if the placeholder doesn't
-                provide sufficient context
-              </li>
-              <li>
-                Disabled items are automatically excluded from keyboard
-                navigation
-              </li>
-              <li>
-                CommandDialog includes proper ARIA attributes for modal dialogs
-              </li>
-              <li>
-                Screen readers will announce group headings and item labels
-                appropriately
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </div>
+      <DocSection
+        title="Anatomy"
+        description="Checkboxes are explicit item slots; omit them for ordinary command items."
+      >
+        <Anatomy
+          code={`<CommandDialog multiple value={value} onValueChange={setValue}>
+  <CommandInput />
+  <CommandList>
+    <CommandEmpty />
+    <CommandGroup>
+      <CommandItem value="option">
+        <CommandItemCheckbox aria-label="Toggle option" />
+        <span>Option</span>
+        <CommandTrail>
+          <CommandShortcut keybind="mod+1" />
+        </CommandTrail>
+      </CommandItem>
+    </CommandGroup>
+  </CommandList>
+  <CommandFooter />
+</CommandDialog>`}
+        />
+      </DocSection>
+    </DocPage>
   );
 }


### PR DESCRIPTION
## Summary

- add controlled and uncontrolled multi-select behavior to the shared Command dialog
- add checkbox, mouse, and keyboard selection semantics for multi-select command items
- add a Change labels page to the thread command menu backed by live-state attach and detach mutations
- preserve the active command subpage while its live context refreshes
- update the UI Studio Command documentation and examples

## Verification

- bun run --filter @workspace/ui typecheck
- bun run --filter web typecheck
- bun run --filter web build
- oxfmt and oxlint on the changed files
- browser-verified checkbox click, item click, Space, and Enter behavior in UI Studio

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds checkbox-based multi-select to the `@workspace/ui` command dialog and a “Change labels” page in the thread command menu with live attach/detach. Improves keyboard and selection behavior (Space toggles; Enter toggles and closes), keeps the active subpage stable during live refresh, and preserves Space behavior in editable controls.

- **New Features**
  - Multi-select mode in `CommandDialog` with `multiple`, controlled/uncontrolled `value` and `defaultValue`, and `onValueChange`.
  - New `CommandItemCheckbox` slot; requires item `value`. Space toggles without closing; Enter toggles and closes; sensible `aria-label` default; click stops propagation.
  - Thread command menu adds a Labels page showing org labels with color dots and live toggle mutations; dialog stays open while toggling.

- **Refactors**
  - `useCommandContext` safely re-registers/unregisters contexts, preserves the current context across refresh, and correctly handles `active` changes.
  - Keyboard handling in `Command` for Space-to-toggle in multi-select; does not intercept Space in inputs or contenteditable; improved selection semantics and search keywords on multi-select pages.
  - Minor `Checkbox` indicator sizing tweaks; updated UI Studio command docs and examples with multi-select and API details.

<sup>Written for commit dc52888cfd7808c0a89c555c50e96d180b728924. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-select support to command menus, including checkbox controls, selected values, search, and keyboard toggling.
  * Added thread label management through the command menu, allowing labels to be attached or removed with live updates.
  * Added comprehensive command component documentation and interactive examples.

* **Bug Fixes**
  * Improved command context registration and cleanup when contexts change or become inactive.
  * Refined checkbox indicator sizing and color behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->