### PR TITLE
fix(ui): keep surface-frame within its layout box

### DIFF
--- a/packages/ui/src/routes/surface-frame.tsx
+++ b/packages/ui/src/routes/surface-frame.tsx
@@ -50,6 +50,48 @@ function RouteComponent() {
       </DocSection>
 
       <DocSection
+        title="Sizing parity with a real border"
+        description="The frame is painted on a pseudo-element inside the box, not as a shadow spreading out of it, so a framed element occupies exactly the space a bordered one does. Stacked flush, the two edges stay collinear; at equal height and width, the two boxes render identically sized."
+      >
+        <Demo
+          code={`<div className="flex flex-col">
+  <div className="surface-frame surface-frame-bevel-none flex h-9 w-56 items-center rounded-none px-3 text-xs">
+    surface-frame
+  </div>
+  <div className="border border-border-primary flex h-9 w-56 items-center rounded-none px-3 text-xs">
+    border
+  </div>
+</div>
+
+<div className="flex items-center gap-4">
+  <div className="surface-frame surface-frame-bevel-none flex h-9 w-32 items-center justify-center rounded-md text-xs">
+    surface-frame
+  </div>
+  <div className="border border-border-primary flex h-9 w-32 items-center justify-center rounded-md text-xs">
+    border
+  </div>
+</div>`}
+        >
+          <div className="flex flex-col">
+            <div className="surface-frame surface-frame-bevel-none rounded-none flex h-9 w-56 items-center px-3 text-xs">
+              surface-frame
+            </div>
+            <div className="border border-border-primary rounded-none flex h-9 w-56 items-center px-3 text-xs">
+              border
+            </div>
+          </div>
+          <div className="flex items-center gap-4">
+            <div className="surface-frame surface-frame-bevel-none flex h-9 w-32 items-center justify-center rounded-md text-xs">
+              surface-frame
+            </div>
+            <div className="border border-border-primary flex h-9 w-32 items-center justify-center rounded-md text-xs">
+              border
+            </div>
+          </div>
+        </Demo>
+      </DocSection>
+
+      <DocSection
         title="Elevation"
         description="Use the elevation utility to control the smooth stacked shadow. The scale is adapted from flornkm/shadow-plugin and can use Tailwind shadow colors through --tw-shadow-color."
       >

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -301,13 +301,81 @@
       color-mix(in srgb, var(--surface-frame-shadow-color) 1%, transparent);
   --surface-frame-elevation: var(--surface-frame-elevation-default);
 
+  /*
+   * An outset box-shadow spread renders outside the border box, so a ring
+   * drawn that way makes the element paint 1px larger than its layout box on
+   * every side, misaligning it with real-bordered elements of the same size.
+   * The transparent border below reserves that ring of space inside the border
+   * box instead, and the frame is painted into it by two pseudo-elements —
+   * they need different reference boxes, and one element only has two:
+   *
+   *   border box   radius r    the ring and the halo, on ::before
+   *   padding box  radius r-1  the fill, the bevel, and the elevation ::after
+   *                            casts, which has to originate here so its near
+   *                            field lands under the ring rather than outside
+   *                            it
+   *
+   * Those two are parallel offsets of each other, so the ring, the fill and
+   * the bevel stay concentric. ::after is the one approximation: it sits on
+   * the padding box but inherits radius r, since CSS gives no way to name r-1,
+   * leaving it a fraction of a pixel over the fill at the corners — which only
+   * a blur is soft enough to get away with.
+   */
+  position: relative;
+  border: var(--surface-frame-ring-spread) solid transparent;
+  /* Keep the fill ending where the ring begins: ring colors are translucent,
+   * and a background would otherwise paint under the transparent border and
+   * tint them with the element's own fill. */
+  background-clip: padding-box;
+  /* The bevel stays on the element: an inset shadow is clipped to the padding
+   * box, which is already the fill, at a radius the browser derives from the
+   * border width — so the highlight hugs the fill's corners with no radius
+   * math, and paints under the content the way it always has. Declaring the
+   * property here also keeps ring/shadow utilities inert on surface-frame
+   * elements, as they were when the whole frame lived on this declaration. */
   box-shadow:
     inset 0 var(--surface-frame-bevel-y) 0 -0.5px
-      var(--surface-frame-bevel-color),
-    var(--surface-frame-elevation),
-    0 0 0 var(--surface-frame-halo-gap) var(--surface-frame-halo-spacer),
-    0 0 0 var(--surface-frame-halo-spread) var(--surface-frame-halo-color),
-    0 0 0 var(--surface-frame-ring-spread) var(--surface-frame-ring-color) !important;
+      var(--surface-frame-bevel-color) !important;
+
+  /* The ring, lining the reserved border from the border box inwards: outer
+   * edge on the element's own radius, inner edge on the padding box's, which
+   * is where the fill and the bevel end. The halo rides along because it needs
+   * the same exact box — its spacer is opaque, so the fraction of a pixel that
+   * ::after can be off by would paint the backdrop over the fill's corners and
+   * scrub the bevel out of them. Measured from the outer edge, which the ring
+   * no longer extends past, the halo gives back the ring's width. */
+  &::before {
+    content: "";
+    position: absolute;
+    inset: calc(-1 * var(--surface-frame-ring-spread));
+    border-radius: inherit;
+    pointer-events: none;
+    box-shadow:
+      0 0 0
+        calc(var(--surface-frame-halo-gap) - var(--surface-frame-ring-spread))
+        var(--surface-frame-halo-spacer),
+      0 0 0
+        calc(var(--surface-frame-halo-spread) - var(--surface-frame-ring-spread))
+        var(--surface-frame-halo-color),
+      inset 0 0 0 var(--surface-frame-ring-spread)
+        var(--surface-frame-ring-color);
+  }
+
+  /* Elevation, cast from the padding box so its near field falls under the ring
+   * the way it always did — cast from the outer edge instead, it piles up just
+   * outside the ring and the edge stops reading as a line. An outset shadow is
+   * clipped to its caster's border box, so this is the only way to get it in
+   * there; no amount of spread moves a shadow inside the box casting it. Last
+   * of the two pseudo-elements, so it still paints over the ring and over the
+   * halo's opaque spacer, as it did when the frame was one shadow stack. */
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    box-shadow: var(--surface-frame-elevation);
+  }
 }
 
 @utility surface-frame-elevation-none {


### PR DESCRIPTION
## Problem

`surface-frame` drew its 1px edge as the last entry in an outset `box-shadow` stack. An outset spread renders *entirely outside* the border box, so a framed element painted 1px past its layout box on every side — an `h-7` button occupied 28px of layout but painted 30px, where a real `border: 1px` element with `box-sizing: border-box` paints exactly 28px.

## Approach

A transparent border reserves the ring's space *inside* the border box. That's the size fix; everything else exists to keep the appearance identical.

Reserving that space gives the element two boxes with different radii — border box at `r`, padding box at `r−1` — and the frame's layers don't all want the same one. They're split across two pseudo-elements accordingly:

| | Box | Draws |
|---|---|---|
| `::before` | border box, radius `r` | ring (inset) + halo |
| `::after` | padding box | elevation |
| element | padding box (inset-shadow clip, radius `r−1`) | bevel |

- **Ring** is inset from the border box, so its outer edge lands on the element's own radius and its inner edge on the padding box's — concentric with both the fill and the bevel.
- **Halo** shares that box because its spacer is opaque: a sub-pixel radius error there paints the backdrop over the fill's corners and scrubs the bevel out of them.
- **Elevation** must originate at the fill's edge, otherwise its near field piles up just outside the ring and the edge stops reading as a line. An outset shadow is clipped to its caster's border box, so a separate caster is the only way in — no amount of spread moves a shadow inside the box casting it.
- **Bevel** stays on the element, where an inset shadow is clipped to the padding box at a radius the browser derives from the border width, so it hugs the fill's corners with no radius math.
- `background-clip: padding-box` keeps the translucent ring composited over the page background rather than the element's own fill, and `box-shadow` staying declared on the element keeps `focus-visible:ring-*` / `aria-invalid:ring-*` inert on these variants, as the old `!important` did.

`::after` is the one approximation: it sits on the padding box but inherits radius `r`, since CSS gives no way to name `r−1`, leaving it ~0.3px over the fill at the corners — which only a blur is soft enough to get away with.

## Result

Painted size now equals layout size. Fixed-height elements lose the 2px overhang; auto-width ones are unchanged on screen, since the border adds back exactly what the ring stops painting. Elevation, halo and bevel values are untouched.

The Surface Frame route gains a **Sizing parity with a real border** section: a framed box stacked flush above a bordered one at identical size, so any overhang shows as a step at the seam.

## Test plan

- [ ] `/surface-frame` — parity section: edges collinear at the seam, no step
- [ ] Elevation, bevel and halo sections match `main` visually
- [ ] Buttons sit flush in fixed-height rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps `surface-frame` within its layout box by painting the ring inside a reserved transparent border using pseudo-elements. Elements now render at their layout size, matching real `border` sizing.

- **Bug Fixes**
  - Replaced outset `box-shadow` ring with a transparent border and split painting: ring+halo on `::before` (border box), elevation on `::after` (padding box), bevel stays inset on the element.
  - Removed the 1px overhang on all sides so fixed-height controls sit flush and framed vs bordered elements are identically sized and collinear.
  - Added a “Sizing parity with a real border” demo to the `/surface-frame` route to verify alignment.

<sup>Written for commit 29d41b53d2d3fe71997ed6fc022ee51e6b8fbdb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `surface-frame` sizing and alignment to match elements with real borders.
  * Added clearer ring, halo, elevation, and bevel rendering for more consistent visual results.

* **Documentation**
  * Added examples demonstrating sizing parity in stacked and side-by-side layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->