### PR TITLE
feat(web): move issue target settings to Integrations

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -88,7 +88,9 @@ Whether an [integration](#integration)'s [external install](#external-install) s
 
 ### Developer tooling
 
-**Organization**: A FrontDesk tenant and membership boundary. It owns threads, integrations, and configuration; a user gets access through organization membership. _Avoid_: "account" when the tenant is meant.
+### Organization
+
+A FrontDesk tenant and membership boundary. It owns threads, integrations, and configuration; a user gets access through organization membership. _Avoid_: "account" when the tenant is meant.
 
 **Internal developer**: A workspace user with a verified `@tryfrontdesk.app` email address. An internal developer may use [developer tools](#developer-tool) for any [organization](#organization) they belong to; this does not make them an organization owner. _Avoid_: "admin" as a synonym — ownership and internal status are different concepts.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -130,7 +130,7 @@ The vector index of mirrored [external issues](#external-issue), the counterpart
 
 ### Default issue target
 
-The [organization](#organization)-designated sub-resource (e.g. a repository) where **Agent-initiated** issue creation lands. Distinct from the primary [integration](#integration) for the issue-tracker [capability](#capability), which answers _which external system_; this answers _where inside it_. The Agent never chooses the target itself: when no default issue target is set, issue creation is simply not available to [synthesis](#synthesis). Humans remain free to pick any target, including when accepting an Agent proposal.
+The [organization](#organization)-designated sub-resource (e.g. a repository) where **Agent-initiated** issue creation lands. Distinct from the primary [integration](#integration) for the issue-tracker [capability](#capability), which answers _which external system_; this answers _where inside it_. The Agent never chooses the target itself: when no default is set, it falls back to the first available target on the primary tracker (same "first when unset" rule as the primary itself). Issue creation is unavailable to [synthesis](#synthesis) only when no usable target exists. Humans remain free to pick any target, including when accepting an Agent proposal.
 
 ### Flagged ambiguities
 

--- a/apps/api/src/lib/issue-tracker.test.ts
+++ b/apps/api/src/lib/issue-tracker.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { schema } from "../live-state/schema";
+import { connectorRegistry } from "./connector-registry";
+import { resolveEffectiveDefaultIssueTarget } from "./issue-tracker";
+
+const organizationId = "org-a";
+const integrationId = "integration-a";
+
+const githubRepo = {
+  fullName: "acme/widgets",
+  name: "widgets",
+  owner: "acme",
+};
+
+const savedTarget = {
+  integrationId,
+  label: "acme/saved",
+  target: { owner: "acme", repo: "saved" },
+};
+
+const makeDb = (integrations: Record<string, unknown>[]) => ({
+  find: vi.fn(async (_table: unknown, _opts: unknown) => {
+    const byId: Record<string, unknown> = {};
+    for (const row of integrations) {
+      byId[String((row as { id: string }).id)] = row;
+    }
+    return byId;
+  }),
+});
+
+describe("resolveEffectiveDefaultIssueTarget", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the saved target when one is set", async () => {
+    const db = makeDb([]);
+
+    await expect(
+      resolveEffectiveDefaultIssueTarget(db, organizationId, {
+        defaultIssueTarget: savedTarget,
+      })
+    ).resolves.toEqual(savedTarget);
+    expect(db.find).not.toHaveBeenCalled();
+  });
+
+  it("returns null when no issue tracker resolves", async () => {
+    const db = makeDb([]);
+
+    await expect(
+      resolveEffectiveDefaultIssueTarget(db, organizationId, {})
+    ).resolves.toBeNull();
+  });
+
+  it("returns null for a non-GitHub tracker", async () => {
+    const entry = connectorRegistry.getByType("github");
+    if (!entry) {
+      throw new Error("GitHub connector is not registered");
+    }
+    vi.spyOn(connectorRegistry, "providersOf").mockReturnValue([
+      {
+        invokeUrl: entry.invokeUrl,
+        manifest: {
+          capabilities: ["issue-tracker"],
+          type: "linear",
+        },
+      },
+    ] as ReturnType<typeof connectorRegistry.providersOf>);
+    vi.spyOn(connectorRegistry, "getByType").mockReturnValue({
+      ...entry,
+      manifest: { ...entry.manifest, type: "linear" },
+    });
+
+    const db = makeDb([
+      {
+        configStr: JSON.stringify({ boards: [] }),
+        enabled: true,
+        id: integrationId,
+        organization: { id: organizationId, settings: {}, slug: "acme" },
+        organizationId,
+        type: "linear",
+      },
+    ]);
+
+    await expect(
+      resolveEffectiveDefaultIssueTarget(db, organizationId, {})
+    ).resolves.toBeNull();
+  });
+
+  it("returns null when GitHub config JSON is invalid", async () => {
+    const db = makeDb([
+      {
+        configStr: "{not-json",
+        enabled: true,
+        id: integrationId,
+        organization: { id: organizationId, settings: {}, slug: "acme" },
+        organizationId,
+        type: "github",
+      },
+    ]);
+
+    await expect(
+      resolveEffectiveDefaultIssueTarget(db, organizationId, {})
+    ).resolves.toBeNull();
+  });
+
+  it("returns null when GitHub configuration has no repositories", async () => {
+    const db = makeDb([
+      {
+        configStr: JSON.stringify({
+          installationId: 1,
+          repos: [],
+        }),
+        enabled: true,
+        id: integrationId,
+        organization: { id: organizationId, settings: {}, slug: "acme" },
+        organizationId,
+        type: "github",
+      },
+    ]);
+
+    await expect(
+      resolveEffectiveDefaultIssueTarget(db, organizationId, {})
+    ).resolves.toBeNull();
+  });
+
+  it("falls back to the first GitHub repository and pins its integration", async () => {
+    const db = makeDb([
+      {
+        configStr: JSON.stringify({
+          installationId: 1,
+          repos: [
+            githubRepo,
+            { fullName: "acme/other", name: "other", owner: "acme" },
+          ],
+        }),
+        enabled: true,
+        id: integrationId,
+        organization: { id: organizationId, settings: {}, slug: "acme" },
+        organizationId,
+        type: "github",
+      },
+    ]);
+
+    await expect(
+      resolveEffectiveDefaultIssueTarget(db, organizationId, {})
+    ).resolves.toEqual({
+      integrationId,
+      label: githubRepo.fullName,
+      target: { owner: githubRepo.owner, repo: githubRepo.name },
+    });
+    expect(db.find).toHaveBeenCalledWith(
+      schema.integration,
+      expect.objectContaining({
+        where: { enabled: true, organizationId },
+      })
+    );
+  });
+});

--- a/apps/api/src/lib/issue-tracker.ts
+++ b/apps/api/src/lib/issue-tracker.ts
@@ -30,6 +30,10 @@ export interface ResolvedIssueTracker {
  * GitHub connector config shape used only to pick a first-repo fallback for the
  * default issue target. Core still treats `target` as opaque at dispatch —
  * this is the same provider-aware boundary the web settings picker uses.
+ *
+ * TODO: Extract a shared GitHub repo schema with
+ * `githubBackfillConfigSchema` in live-state/router/integration.ts (and the
+ * web settings picker) so Agent fallback and re-enable/backfill stay aligned.
  */
 const githubIssueTargetConfigSchema = z.object({
   repos: z

--- a/apps/api/src/lib/issue-tracker.ts
+++ b/apps/api/src/lib/issue-tracker.ts
@@ -2,7 +2,12 @@ import { invokeCapability } from "@connectors/framework";
 import type { NormalizedIssue } from "@connectors/framework";
 import type { InferLiveObject } from "@live-state/sync";
 import type { ServerDB } from "@live-state/sync/server";
-import { readCapabilityPrimary } from "@workspace/schemas/organization";
+import type { DefaultIssueTarget } from "@workspace/schemas/organization";
+import {
+  readCapabilityPrimary,
+  readDefaultIssueTarget,
+} from "@workspace/schemas/organization";
+import { z } from "zod";
 
 import { schema } from "../live-state/schema";
 import { connectorInvokeSecret, connectorRegistry } from "./connector-registry";
@@ -22,6 +27,28 @@ export interface ResolvedIssueTracker {
 }
 
 /**
+ * GitHub connector config shape used only to pick a first-repo fallback for the
+ * default issue target. Core still treats `target` as opaque at dispatch —
+ * this is the same provider-aware boundary the web settings picker uses.
+ */
+const githubIssueTargetConfigSchema = z.object({
+  repos: z
+    .array(
+      z
+        .object({
+          fullName: z.string().min(1),
+          name: z.string().regex(/^[^/]+$/),
+          owner: z.string().regex(/^[^/]+$/),
+        })
+        .refine(
+          ({ fullName, name, owner }) => fullName === `${owner}/${name}`,
+          { message: "fullName must match owner/name" }
+        )
+    )
+    .default([]),
+});
+
+/**
  * Resolve the enabled, configured integration that should receive an
  * issue-tracker `create`. Unlike `resolveEntityCapabilityTarget` there is no
  * mirrored entity to route by — nothing has been created yet — so selection
@@ -29,7 +56,7 @@ export interface ResolvedIssueTracker {
  * primary for the capability, then the first enabled provider.
  *
  * Returns null when the org has no usable issue tracker, which is also what
- * makes `create_issue` unavailable to the Agent.
+ * makes `create_issue` unavailable to the Agent when no targets exist either.
  */
 export const resolveIssueTrackerTarget = async (
   db: IssueTrackerDb,
@@ -51,6 +78,13 @@ export const resolveIssueTrackerTarget = async (
       .map((entry) => entry.manifest.type)
   );
 
+  // Prefer configured trackers when falling back to "first" — an enabled but
+  // empty install can't receive creates, and the settings UI only lists ones
+  // with config.
+  const configuredTrackers = enabledIntegrations.filter(
+    (i) => providerTypes.has(i.type) && i.configStr
+  );
+
   const primaryIssueTrackerId = readCapabilityPrimary(
     enabledIntegrations[0]?.organization?.settings,
     "issue-tracker"
@@ -61,11 +95,8 @@ export const resolveIssueTrackerTarget = async (
         (i) => i.id === integrationId && providerTypes.has(i.type)
       )
     : ((primaryIssueTrackerId
-        ? enabledIntegrations.find(
-            (i) => i.id === primaryIssueTrackerId && providerTypes.has(i.type)
-          )
-        : undefined) ??
-      enabledIntegrations.find((i) => providerTypes.has(i.type)));
+        ? configuredTrackers.find((i) => i.id === primaryIssueTrackerId)
+        : undefined) ?? configuredTrackers[0]);
 
   // An integration can be enabled before it's configured (`configStr` is
   // nullable); treat that as unresolved rather than forwarding a null config.
@@ -91,6 +122,53 @@ export const resolveIssueTrackerTarget = async (
     },
     invokeUrl: entry.invokeUrl,
     organization,
+  };
+};
+
+/**
+ * Where Agent-initiated issue creation should land: the org's saved default,
+ * or — when unset — the first sub-resource on the resolved issue tracker
+ * (same "first when unset" rule as capability primary). Returns null only when
+ * nothing usable exists, which keeps `create_issue` unavailable.
+ */
+export const resolveEffectiveDefaultIssueTarget = async (
+  db: IssueTrackerDb,
+  organizationId: string,
+  settings: unknown
+): Promise<DefaultIssueTarget | null> => {
+  const saved = readDefaultIssueTarget(settings);
+  if (saved) {
+    return saved;
+  }
+
+  const resolved = await resolveIssueTrackerTarget(db, organizationId);
+  if (!resolved) {
+    return null;
+  }
+
+  // Only GitHub exposes listable targets today; other trackers must set an
+  // explicit default until they grow a config surface we can read.
+  if (resolved.integration.type !== "github") {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(resolved.integration.configStr);
+  } catch {
+    return null;
+  }
+
+  const config = githubIssueTargetConfigSchema.safeParse(parsed);
+  const first = config.success ? config.data.repos[0] : undefined;
+  if (!first) {
+    return null;
+  }
+
+  return {
+    integrationId: resolved.integration.id,
+    label: first.fullName,
+    target: { owner: first.owner, repo: first.name },
   };
 };
 

--- a/apps/api/src/lib/signals/handlers/create-issue.ts
+++ b/apps/api/src/lib/signals/handlers/create-issue.ts
@@ -1,8 +1,10 @@
-import { readDefaultIssueTarget } from "@workspace/schemas/organization";
 import type { CreateIssueAction } from "@workspace/schemas/signals";
 
 import { schema } from "../../../live-state/schema";
-import { runCreateIssue } from "../../issue-tracker";
+import {
+  resolveEffectiveDefaultIssueTarget,
+  runCreateIssue,
+} from "../../issue-tracker";
 import type { ActionHandler } from "../types";
 
 /**
@@ -42,10 +44,15 @@ export const createIssueHandler: ActionHandler<CreateIssueAction> = {
     }
 
     // The Agent never picks a destination. `auto` mode gets the org's default
-    // issue target; on the accept path a human may redirect it from the card,
-    // which arrives as the override.
+    // issue target (or the first available target when unset); on the accept
+    // path a human may redirect it from the card, which arrives as the override.
     const target =
-      ctx.issueTarget ?? readDefaultIssueTarget(organization.settings);
+      ctx.issueTarget ??
+      (await resolveEffectiveDefaultIssueTarget(
+        ctx.db,
+        ctx.organizationId,
+        organization.settings
+      ));
     if (!target) {
       throw new Error("DEFAULT_ISSUE_TARGET_NOT_CONFIGURED");
     }

--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -6,7 +6,6 @@ import { earlyAccessRequestSchema } from "@workspace/schemas/early-access";
 import {
   defaultIssueTargetSchema,
   organizationSettingsSchema,
-  readDefaultIssueTarget,
 } from "@workspace/schemas/organization";
 import type { OrganizationSettings } from "@workspace/schemas/organization";
 import {
@@ -33,7 +32,10 @@ import {
   requireInternalApiKey,
 } from "../lib/authorize";
 import { connectorRegistry } from "../lib/connector-registry";
-import { resolveIssueTrackerTarget } from "../lib/issue-tracker";
+import {
+  resolveEffectiveDefaultIssueTarget,
+  resolveIssueTrackerTarget,
+} from "../lib/issue-tracker";
 import { dodopayments } from "../lib/payment";
 import { resend } from "../lib/resend";
 import { notifyWaitlistSignup } from "../lib/waitlist-discord";
@@ -103,8 +105,9 @@ export const router = createRouter({
        * never offer a move that cannot execute.
        *
        * Only `create_issue` needs a rule — every other action self-gates on
-       * evidence. It is available exactly when the org has a default issue
-       * target *and* a usable issue-tracker integration to send it to; the
+       * evidence. It is available exactly when the org has a usable default
+       * issue target (explicit, or the first target on the primary tracker)
+       * *and* a usable issue-tracker integration to send it to; the
        * connector-registry check lives here rather than in the worker so
        * capability knowledge stays on the API side.
        */
@@ -117,7 +120,11 @@ export const router = createRouter({
         authorize(req, { organizationId: req.input.organizationId });
 
         const org = await db.organization.one(req.input.organizationId).get();
-        const defaultIssueTarget = readDefaultIssueTarget(org?.settings);
+        const defaultIssueTarget = await resolveEffectiveDefaultIssueTarget(
+          db,
+          req.input.organizationId,
+          org?.settings
+        );
         if (!defaultIssueTarget) {
           return { create_issue: false } satisfies ActionAvailability;
         }
@@ -314,8 +321,8 @@ export const router = createRouter({
        * Set (or clear, with `target: null`) the org's [default issue
        * target](../../CONTEXT.md) — where Agent-initiated issue creation lands.
        * Distinct from `setCapabilityPrimary`, which pins *which* external
-       * system; this pins where inside it. While unset, `create_issue` is
-       * unavailable to synthesis rather than merely switched off.
+       * system; this pins where inside it. While unset, synthesis falls back
+       * to the first available target on the primary tracker.
        */
       setDefaultIssueTarget: mutation(
         z.object({

--- a/apps/web/src/components/signals/action-row/thread-read-card.tsx
+++ b/apps/web/src/components/signals/action-row/thread-read-card.tsx
@@ -467,7 +467,7 @@ function formatErrorMessage(error: unknown): string {
   // proposed create_issue. Retrying will never work, so say what to change
   // instead of offering the generic try-again.
   if (message.includes("DEFAULT_ISSUE_TARGET_NOT_CONFIGURED")) {
-    return "No default issue target is configured. Set one in Support Intelligence settings.";
+    return "No issue target is available. Connect a repository in Integrations settings.";
   }
   if (message.includes("ISSUE_TRACKER_NOT_CONFIGURED")) {
     return "This organization has no configured issue tracker.";
@@ -475,7 +475,7 @@ function formatErrorMessage(error: unknown): string {
   // Raised by the connector, which owns target validation — core treats the
   // integration config as opaque and cannot check the target up front.
   if (message.includes("REPOSITORY_NOT_CONNECTED")) {
-    return "The configured issue target is no longer connected. Pick another in Support Intelligence settings.";
+    return "The configured issue target is no longer connected. Pick another in Integrations settings.";
   }
   return "Could not apply this signal. Please try again.";
 }

--- a/apps/web/src/routes/app/_workspace/settings/organization/integration/index.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/integration/index.tsx
@@ -240,8 +240,7 @@ function DefaultIssueTargetField({
       <div className="text-sm">Default issue target</div>
       <div className="text-muted-foreground text-sm">
         Where Support Intelligence files issues. Defaults to the first available
-        target when unset. You can still redirect an individual issue when you
-        accept a suggestion.
+        target when unset.
       </div>
       {options.length === 0 && !current ? (
         <span className="text-sm text-muted-foreground mt-1">

--- a/apps/web/src/routes/app/_workspace/settings/organization/integration/index.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/integration/index.tsx
@@ -172,7 +172,12 @@ function DefaultIssueTargetField({
       ? current
       : null;
 
+  // Sentinel for clearing a stale orphan; never collides with a repo fullName.
+  const clearValue = "__clear_default_issue_target__";
+
   // Base UI Select.Value shows the raw value unless `items` maps value → label.
+  // Orphans get a clear path so owners can disconnect a removed repo without
+  // waiting to reconnect a tracker.
   const targetItems = [
     ...(orphanCurrent
       ? [
@@ -180,6 +185,7 @@ function DefaultIssueTargetField({
             value: orphanCurrent.label,
             label: `${orphanCurrent.label} (no longer connected)`,
           },
+          { value: clearValue, label: "No target" },
         ]
       : []),
     ...options.map((option) => ({
@@ -188,15 +194,20 @@ function DefaultIssueTargetField({
     })),
   ];
 
-  // No "none" option — when nothing is saved, surface the first target so the
-  // control matches what the Agent will use.
+  // No "none" option when a real target is available — when nothing is saved,
+  // surface the first target so the control matches what the Agent will use.
+  // Orphans already resolve via current.label.
   const selected =
-    current?.label ??
-    (options.length > 0 ? options[0].label : null) ??
-    orphanCurrent?.label ??
-    null;
+    current?.label ?? (options.length > 0 ? options[0].label : null) ?? null;
 
   const handleChange = (label: string) => {
+    if (label === clearValue) {
+      mutate.organization.setDefaultIssueTarget({
+        organizationId,
+        target: null,
+      });
+      return;
+    }
     const option = options.find((o) => o.label === label);
     if (!option) {
       return;
@@ -214,7 +225,9 @@ function DefaultIssueTargetField({
     });
   };
 
-  const soleOption = targetItems.length === 1;
+  // Only real options count as a settled single choice; an orphan entry is
+  // display-only and must leave the control interactive so it stays clearable.
+  const soleOption = options.length === 1 && !orphanCurrent;
   const select = (
     <Select
       value={selected}

--- a/apps/web/src/routes/app/_workspace/settings/organization/integration/index.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/integration/index.tsx
@@ -1,7 +1,10 @@
 import { typesProvidingCapability } from "@connectors/framework";
 import { useLiveQuery } from "@live-state/sync/client";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { safeParseOrgSettings } from "@workspace/schemas/organization";
+import {
+  readDefaultIssueTarget,
+  safeParseOrgSettings,
+} from "@workspace/schemas/organization";
 import { Badge } from "@workspace/ui/components/badge";
 import {
   Select,
@@ -10,12 +13,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@workspace/ui/components/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@workspace/ui/components/tooltip";
 import { cn } from "@workspace/ui/lib/utils";
 
 import { LimitCallout } from "~/components/integration-settings/limit-callout";
 import { useIntegrationWarnings } from "~/lib/hooks/query/use-integration-warnings";
 import { useOrganizationSwitcher } from "~/lib/hooks/query/use-organization-switcher";
 import { usePlanLimits } from "~/lib/hooks/query/use-plan-limits";
+import { useIssueTargetOptions } from "~/lib/issue-targets";
 import { mutate, query } from "~/lib/live-state";
 import { seo } from "~/utils/seo";
 
@@ -139,11 +148,133 @@ const integrationLabel = (type: string): string =>
   integrationOptions.find((option) => option.id === type)?.label ?? type;
 
 /**
- * Picks the org's primary issue-tracker — the target used when none is implied
- * (e.g. an agent-initiated issue create). Gated on the capability, not a named
- * provider, so it lists whichever enabled integrations provide `issue-tracker`.
+ * Where Agent-initiated issue creation lands. Saves immediately on change.
+ * When unset, the Agent (and this control) fall back to the first target —
+ * same rule as the primary issue tracker.
  */
-function PrimaryIssueTrackerSection({
+function DefaultIssueTargetField({
+  organizationId,
+  settings,
+  isUserOwner,
+}: {
+  organizationId: string;
+  settings: unknown;
+  isUserOwner: boolean;
+}) {
+  const options = useIssueTargetOptions(organizationId);
+  const current = readDefaultIssueTarget(settings);
+
+  // Still render the control when there are no options but a target is saved —
+  // otherwise a target pointing at a removed repo becomes unclearable while
+  // `create_issue` stays available against it.
+  const orphanCurrent =
+    current && !options.some((o) => o.label === current.label)
+      ? current
+      : null;
+
+  // Base UI Select.Value shows the raw value unless `items` maps value → label.
+  const targetItems = [
+    ...(orphanCurrent
+      ? [
+          {
+            value: orphanCurrent.label,
+            label: `${orphanCurrent.label} (no longer connected)`,
+          },
+        ]
+      : []),
+    ...options.map((option) => ({
+      value: option.label,
+      label: option.label,
+    })),
+  ];
+
+  // No "none" option — when nothing is saved, surface the first target so the
+  // control matches what the Agent will use.
+  const selected =
+    current?.label ??
+    (options.length > 0 ? options[0].label : null) ??
+    orphanCurrent?.label ??
+    null;
+
+  const handleChange = (label: string) => {
+    const option = options.find((o) => o.label === label);
+    if (!option) {
+      return;
+    }
+    mutate.organization.setDefaultIssueTarget({
+      organizationId,
+      target: {
+        // Pin the integration the repo list came from; without it, routing
+        // falls back to the capability primary, which may be a different
+        // tracker that has never heard of this repo.
+        integrationId: option.integrationId,
+        label: option.label,
+        target: option.target,
+      },
+    });
+  };
+
+  const soleOption = targetItems.length === 1;
+  const select = (
+    <Select
+      value={selected}
+      items={targetItems}
+      onValueChange={(value) => handleChange(value as string)}
+      disabled={!isUserOwner || soleOption}
+    >
+      <SelectTrigger aria-label="Default issue target" className="w-72">
+        <SelectValue placeholder="Select a target" />
+      </SelectTrigger>
+      <SelectContent>
+        {targetItems.map((item) => (
+          <SelectItem key={item.value} value={item.value}>
+            {item.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="text-sm">Default issue target</div>
+      <div className="text-muted-foreground text-sm">
+        Where Support Intelligence files issues. Defaults to the first available
+        target when unset. You can still redirect an individual issue when you
+        accept a suggestion.
+      </div>
+      {options.length === 0 && !current ? (
+        <span className="text-sm text-muted-foreground mt-1">
+          Connect an issue tracker to choose a target.
+        </span>
+      ) : (
+        <div className="mt-1 w-fit">
+          {soleOption ? (
+            <Tooltip>
+              {/* Span wrapper: disabled selects don't fire pointer events, so
+                  the tooltip trigger has to sit outside the control. */}
+              <TooltipTrigger render={<span className="inline-flex" />}>
+                {select}
+              </TooltipTrigger>
+              <TooltipContent>
+                Only one repository is connected.
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            select
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Primary issue-tracker + default sub-resource target for Agent-initiated
+ * creates. Gated on the capability for the tracker list; the default target
+ * answers where inside that system issues land.
+ */
+function IssueTrackingSection({
   organizationId,
   integrations,
   isUserOwner,
@@ -169,8 +300,9 @@ function PrimaryIssueTrackerSection({
       providerTypes.has(integration.type)
   );
 
-  // Nothing to route through, or nobody's allowed to change it — hide the control.
-  if (!isUserOwner || trackers.length === 0) {
+  // Nobody's allowed to change these — hide the section. Owners still see the
+  // default-target control even with zero trackers (connect prompt).
+  if (!isUserOwner) {
     return null;
   }
 
@@ -179,38 +311,80 @@ function PrimaryIssueTrackerSection({
   ];
   // Default the selection to the first tracker when none is pinned yet.
   const selected =
-    trackers.find((tracker) => tracker.id === primaryId)?.id ?? trackers[0].id;
+    trackers.length > 0
+      ? (trackers.find((tracker) => tracker.id === primaryId)?.id ??
+        trackers[0].id)
+      : null;
+
+  // Base UI Select.Value shows the raw value unless `items` maps value → label.
+  const trackerItems = trackers.map((tracker) => ({
+    value: tracker.id,
+    label: integrationLabel(tracker.type),
+  }));
+  const soleTracker = trackerItems.length === 1;
+
+  const primarySelect = selected ? (
+    <Select
+      value={selected}
+      items={trackerItems}
+      disabled={soleTracker}
+      onValueChange={(value) =>
+        mutate.organization.setCapabilityPrimary({
+          capability: "issue-tracker",
+          integrationId: value as string,
+          organizationId,
+        })
+      }
+    >
+      <SelectTrigger className="w-64">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {trackerItems.map((item) => (
+          <SelectItem key={item.value} value={item.value}>
+            {item.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  ) : null;
 
   return (
     <div className="p-4 flex flex-col gap-4 w-full">
       <h2 className="text-base">Issue tracking</h2>
-      <div className="flex flex-col gap-2 rounded-md border bg-muted/30 p-4">
-        <div className="text-sm">Primary issue tracker</div>
-        <div className="text-muted-foreground text-sm">
-          Where the Agent opens issues when a thread doesn't already point at a
-          specific target. You can still pick any target by hand.
-        </div>
-        <Select
-          value={selected}
-          onValueChange={(value) =>
-            mutate.organization.setCapabilityPrimary({
-              capability: "issue-tracker",
-              integrationId: value as string,
-              organizationId,
-            })
-          }
-        >
-          <SelectTrigger className="w-64 mt-1">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {trackers.map((tracker) => (
-              <SelectItem key={tracker.id} value={tracker.id}>
-                {integrationLabel(tracker.type)}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+      <div className="flex flex-col gap-6 rounded-md border bg-muted/30 p-4">
+        {primarySelect ? (
+          <div className="flex flex-col gap-2">
+            <div className="text-sm">Primary issue tracker</div>
+            <div className="text-muted-foreground text-sm">
+              Which external system the Agent opens issues in when a thread
+              doesn't already point at a specific target. Defaults to the first
+              connected tracker when unset. You can still pick any target by
+              hand.
+            </div>
+            <div className="mt-1 w-fit">
+              {soleTracker ? (
+                <Tooltip>
+                  {/* Span wrapper: disabled selects don't fire pointer events,
+                      so the tooltip trigger sits outside the control. */}
+                  <TooltipTrigger render={<span className="inline-flex" />}>
+                    {primarySelect}
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Only one issue tracker is connected.
+                  </TooltipContent>
+                </Tooltip>
+              ) : (
+                primarySelect
+              )}
+            </div>
+          </div>
+        ) : null}
+        <DefaultIssueTargetField
+          organizationId={organizationId}
+          settings={org?.settings}
+          isUserOwner={isUserOwner}
+        />
       </div>
     </div>
   );
@@ -322,7 +496,7 @@ function RouteComponent() {
       {renderIntegrationGroup("Active integrations", activeIntegrations)}
       {renderIntegrationGroup("Available integrations", availableIntegrations)}
       {activeOrganization?.id && (
-        <PrimaryIssueTrackerSection
+        <IssueTrackingSection
           organizationId={activeOrganization.id}
           integrations={allIntegrations ?? []}
           isUserOwner={isUserOwner}

--- a/apps/web/src/routes/app/_workspace/settings/organization/support-intelligence.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/support-intelligence.tsx
@@ -1,10 +1,7 @@
 import { useLiveQuery } from "@live-state/sync/client";
 import { useForm, useStore } from "@tanstack/react-form";
 import { createFileRoute } from "@tanstack/react-router";
-import {
-  readDefaultIssueTarget,
-  safeParseOrgSettings,
-} from "@workspace/schemas/organization";
+import { safeParseOrgSettings } from "@workspace/schemas/organization";
 import {
   AUTO_CAPABLE_ACTIONS,
   getDefaultActionAutonomy,
@@ -23,13 +20,6 @@ import {
   SegmentedControl,
   SegmentedControlItem,
 } from "@workspace/ui/components/segmented-control";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@workspace/ui/components/select";
 import { Textarea } from "@workspace/ui/components/textarea";
 import {
   Tooltip,
@@ -41,7 +31,6 @@ import { useMemo, useState } from "react";
 import { z } from "zod";
 
 import { activeOrganizationAtom } from "~/lib/atoms";
-import { useIssueTargetOptions } from "~/lib/issue-targets";
 import { mutate, query } from "~/lib/live-state";
 import { seo } from "~/utils/seo";
 
@@ -179,102 +168,12 @@ const AUTONOMY_ACTION_LABEL: Record<ActionKind, string> = {
 /** Extra caveats shown under a row whose consequences aren't self-evident. */
 const AUTONOMY_ACTION_HELP: Partial<Record<ActionKind, string>> = {
   create_issue:
-    "Filing an issue can't be undone, and the issue may be visible to anyone who can see the repository. Requires a default issue target below.",
+    "Filing an issue can't be undone, and the issue may be visible to anyone who can see the repository. Requires a connected issue tracker (and defaults to the first target when none is pinned).",
 };
 
-const NO_TARGET = "__none__";
-
 /**
- * Where Agent-initiated issue creation lands. Saves immediately rather than
- * joining the card's pending-autonomy batch: it is a single choice, and issue
- * filing stays unavailable to the Agent until it is set, so deferring it behind
- * the shared Save button would silently keep the feature dark.
+ * Mode-neutral autonomy settings for Support Intelligence signals.
  */
-function DefaultIssueTargetField({
-  organizationId,
-  settings,
-  isUserOwner,
-}: {
-  organizationId: string | undefined;
-  settings: unknown;
-  isUserOwner: boolean;
-}) {
-  const options = useIssueTargetOptions(organizationId);
-  const current = readDefaultIssueTarget(settings);
-
-  const handleChange = (label: string) => {
-    if (!organizationId) {
-      return;
-    }
-    if (label === NO_TARGET) {
-      mutate.organization.setDefaultIssueTarget({
-        organizationId,
-        target: null,
-      });
-      return;
-    }
-    const option = options.find((o) => o.label === label);
-    if (!option) {
-      return;
-    }
-    mutate.organization.setDefaultIssueTarget({
-      organizationId,
-      target: {
-        // Pin the integration the repo list came from; without it, routing
-        // falls back to the capability primary, which may be a different
-        // tracker that has never heard of this repo.
-        integrationId: option.integrationId,
-        label: option.label,
-        target: option.target,
-      },
-    });
-  };
-
-  return (
-    <div className="flex flex-col gap-1 border-t border-border pt-4">
-      <span className="text-sm font-medium">Default issue target</span>
-      <span className="text-sm text-muted-foreground">
-        Where the Agent files issues. It never picks a destination itself —
-        while this is unset, issue filing is unavailable to it. You can still
-        redirect an individual issue when you accept a suggestion.
-      </span>
-      <div className="pt-2">
-        {/* Still render the control when there are no options but a target is
-            saved — otherwise a target pointing at a removed repo becomes
-            unclearable while `create_issue` stays available against it. */}
-        {options.length === 0 && !current ? (
-          <span className="text-sm text-muted-foreground">
-            Connect an issue tracker to choose a target.
-          </span>
-        ) : (
-          <Select
-            value={current?.label ?? NO_TARGET}
-            onValueChange={(value) => handleChange(value as string)}
-            disabled={!isUserOwner}
-          >
-            <SelectTrigger aria-label="Default issue target" className="w-72">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={NO_TARGET}>No target</SelectItem>
-              {current && !options.some((o) => o.label === current.label) ? (
-                <SelectItem value={current.label}>
-                  {current.label} (no longer connected)
-                </SelectItem>
-              ) : null}
-              {options.map((option) => (
-                <SelectItem key={option.label} value={option.label}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
-      </div>
-    </div>
-  );
-}
-
 function AutomationCard({
   organizationId,
   settings,
@@ -411,11 +310,6 @@ function AutomationCard({
               );
             })}
           </div>
-          <DefaultIssueTargetField
-            organizationId={organizationId}
-            settings={settings}
-            isUserOwner={isUserOwner}
-          />
         </CardContent>
       </Card>
       {isUserOwner && (

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
@@ -177,8 +177,8 @@ These are leads, not confirmed links. Read a candidate with read_pr and confirm 
 
   // Action availability (see CONTEXT.md) shapes the vocabulary itself.
   // `create_issue` needs no evidence, so unlike link_pr it cannot self-gate on
-  // an empty hint — if the org has no default issue target, the verb simply
-  // isn't offered.
+  // an empty hint — if the org has no usable issue target (explicit default or
+  // first-available fallback), the verb simply isn't offered.
   const createIssueVocabulary = input.availability.create_issue
     ? "\n- create_issue (requires title and body) — file a NEW issue on the organization's default issue target and link it to this thread"
     : "";

--- a/packages/schemas/src/organization.ts
+++ b/packages/schemas/src/organization.ts
@@ -29,8 +29,9 @@ export const digestSettingsSchema = z.object({
  * a GitHub `{ owner, repo }`) — core forwards it untouched. `label` is the
  * human-readable rendering shown in settings and on the accept card.
  *
- * The Agent never picks a target itself: when this is unset, `create_issue` is
- * simply not available to synthesis.
+ * The Agent never picks a target itself: when this is unset, synthesis falls
+ * back to the first available target on the primary issue tracker (same rule
+ * as `capabilityPrimary`).
  */
 export const defaultIssueTargetSchema = z.object({
   /** Pins the issue-tracker integration; falls back to the capability primary. */
@@ -111,8 +112,9 @@ export const readCapabilityPrimary = (
  * Reads the default issue target directly from raw settings, without validating
  * the rest of the object — same reasoning as `readCapabilityPrimary`: an
  * unrelated bad field must not silently drop a validly configured target.
- * Returns null when unset or malformed, which reads as "issue creation is not
- * available to the Agent".
+ * Returns null when unset or malformed. Callers that need the Agent-effective
+ * destination should fall back to the first available target (see
+ * `resolveEffectiveDefaultIssueTarget` on the API).
  */
 export const readDefaultIssueTarget = (
   settings: unknown

--- a/packages/schemas/src/signals.ts
+++ b/packages/schemas/src/signals.ts
@@ -490,7 +490,7 @@ export const AUTO_CAPABLE_ACTIONS: ReadonlySet<ActionKind> = new Set([
  * proposed. `create_issue` needs no evidence, so it needs this.
  */
 export interface ActionAvailability {
-  /** True when the org has a usable [default issue target](../../CONTEXT.md). */
+  /** True when the org has a usable [default issue target](../../CONTEXT.md) (explicit or first-available fallback). */
   create_issue: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Move primary issue tracker and default issue target into a shared Issue tracking section on the Integrations settings page (removed from Support Intelligence).
- Fall back to the first available target on the primary tracker when no default is pinned, so Agent issue filing works without an explicit setting.
- Fix Base UI select labels via `items`, disable sole-option selects, and add tooltips explaining why.

## Test plan
- [ ] Open Integrations settings as an owner with GitHub connected
- [ ] Confirm Issue tracking shows primary tracker + default issue target
- [ ] With one tracker/repo: selects are disabled and show the correct labels (not IDs), with tooltips on hover
- [ ] With multiple repos: can change the default issue target; selection persists
- [ ] Confirm Support Intelligence no longer has the default issue target control
- [ ] With no default pinned and at least one repo: Agent can still propose/create issues against the first repo


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the primary issue tracker and default issue target into Integrations > Issue tracking. When no default is set, the Agent falls back to the first available GitHub repository on the primary tracker so issue filing keeps working.

- **New Features**
  - Unified Issue tracking in Integrations to set the primary tracker and default issue target; removed the control from Support Intelligence.
  - Agent uses the saved default or the first repo on the primary tracker when unset; action availability and the create-issue handler use the same rule.
  - UI polish: selects show the right labels, disable with a single option, include tooltips, and simplify copy; errors now point to Integrations.

- **Bug Fixes**
  - Orphan defaults from disconnected repos remain visible and clearable.
  - Fallback and availability ignore unconfigured installs and non-GitHub trackers, and validate GitHub config JSON and repo lists.
  - Added unit tests for `resolveEffectiveDefaultIssueTarget`; restored the `#organization` docs anchor and clarified fallback behavior.

<sup>Written for commit cf1123b07f9d0d2ba31ccedffd6b84833553b25e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent-created issues now use the configured default repository or automatically fall back to the first available target on the primary tracker.
  * Added organization settings to select the primary tracker and default issue target.
  * Settings handle disconnected targets and organizations without configured trackers.

* **Bug Fixes**
  * Issue creation is now unavailable only when no valid target exists.
  * Improved guidance when issue targets are unavailable or not configured.

* **Documentation**
  * Updated issue-target and action-availability guidance to reflect fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->