### PR TITLE
feat(agent): gate auto-reply on grounding

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,6 +66,22 @@ A deterministic, no-LLM helper (not a pipeline processor) that action-emitting p
 
 Whether an action is _able_ to execute at all on this run, given the [organization](#organization)'s [integrations](#integration) and configuration **and** the state of the [thread](#thread) itself — as opposed to whether the org has _permitted_ the Agent to, which is the [autonomy stage](#autonomy-stage)'s job. Availability is resolved before [synthesis](#synthesis) runs and shapes what synthesis is even offered, so the Agent never proposes a move that cannot execute. Most actions self-gate on evidence (no mirrored pull requests, no PR to link); actions that need no evidence, such as issue creation, need an explicit availability rule. Issue creation carries both halves: the org needs a usable default issue target, and the thread must not already link an issue — a thread links a single issue, so a second file can only be refused at execution. Linking an issue stays available on an already-linked thread, since re-linking to a different issue is legal. _Avoid_: describing an unavailable action as "off" — `off` is a deliberate org choice; and treating availability as purely org-scoped.
 
+### Action gate
+
+A per-kind predicate the [autonomy stage](#autonomy-stage) consults before promoting an action to `auto`, asking whether _this particular instance_ has earned autonomous execution. Distinct from [action availability](#action-availability) (_can_ it run) and from autonomy (_is the Agent permitted_ to run it): both of those are properties of the org and the thread, while a gate judges the action's own content. Kinds without a registered gate are promoted unconditionally. A gate runs _after_ per-kind autonomy partitioning, so it can see which sibling actions are actually executing. A failed gate downgrades that one action to `suggest`; it never vetoes its siblings.
+
+Today the only gate is on [reply](#grounding).
+
+### Grounding
+
+A [reply](#action-gate) action's claim about what backs it, and the input to reply's [action gate](#action-gate). One of three classes, each carrying the evidence that justifies it:
+
+- **`documented`** — the cited sources answer the customer's question _as asked_. A source that is merely related, or that answers an adjacent question, is not `documented`; it is `inferred`. Citable sources are those actually retrieved in this [run](#run): the `related_docs` [hint](#read-hint) bag plus anything pulled via the agent's documentation tools.
+- **`state_report`** — the reply asserts nothing about the product, only reports thread state the Agent can already see ("we're aware, tracked in #412"). Requires the cited [external issue](#external-issue) / [external pull request](#external-pull-request) to be linked to the thread, or to be linked by a sibling action that is itself executing autonomously.
+- **`inferred`** — everything else. Never auto-sends.
+
+Grounding is a _named class_, not a score, and is deliberately not called "confidence": `inlineSuggestion.confidence` is an unrelated 0–1 scalar from the [inline-track](#inline-suggestion) classifiers, and agent reasoning is scrubbed of confidence language before humans read it. Grounding's sources _are_ shown to humans, as citations on the draft. _Avoid_: "confidence" for this concept, "reply score".
+
 ### Autonomous action
 
 A receipt of work the Agent performed without human approval. Stored in `autonomousAction`. Carries an undo affordance when the action is reversible by construction.

--- a/apps/api/src/live-state/router/autonomous-action.ts
+++ b/apps/api/src/live-state/router/autonomous-action.ts
@@ -54,6 +54,9 @@ export default privateRoute.withProcedures(({ mutation, query }) => ({
   ).handler(async ({ req, db }) => {
     requireInternalApiKey(req.context);
 
+    // Ordered and limited in the query, not in memory: a long-running thread
+    // accumulates a receipt per auto-reply, and every gate evaluation would
+    // otherwise load and sort all of them to read one row.
     const rows = await db.autonomousAction
       .where({
         entityId: req.input.threadId,
@@ -61,15 +64,11 @@ export default privateRoute.withProcedures(({ mutation, query }) => ({
         signalType: "reply",
         undoneAt: null,
       })
+      .orderBy("appliedAt", "desc")
+      .limit(1)
       .get();
 
-    return (
-      [...rows].sort(
-        (left, right) =>
-          new Date(right.appliedAt).getTime() -
-          new Date(left.appliedAt).getTime()
-      )[0] ?? null
-    );
+    return rows[0] ?? null;
   }),
   record: mutation(recordAutonomousActionInputSchema).handler(
     async ({ req, db }) => {

--- a/apps/api/src/live-state/router/autonomous-action.ts
+++ b/apps/api/src/live-state/router/autonomous-action.ts
@@ -1,5 +1,6 @@
 import {
   parseAutonomousActionMetadata,
+  REVERSIBLE_ACTIONS,
   STATUS_LABELS,
 } from "@workspace/schemas/signals";
 import type {
@@ -21,7 +22,7 @@ import {
 import { runRecordActivity } from "../../lib/update-mutations";
 import { privateRoute } from "../factories";
 
-export default privateRoute.withProcedures(({ mutation }) => ({
+export default privateRoute.withProcedures(({ mutation, query }) => ({
   clearFake: mutation(z.object({ organizationId: z.string() })).handler(
     async ({ req, db }) => {
       if (process.env.NODE_ENV === "production") {
@@ -39,6 +40,37 @@ export default privateRoute.withProcedures(({ mutation }) => ({
       return { cleared: rows.length };
     }
   ),
+  /**
+   * The newest autonomous-reply receipt on a thread, or null. Feeds the reply
+   * [action gate](../../../../worker/src/pipeline/core/action-gates.ts)'s
+   * consecutive-reply invariant, which needs to know what state the Agent last
+   * reported here. Internal (worker) use only.
+   */
+  latestReplyForThread: query(
+    z.object({
+      organizationId: z.string(),
+      threadId: z.string(),
+    })
+  ).handler(async ({ req, db }) => {
+    requireInternalApiKey(req.context);
+
+    const rows = await db.autonomousAction
+      .where({
+        entityId: req.input.threadId,
+        organizationId: req.input.organizationId,
+        signalType: "reply",
+        undoneAt: null,
+      })
+      .get();
+
+    return (
+      [...rows].sort(
+        (left, right) =>
+          new Date(right.appliedAt).getTime() -
+          new Date(left.appliedAt).getTime()
+      )[0] ?? null
+    );
+  }),
   record: mutation(recordAutonomousActionInputSchema).handler(
     async ({ req, db }) => {
       // Receipts are written by the worker only — never by user sessions or
@@ -131,6 +163,12 @@ export default privateRoute.withProcedures(({ mutation }) => ({
 
     const metadata = parseAutonomousActionMetadata(row.metadataStr);
     if (!metadata) throw new Error("AUTONOMOUS_ACTION_METADATA_INVALID");
+    // A reply receipt would otherwise fall through every branch below and still
+    // be stamped `undoneAt`, claiming a retraction that never happened — and
+    // taking the gate's record of what we last told this customer with it.
+    if (!REVERSIBLE_ACTIONS.has(metadata.kind)) {
+      throw new Error("AUTONOMOUS_ACTION_NOT_UNDOABLE");
+    }
     const threadId = row.entityId;
     const now = new Date();
 

--- a/apps/web/src/lib/live-state.ts
+++ b/apps/web/src/lib/live-state.ts
@@ -8,6 +8,7 @@ import { getRequestHeaders } from "@tanstack/react-start/server";
 import {
   parseAutonomousActionMetadata,
   PRIORITY_LABELS,
+  REVERSIBLE_ACTIONS,
   STATUS_LABELS,
 } from "@workspace/schemas/signals";
 import type { Router } from "api/router";
@@ -573,6 +574,10 @@ const { client, store } = createClient<Router>({
 
         const metadata = parseAutonomousActionMetadata(row.metadataStr);
         if (!metadata) return;
+        // Mirror the server's reversibility guard, which rejects anything
+        // outside REVERSIBLE_ACTIONS. Predicting a rollback the server will
+        // refuse just shows the thread changing and snapping back.
+        if (!REVERSIBLE_ACTIONS.has(metadata.kind)) return;
         const threadId = row.entityId;
         const now = new Date();
 
@@ -594,18 +599,6 @@ const { client, store } = createClient<Router>({
             action: "removed",
             labelId: metadata.labelId,
             labelName: label?.name ?? null,
-            source: "autonomous_undo",
-          };
-        } else if (metadata?.kind === "link_pr") {
-          const thread = storage.thread.where({ id: threadId }).get()[0];
-          const oldPrId = thread?.externalPrId ?? null;
-          storage.thread.update(threadId, { externalPrId: null });
-          activityType = "pr_changed";
-          activityMetadata = {
-            oldPrId,
-            newPrId: null,
-            oldPrLabel: oldPrId ? "linked PR" : null,
-            newPrLabel: null,
             source: "autonomous_undo",
           };
         } else if (metadata?.kind === "mark_duplicate") {

--- a/apps/web/src/routes/app/_workspace/settings/organization/support-intelligence.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/support-intelligence.tsx
@@ -172,6 +172,17 @@ const AUTONOMY_ACTION_HELP: Partial<Record<ActionKind, string>> = {
 };
 
 /**
+ * Shown only while a row sits at `auto`, for kinds where "auto" is narrower
+ * than it sounds. Reply is gated, so the honest place to say so is next to the
+ * choice at the moment it's made — not in permanent help text under a control
+ * that's switched off.
+ */
+const AUTONOMY_AUTO_NOTICE: Partial<Record<ActionKind, string>> = {
+  reply:
+    "The Agent sends a reply on its own only when it's confident in the draft. Anything else still comes to you for review.",
+};
+
+/**
  * Mode-neutral autonomy settings for Support Intelligence signals.
  */
 function AutomationCard({
@@ -252,6 +263,8 @@ function AutomationCard({
               const locked = !AUTO_CAPABLE_ACTIONS.has(t);
               const current = valueFor(t);
               const help = AUTONOMY_ACTION_HELP[t];
+              const autoNotice =
+                current === "auto" ? AUTONOMY_AUTO_NOTICE[t] : undefined;
               return (
                 <div key={t} className="contents">
                   <div className="flex flex-col gap-0.5">
@@ -306,6 +319,11 @@ function AutomationCard({
                       return item;
                     })}
                   </SegmentedControl>
+                  {autoNotice ? (
+                    <span className="col-span-2 rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+                      {autoNotice}
+                    </span>
+                  ) : null}
                 </div>
               );
             })}

--- a/apps/web/src/routes/app/_workspace/settings/organization/support-intelligence.tsx
+++ b/apps/web/src/routes/app/_workspace/settings/organization/support-intelligence.tsx
@@ -179,7 +179,7 @@ const AUTONOMY_ACTION_HELP: Partial<Record<ActionKind, string>> = {
  */
 const AUTONOMY_AUTO_NOTICE: Partial<Record<ActionKind, string>> = {
   reply:
-    "The Agent sends a reply on its own only when it's confident in the draft. Anything else still comes to you for review.",
+    "The Agent sends a reply on its own only when the draft is backed by your documentation, or reports the state of work already linked to the thread. Anything else still comes to you for review — with no documentation connected, that means only status updates send on their own.",
 };
 
 /**

--- a/apps/worker/src/lib/message-order.ts
+++ b/apps/worker/src/lib/message-order.ts
@@ -1,0 +1,36 @@
+/**
+ * The one definition of "which message came last".
+ *
+ * Order by `createdAt` with `id` as a stable tie-breaker. Sorting by `id` alone
+ * is wrong for Slack/Discord backfills, where ids are ULIDs assigned at insert
+ * time but `createdAt` reflects the original external timestamp — a backfilled
+ * conversation would come out newest-first.
+ *
+ * Shared rather than reimplemented per call site: the synthesis context and the
+ * reply [action gate](../pipeline/core/action-gates.ts) both decide things from
+ * message order, and an ordering fix that reached only one of them would let
+ * them disagree about what the customer last said.
+ */
+
+const sentAt = (createdAt: unknown): number => {
+  const time = new Date(createdAt as string | number | Date).getTime();
+  return Number.isNaN(time) ? 0 : time;
+};
+
+export interface OrderableMessage {
+  createdAt: unknown;
+  id: string;
+}
+
+export const sortMessagesByTime = <T extends OrderableMessage>(
+  messages: readonly T[] | null | undefined
+): T[] =>
+  [...(messages ?? [])].toSorted((a, b) => {
+    const delta = sentAt(a.createdAt) - sentAt(b.createdAt);
+    return delta === 0 ? a.id.localeCompare(b.id) : delta;
+  });
+
+/** The newest message, or undefined on an empty thread. */
+export const newestMessage = <T extends OrderableMessage>(
+  messages: readonly T[] | null | undefined
+): T | undefined => sortMessagesByTime(messages).at(-1);

--- a/apps/worker/src/lib/message-roles.ts
+++ b/apps/worker/src/lib/message-roles.ts
@@ -59,3 +59,27 @@ export const threadHasTeamReply = (
   roles: Map<string, MessageRole>
 ): boolean =>
   messages.some((message) => roles.get(message.authorId) === "agent");
+
+const sentAt = (createdAt: unknown): number => {
+  const time = new Date(createdAt as string | number | Date).getTime();
+  return Number.isNaN(time) ? 0 : time;
+};
+
+/**
+ * Who spoke last, or "unknown" on an empty thread. Ordered by `createdAt` with
+ * `id` as the tie-breaker: ids are assigned at insert time, so a Slack/Discord
+ * backfill would put the wrong message last if sorted by id alone.
+ */
+export const lastMessageRole = (
+  messages: { authorId: string; id: string; createdAt: unknown }[],
+  roles: Map<string, MessageRole>
+): MessageRole => {
+  const last = [...messages]
+    .toSorted((a, b) => {
+      const delta = sentAt(a.createdAt) - sentAt(b.createdAt);
+      return delta === 0 ? a.id.localeCompare(b.id) : delta;
+    })
+    .at(-1);
+
+  return last ? (roles.get(last.authorId) ?? "unknown") : "unknown";
+};

--- a/apps/worker/src/lib/message-roles.ts
+++ b/apps/worker/src/lib/message-roles.ts
@@ -1,5 +1,8 @@
 import z from "zod";
 
+import type { OrderableMessage } from "./message-order";
+import { newestMessage } from "./message-order";
+
 export type MessageRole = "customer" | "agent" | "unknown";
 
 const authorRowSchema = z.object({
@@ -60,26 +63,11 @@ export const threadHasTeamReply = (
 ): boolean =>
   messages.some((message) => roles.get(message.authorId) === "agent");
 
-const sentAt = (createdAt: unknown): number => {
-  const time = new Date(createdAt as string | number | Date).getTime();
-  return Number.isNaN(time) ? 0 : time;
-};
-
-/**
- * Who spoke last, or "unknown" on an empty thread. Ordered by `createdAt` with
- * `id` as the tie-breaker: ids are assigned at insert time, so a Slack/Discord
- * backfill would put the wrong message last if sorted by id alone.
- */
+/** Who spoke last, or "unknown" on an empty thread. */
 export const lastMessageRole = (
-  messages: { authorId: string; id: string; createdAt: unknown }[],
+  messages: (OrderableMessage & { authorId: string })[],
   roles: Map<string, MessageRole>
 ): MessageRole => {
-  const last = [...messages]
-    .toSorted((a, b) => {
-      const delta = sentAt(a.createdAt) - sentAt(b.createdAt);
-      return delta === 0 ? a.id.localeCompare(b.id) : delta;
-    })
-    .at(-1);
-
+  const last = newestMessage(messages);
   return last ? (roles.get(last.authorId) ?? "unknown") : "unknown";
 };

--- a/apps/worker/src/pipeline/core/action-gates.ts
+++ b/apps/worker/src/pipeline/core/action-gates.ts
@@ -1,0 +1,41 @@
+import type { Action, ActionKind } from "@workspace/schemas/signals";
+
+import { replyGroundingGate } from "./gates/reply-grounding";
+import type { RunState } from "./run-state";
+
+export interface ActionGateContext {
+  run: RunState;
+  /** Bundle siblings that are actually executing, not merely proposed. */
+  autoSiblings: Action[];
+}
+
+export type ActionGateResult =
+  | {
+      allowed: true;
+      /** Digest of what this action reported, carried into its receipt. */
+      stateFingerprint?: string;
+    }
+  | { allowed: false; reason: string };
+
+export type ActionGate = (
+  action: Action,
+  ctx: ActionGateContext
+) => Promise<ActionGateResult>;
+
+/**
+ * [Action gates](../../../../CONTEXT.md) by kind. A gate asks whether *this
+ * instance* has earned autonomous execution — distinct from availability (can
+ * it run at all) and autonomy (has the org permitted it), which are properties
+ * of the org and thread rather than of the action's content. Unregistered kinds
+ * run unconditionally.
+ *
+ * Only `reply` has one: every other auto-capable kind self-gates on verified
+ * evidence, whereas a reply's payload is free-form prose with nothing
+ * structural to check.
+ */
+const ACTION_GATES: Partial<Record<ActionKind, ActionGate>> = {
+  reply: replyGroundingGate,
+};
+
+export const gateFor = (kind: ActionKind): ActionGate | undefined =>
+  ACTION_GATES[kind];

--- a/apps/worker/src/pipeline/core/autonomy-stage.ts
+++ b/apps/worker/src/pipeline/core/autonomy-stage.ts
@@ -143,6 +143,12 @@ export const applySynthesisAutonomy = async (
  * sibling set, so "is my sibling actually going to happen?" has a truthful
  * answer. A gate that throws denies: an unreachable gate must fail towards the
  * human, not past them.
+ *
+ * TODO(sibling-truthfulness): `permitted` is everything *proposed* for auto,
+ * not the subset already confirmed to execute, so that answer is truthful only
+ * because `reply` is the sole gated kind and comes last. Register a second
+ * gated kind ahead of it and a denied sibling would still read as executing.
+ * Feed each gate the actions already admitted plus the ungated remainder.
  */
 const applyActionGates = async (
   run: RunState,

--- a/apps/worker/src/pipeline/core/autonomy-stage.ts
+++ b/apps/worker/src/pipeline/core/autonomy-stage.ts
@@ -1,4 +1,7 @@
-import { nextAgentReadAfterExecution } from "@workspace/schemas/signals";
+import {
+  inferredGrounding,
+  nextAgentReadAfterExecution,
+} from "@workspace/schemas/signals";
 import type {
   Action,
   ActionKind,
@@ -8,6 +11,8 @@ import type {
 import { log } from "@workspace/utils/logging";
 
 import { errorFields } from "../../lib/logging";
+import { gateFor } from "./action-gates";
+import type { ActionGateResult } from "./action-gates";
 import type { RunState } from "./run-state";
 
 const keepForRead = (
@@ -54,18 +59,38 @@ export const applySynthesisAutonomy = async (
     primary,
   };
 
-  const autoActions = primary.filter(
+  const permitted = primary.filter(
     (action) => autonomy[action.kind] === "auto"
   );
   const suggestPrimary = primary.filter(
     (action) => autonomy[action.kind] === "suggest"
   );
 
-  let finalPrimary = suggestPrimary;
+  // Gates run *after* per-kind partitioning, never before: reply's gate has to
+  // see which siblings are genuinely executing, or it would clear a reply that
+  // cites a `link_pr` autonomy had already dropped.
+  const { autoActions, gated, fingerprints } = await applyActionGates(
+    run,
+    permitted
+  );
+
+  // A gated action is not lost and does not veto its siblings — it joins the
+  // `suggest` pile a human already reviews. Rebuilt by filtering `primary`
+  // rather than concatenating the piles, because non-reversibles execute in
+  // emitted order (ADR 0003) with reply terminal, and concatenating would
+  // reverse that whenever a gate holds a reply back.
+  const keepInReadOrder = (...piles: Action[][]): Action[] => {
+    const keep = new Set<Action>(piles.flat());
+    return primary.filter((action) => keep.has(action));
+  };
+
+  let finalPrimary = keepInReadOrder(gated, suggestPrimary);
 
   if (autoActions.length > 0) {
     try {
       const result = await run.executeBundle(autoActions);
+
+      await writeReplyReceipt(run, result.succeeded, fingerprints);
 
       const afterAuto = nextAgentReadAfterExecution(
         { ...filteredRead, primary: autoActions },
@@ -73,7 +98,11 @@ export const applySynthesisAutonomy = async (
       );
 
       if (afterAuto?.primary.length) {
-        finalPrimary = [...afterAuto.primary, ...suggestPrimary];
+        finalPrimary = keepInReadOrder(
+          afterAuto.primary,
+          gated,
+          suggestPrimary
+        );
       }
     } catch (error) {
       // TODO(idempotency): On an RPC/transport error we don't know whether the
@@ -90,7 +119,7 @@ export const applySynthesisAutonomy = async (
         error: errorFields(error),
         outcome: "auto_actions_retained_for_review",
       });
-      finalPrimary = [...autoActions, ...suggestPrimary];
+      finalPrimary = keepInReadOrder(autoActions, gated, suggestPrimary);
     }
   }
 
@@ -106,4 +135,104 @@ export const applySynthesisAutonomy = async (
 
   await run.publishRead(agentRead);
   return agentRead;
+};
+
+/**
+ * Splits the permitted actions into what still executes and what an
+ * [action gate](./action-gates.ts) held back. Gates see `permitted` as their
+ * sibling set, so "is my sibling actually going to happen?" has a truthful
+ * answer. A gate that throws denies: an unreachable gate must fail towards the
+ * human, not past them.
+ */
+const applyActionGates = async (
+  run: RunState,
+  permitted: Action[]
+): Promise<{
+  autoActions: Action[];
+  gated: Action[];
+  fingerprints: Map<ActionKind, string>;
+}> => {
+  const autoActions: Action[] = [];
+  const gated: Action[] = [];
+  const fingerprints = new Map<ActionKind, string>();
+
+  for (const action of permitted) {
+    const gate = gateFor(action.kind);
+    if (!gate) {
+      autoActions.push(action);
+      continue;
+    }
+
+    const siblings = permitted.filter((other) => other !== action);
+    let result: ActionGateResult;
+    try {
+      result = await gate(action, { autoSiblings: siblings, run });
+    } catch (error) {
+      result = { allowed: false, reason: "gate_failed" };
+      log.error({
+        action: "worker.action_gate",
+        event: "gate_threw",
+        organizationId: run.organizationId,
+        threadId: run.threadId,
+        actionKind: action.kind,
+        error: errorFields(error),
+        outcome: "downgraded_to_suggest",
+      });
+    }
+
+    if (result.allowed) {
+      if (result.stateFingerprint) {
+        fingerprints.set(action.kind, result.stateFingerprint);
+      }
+      autoActions.push(action);
+      continue;
+    }
+
+    log.info({
+      action: "worker.action_gate",
+      event: "denied",
+      organizationId: run.organizationId,
+      threadId: run.threadId,
+      actionKind: action.kind,
+      reason: result.reason,
+      outcome: "downgraded_to_suggest",
+    });
+    gated.push(action);
+  }
+
+  return { autoActions, fingerprints, gated };
+};
+
+/**
+ * Writes the receipt for a sent reply — the audit trail, and the record the
+ * next run's gate compares against. A failed write must not fail the run: the
+ * message has already gone out, and losing the receipt costs a conservative
+ * denial next time, not a duplicate send.
+ */
+const writeReplyReceipt = async (
+  run: RunState,
+  succeeded: Action[],
+  fingerprints: Map<ActionKind, string>
+): Promise<void> => {
+  const reply = succeeded.find((action) => action.kind === "reply");
+  const fingerprint = fingerprints.get("reply");
+  if (!reply || reply.kind !== "reply" || !fingerprint) {
+    return;
+  }
+
+  try {
+    await run.recordReplyReceipt(
+      reply.grounding ?? inferredGrounding(),
+      fingerprint
+    );
+  } catch (error) {
+    log.error({
+      action: "worker.synthesis_autonomy",
+      event: "reply_receipt_failed",
+      organizationId: run.organizationId,
+      threadId: run.threadId,
+      error: errorFields(error),
+      outcome: "reply_sent_without_receipt",
+    });
+  }
 };

--- a/apps/worker/src/pipeline/core/gates/reply-grounding.ts
+++ b/apps/worker/src/pipeline/core/gates/reply-grounding.ts
@@ -1,0 +1,130 @@
+import type { Action, ReplyGrounding } from "@workspace/schemas/signals";
+import {
+  inferredGrounding,
+  replyStateFingerprint,
+} from "@workspace/schemas/signals";
+
+import {
+  fetchMirroredIssueByUrl,
+  fetchMirroredPrByUrl,
+} from "../../../lib/database/client";
+import { lastMessageRole } from "../../../lib/message-roles";
+import type { ActionGate, ActionGateResult } from "../action-gates";
+
+/**
+ * Reply's [action gate](../../../../../CONTEXT.md): the last thing between a
+ * drafted reply and a customer's inbox.
+ *
+ * It does not check that cited documentation URLs are real. That needs the
+ * synthesis run's tool steps, so it happens at that trust boundary
+ * (`grounding-verification.ts`), which degrades a fabricated citation to
+ * `inferred` well before the action arrives here.
+ */
+export const replyGroundingGate: ActionGate = async (action, ctx) => {
+  if (action.kind !== "reply") {
+    return { allowed: true };
+  }
+
+  const grounding: ReplyGrounding = action.grounding ?? inferredGrounding();
+
+  if (grounding.class === "inferred") {
+    return deny("ungrounded");
+  }
+
+  let entityState: string | null = null;
+
+  if (grounding.class === "documented") {
+    if (grounding.sources.length === 0) {
+      return deny("documented_without_sources");
+    }
+  } else {
+    const entityUrl = grounding.entityUrl?.trim() ?? "";
+    if (!entityUrl) {
+      return deny("state_report_without_entity");
+    }
+    const resolved = await resolveReportedEntity(
+      ctx.run.organizationId,
+      ctx.run.thread,
+      ctx.autoSiblings,
+      entityUrl
+    );
+    if ("denied" in resolved) {
+      return deny(resolved.denied);
+    }
+    entityState = resolved.state;
+  }
+
+  const fingerprint = replyStateFingerprint(grounding, entityState);
+
+  // A run usually happens because the customer wrote, so the Agent is
+  // answering rather than interrupting. The case to guard is the other one: a
+  // detector-driven run on a thread where the last word was ours.
+  const { roles } = await ctx.run.authors();
+  if (lastMessageRole(ctx.run.thread.messages ?? [], roles) === "customer") {
+    return { allowed: true, stateFingerprint: fingerprint };
+  }
+
+  // Speaking twice in a row is licensed by the state having moved, never by
+  // elapsed time — a clock keeps ticking whether or not there is anything new
+  // to say. No prior receipt means the last word was a teammate's, and the
+  // Agent does not talk over one.
+  const previous = await ctx.run.lastAutonomousReply();
+  if (!previous || previous.stateFingerprint === fingerprint) {
+    return deny("no_new_state_since_last_reply");
+  }
+
+  return { allowed: true, stateFingerprint: fingerprint };
+};
+
+const deny = (reason: string): ActionGateResult => ({ allowed: false, reason });
+
+/**
+ * Resolve the entity a `state_report` names and confirm the thread is attached
+ * to it — already, or by a sibling link that is itself executing on this run.
+ * `link_pr` ships at `off`, so without the sibling half a `[link_pr, reply]`
+ * bundle would drop the link and still tell the customer "tracked in #412".
+ */
+const resolveReportedEntity = async (
+  organizationId: string,
+  thread: { externalPrId?: string | null; externalIssueId?: string | null },
+  autoSiblings: Action[],
+  entityUrl: string
+): Promise<{ state: string } | { denied: string }> => {
+  const pr = await fetchMirroredPrByUrl(organizationId, entityUrl);
+  const entity =
+    pr ?? (await fetchMirroredIssueByUrl(organizationId, entityUrl));
+
+  if (!entity) {
+    return { denied: "state_report_entity_not_mirrored" };
+  }
+
+  const alreadyLinked =
+    thread.externalPrId === entity.id || thread.externalIssueId === entity.id;
+
+  if (!alreadyLinked && !siblingLinksUrl(autoSiblings, entityUrl)) {
+    return { denied: "state_report_entity_not_linked" };
+  }
+
+  return { state: describeEntityState(entity) };
+};
+
+const siblingLinksUrl = (siblings: Action[], url: string): boolean =>
+  siblings.some(
+    (sibling) =>
+      (sibling.kind === "link_pr" && sibling.prUrl.trim() === url) ||
+      (sibling.kind === "link_issue" && sibling.issueUrl.trim() === url)
+  );
+
+/**
+ * Merge state is folded in on purpose: "there's a fix open" and "the fix has
+ * merged" are different things to tell a customer, and collapsing them would
+ * make the follow-up the Agent most *should* send look like a repeat.
+ */
+const describeEntityState = (entity: {
+  state: string;
+  merged?: boolean | null;
+  draft?: boolean | null;
+}): string =>
+  [entity.state, entity.merged ? "merged" : "", entity.draft ? "draft" : ""]
+    .filter(Boolean)
+    .join("+");

--- a/apps/worker/src/pipeline/core/gates/reply-grounding.ts
+++ b/apps/worker/src/pipeline/core/gates/reply-grounding.ts
@@ -98,8 +98,12 @@ const resolveReportedEntity = async (
     return { denied: "state_report_entity_not_mirrored" };
   }
 
+  // `externalKey`, not `id`: the link handlers write the provider's key into
+  // `thread.externalPrId` / `externalIssueId`, so comparing mirror row ids here
+  // would never match and would downgrade every already-linked state report.
   const alreadyLinked =
-    thread.externalPrId === entity.id || thread.externalIssueId === entity.id;
+    thread.externalPrId === entity.externalKey ||
+    thread.externalIssueId === entity.externalKey;
 
   if (!alreadyLinked && !siblingLinksUrl(autoSiblings, entityUrl)) {
     return { denied: "state_report_entity_not_linked" };

--- a/apps/worker/src/pipeline/core/run-state.ts
+++ b/apps/worker/src/pipeline/core/run-state.ts
@@ -1,5 +1,8 @@
 import { safeParseOrgSettings } from "@workspace/schemas/organization";
-import { getDefaultActionAutonomy } from "@workspace/schemas/signals";
+import {
+  getDefaultActionAutonomy,
+  parseAutonomousActionMetadata,
+} from "@workspace/schemas/signals";
 import type {
   Action,
   ActionAvailability,
@@ -14,6 +17,7 @@ import type {
   RelatedDocsEvidence,
   RelatedIssuesEvidence,
   RelatedPrsEvidence,
+  ReplyGrounding,
   ThreadRead,
 } from "@workspace/schemas/signals";
 import { log } from "@workspace/utils/logging";
@@ -102,6 +106,7 @@ export class RunState {
   #availability?: Promise<ActionAvailability>;
   #authors?: Promise<ResolvedMessageAuthors>;
   #labels?: Promise<OrgLabel[]>;
+  #lastAutonomousReply?: Promise<{ stateFingerprint: string } | null>;
 
   constructor(thread: Thread) {
     this.thread = thread;
@@ -260,6 +265,44 @@ export class RunState {
     }) as Promise<OrgLabel[]>;
 
     return this.#labels;
+  }
+
+  /**
+   * What the Agent last auto-replied here, or null if it never has. Read lazily:
+   * only a run that gets as far as gating a reply pays for it.
+   */
+  lastAutonomousReply(): Promise<{ stateFingerprint: string } | null> {
+    this.#lastAutonomousReply ??= (async () => {
+      const row = await fetchClient.query.autonomousAction.latestReplyForThread(
+        {
+          organizationId: this.organizationId,
+          threadId: this.threadId,
+        }
+      );
+      const metadata = parseAutonomousActionMetadata(row?.metadataStr ?? null);
+      return metadata?.kind === "reply"
+        ? { stateFingerprint: metadata.stateFingerprint }
+        : null;
+    })();
+
+    return this.#lastAutonomousReply;
+  }
+
+  /**
+   * Written from the worker, unlike every other receipt: the fingerprint comes
+   * from the [action gate](./action-gates.ts), the only place that knows what
+   * the reply claimed to report.
+   */
+  async recordReplyReceipt(
+    grounding: ReplyGrounding,
+    stateFingerprint: string
+  ): Promise<void> {
+    await fetchClient.mutate.autonomousAction.record({
+      actionKind: "reply",
+      entityId: this.threadId,
+      metadata: { grounding, kind: "reply", stateFingerprint },
+      organizationId: this.organizationId,
+    });
   }
 
   /** Executes an approved action bundle and writes its autonomous receipts. */

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/agent-dataset.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/agent-dataset.ts
@@ -92,6 +92,12 @@ export interface SynthesisAgentEvalCase {
     forbiddenReplyPhrases?: string[];
     /** The grounding class every primary reply must declare. */
     expectedGroundingClass?: GroundingClass;
+    /**
+     * Issue / PR URL every `state_report` reply must name. The class alone only
+     * says the reply claims to report linked work; this says it reports the
+     * right work — the thing the gate resolves against the mirror.
+     */
+    expectedGroundingEntityUrl?: string;
     /** Page URLs a `documented` reply must cite exactly (order-insensitive). */
     expectedGroundingSources?: string[];
   };
@@ -1166,6 +1172,8 @@ const synthesisAgentDatasetCases: (Omit<SynthesisAgentEvalCase, "input"> & {
     // (not a guess).
     expected: {
       expectedGroundingClass: "state_report",
+      expectedGroundingEntityUrl: "https://github.com/acme/api/pull/901",
+      expectedLinkPrUrl: "https://github.com/acme/api/pull/901",
       minToolCalls: { read_pr: 1 },
       mustIncludePrimaryKinds: ["link_pr", "reply"],
       requiresReplyDraft: true,

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/agent-dataset.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/agent-dataset.ts
@@ -1,8 +1,10 @@
+import type { GroundingClass } from "@workspace/schemas/signals";
+
+import type { SynthesizeThreadReadInput } from "../synthesize";
 import type {
   DocumentationPageChunkResult,
   DocumentationSearchResult,
 } from "../tools";
-import type { SynthesizeThreadReadInput } from "../synthesize";
 
 export interface SynthesisAgentEvalCase {
   name: string;
@@ -88,6 +90,10 @@ export interface SynthesisAgentEvalCase {
     /** When set, every emitted link_pr.prUrl must equal this exact URL. */
     expectedLinkPrUrl?: string;
     forbiddenReplyPhrases?: string[];
+    /** The grounding class every primary reply must declare. */
+    expectedGroundingClass?: GroundingClass;
+    /** Page URLs a `documented` reply must cite exactly (order-insensitive). */
+    expectedGroundingSources?: string[];
   };
 }
 
@@ -997,6 +1003,226 @@ const synthesisAgentDatasetCases: (Omit<SynthesisAgentEvalCase, "input"> & {
         },
       },
       threads: { t19: mkThread("t19", "How do I change my billing email?") },
+    },
+  },
+  // --- Grounding calibration (ADR 0013) ------------------------------------
+  // Three threads that all look answerable and must land on three different
+  // classes. What is being scored is not "did it reply" but "did it tell the
+  // truth about what the reply rests on".
+  {
+    expected: {
+      expectedGroundingClass: "documented",
+      expectedGroundingSources: ["https://docs.example/webhooks/retries"],
+      minToolCalls: { search_documentation: 1 },
+      mustIncludePrimaryKinds: ["reply"],
+      requiresReplyDraft: true,
+    },
+    input: {
+      hints: {
+        related_docs: {
+          computedAt: now,
+          evidence: {
+            docs: [
+              {
+                docId: "https://docs.example/webhooks/retries",
+                score: 0.94,
+                title: "Webhook retry behaviour",
+                url: "https://docs.example/webhooks/retries",
+              },
+            ],
+          },
+          hash: "hg1",
+        },
+      },
+      sourceInputMessageId: "tg1m1",
+      summary: {
+        entities: ["webhooks"],
+        expectedAction: "documentation guidance",
+        keywords: ["webhook", "retry", "failed delivery"],
+        shortDescription:
+          "Customer asks how many times a failed webhook is retried.",
+        title: "How many times are failed webhooks retried?",
+      },
+      threadId: "tg1",
+      threadMessages: [
+        {
+          id: "tg1m1",
+          authorId: "cg1",
+          createdAt: now,
+          content:
+            "If our endpoint is down, how many times will you retry a webhook before giving up?",
+        },
+      ],
+      threadName: "Webhook retry count",
+    },
+    name: "grounding: doc directly answers the question -> documented",
+    toolFixtures: {
+      docsPageChunksByUrl: {
+        "https://docs.example/webhooks/retries": [
+          {
+            chunkIndex: 0,
+            chunkText:
+              "Failed webhook deliveries are retried 6 times with exponential backoff over roughly 24 hours. After the sixth failure the event is dropped and the endpoint is marked unhealthy.",
+            headingHierarchy: ["Webhooks", "Retries"],
+            pageTitle: "Webhook retry behaviour",
+            pageUrl: "https://docs.example/webhooks/retries",
+          },
+        ],
+      },
+      docsSearchHitsByQuery: {
+        "How many times are failed webhooks retried?": [
+          {
+            chunkText:
+              "Failed webhook deliveries are retried 6 times with exponential backoff over roughly 24 hours.",
+            headingHierarchy: ["Webhooks", "Retries"],
+            pageTitle: "Webhook retry behaviour",
+            pageUrl: "https://docs.example/webhooks/retries",
+            score: 0.94,
+          },
+        ],
+      },
+      threads: { tg1: mkThread("tg1", "Webhook retry count") },
+    },
+  },
+  {
+    // The trap: a real, well-scoring, adjacent page that answers a *different*
+    // question. Citation checking cannot catch this — the URL is genuine — so
+    // only an honest class keeps the reply away from the customer.
+    expected: {
+      expectedGroundingClass: "inferred",
+      mustIncludePrimaryKinds: ["reply"],
+      requiresReplyDraft: true,
+    },
+    input: {
+      hints: {
+        related_docs: {
+          computedAt: now,
+          evidence: {
+            docs: [
+              {
+                docId: "https://docs.example/webhooks/signatures",
+                score: 0.88,
+                title: "Verifying webhook signatures",
+                url: "https://docs.example/webhooks/signatures",
+              },
+            ],
+          },
+          hash: "hg2",
+        },
+      },
+      sourceInputMessageId: "tg2m1",
+      summary: {
+        entities: ["webhooks"],
+        expectedAction: "answer configuration question",
+        keywords: ["webhook", "ip", "allowlist", "firewall"],
+        shortDescription:
+          "Customer asks which IP ranges webhooks are delivered from.",
+        title: "Webhook source IP ranges for firewall allowlist",
+      },
+      threadId: "tg2",
+      threadMessages: [
+        {
+          id: "tg2m1",
+          authorId: "cg2",
+          createdAt: now,
+          content:
+            "Our firewall needs an allowlist. Which IP ranges do your webhooks come from?",
+        },
+      ],
+      threadName: "Webhook source IPs",
+    },
+    name: "grounding: adjacent doc that does not answer the question -> inferred",
+    toolFixtures: {
+      docsPageChunksByUrl: {
+        "https://docs.example/webhooks/signatures": [
+          {
+            chunkIndex: 0,
+            chunkText:
+              "Every webhook carries an X-Signature header. Verify it by computing an HMAC-SHA256 of the raw body with your signing secret. This is the recommended way to confirm a request came from us.",
+            headingHierarchy: ["Webhooks", "Security"],
+            pageTitle: "Verifying webhook signatures",
+            pageUrl: "https://docs.example/webhooks/signatures",
+          },
+        ],
+      },
+      docsSearchHitsByQuery: {
+        "Webhook source IP ranges for firewall allowlist": [
+          {
+            chunkText:
+              "Every webhook carries an X-Signature header. Verify it by computing an HMAC-SHA256 of the raw body with your signing secret.",
+            headingHierarchy: ["Webhooks", "Security"],
+            pageTitle: "Verifying webhook signatures",
+            pageUrl: "https://docs.example/webhooks/signatures",
+            score: 0.88,
+          },
+        ],
+      },
+      threads: { tg2: mkThread("tg2", "Webhook source IPs") },
+    },
+  },
+  {
+    // Asserts nothing about product behaviour, so it is `state_report` and must
+    // name the PR it reports on — not `documented` (no docs) and not `inferred`
+    // (not a guess).
+    expected: {
+      expectedGroundingClass: "state_report",
+      minToolCalls: { read_pr: 1 },
+      mustIncludePrimaryKinds: ["link_pr", "reply"],
+      requiresReplyDraft: true,
+    },
+    input: {
+      hints: {},
+      sourceInputMessageId: "tg3m1",
+      summary: {
+        entities: ["csv_export"],
+        expectedAction: "bug acknowledgement",
+        keywords: ["csv", "export", "timeout"],
+        shortDescription:
+          "Customer reports CSV exports timing out on large date ranges.",
+        title: "CSV export times out for large date ranges",
+      },
+      threadId: "tg3",
+      threadMessages: [
+        {
+          id: "tg3m1",
+          authorId: "cg3",
+          createdAt: now,
+          content:
+            "Exporting a CSV for the full quarter just spins and then fails. Smaller ranges work fine.",
+        },
+      ],
+      threadName: "CSV export timeout",
+      triggers: [
+        {
+          kind: "pr_matched",
+          prMatched: {
+            prId: "pr-tg3",
+            score: 0.91,
+            title: "Stream CSV export rows instead of buffering",
+            url: "https://github.com/acme/api/pull/901",
+          },
+        },
+      ],
+    },
+    name: "grounding: status update on a verified PR -> state_report",
+    toolFixtures: {
+      prsByUrl: {
+        "https://github.com/acme/api/pull/901": {
+          authorLogin: "dev-dana",
+          baseRef: "main",
+          body: "Large CSV exports buffered the whole result set in memory and timed out past ~200k rows. Streams rows instead.",
+          draft: false,
+          headRef: "fix/csv-export-streaming",
+          labels: ["bug"],
+          merged: false,
+          number: 901,
+          repoFullName: "acme/api",
+          state: "open",
+          title: "Stream CSV export rows instead of buffering",
+          url: "https://github.com/acme/api/pull/901",
+        },
+      },
+      threads: { tg3: mkThread("tg3", "CSV export timeout") },
     },
   },
 ];

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/agent-scorers.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/agent-scorers.ts
@@ -10,6 +10,10 @@ import type {
 
 type In = SynthesisAgentEvalInput;
 type Expected = SynthesisAgentEvalCase["expected"];
+type PrimaryReply = Extract<
+  SynthesisRawActionSet["primary"][number],
+  { kind: "reply" }
+>;
 interface Out {
   raw: SynthesisRawActionSet;
   toolCalls: {
@@ -409,13 +413,26 @@ export const reasoningUserSafe = createScorer<In, Out, Expected>({
 });
 
 /**
- * The reply's declared [grounding](../../../../../../CONTEXT.md) class matches
- * what the case's evidence supports.
+ * Every primary reply, not just the first. Each one is separately auto-capable,
+ * so scoring only the first would let a correctly grounded reply cover for an
+ * over-claiming one in the same bundle.
+ */
+const primaryReplies = (output: Out): PrimaryReply[] =>
+  output.raw.primary.filter(
+    (action): action is PrimaryReply => action.kind === "reply"
+  );
+
+/**
+ * The reply's declared [grounding](../../../../../../../../CONTEXT.md) class
+ * matches what the case's evidence supports.
  *
  * Scored asymmetrically on purpose. Under-claiming costs a suggestion a human
  * still sees; over-claiming sends a wrong answer with nobody in the loop. Only
  * the second is a product failure, so it scores 0 and the first scores 0.5 —
  * the metric must not chase the cheap mistake into the expensive one.
+ *
+ * A bundle scores as its worst reply: one ungrounded send is the failure,
+ * whatever else shipped alongside it.
  */
 export const groundingCalibration = createScorer<In, Out, Expected>({
   description: "Reply grounding class matches the evidence the case supplies.",
@@ -426,25 +443,56 @@ export const groundingCalibration = createScorer<In, Out, Expected>({
       return { score: 1, metadata: { skipped: true } };
     }
 
-    const reply = output.raw.primary.find((action) => action.kind === "reply");
-    if (!reply || reply.kind !== "reply") {
+    const replies = primaryReplies(output);
+    if (replies.length === 0) {
       return { score: 0, metadata: { reason: "no_primary_reply" } };
     }
 
-    const actualClass = reply.grounding?.class ?? "inferred";
-    const overClaimed =
-      expectedClass === "inferred" && actualClass !== "inferred";
-
-    const score = actualClass === expectedClass ? 1 : overClaimed ? 0 : 0.5;
+    const scored = replies.map((reply) => {
+      const actualClass = reply.grounding?.class ?? "inferred";
+      const overClaimed =
+        expectedClass === "inferred" && actualClass !== "inferred";
+      return {
+        actualClass,
+        overClaimed,
+        score: actualClass === expectedClass ? 1 : overClaimed ? 0 : 0.5,
+        sources: reply.grounding?.sources ?? [],
+      };
+    });
 
     return {
-      score,
-      metadata: {
-        actualClass,
-        expectedClass,
-        overClaimed,
-        sources: reply.grounding?.sources ?? [],
-      },
+      score: Math.min(...scored.map((entry) => entry.score)),
+      metadata: { expectedClass, replies: scored },
+    };
+  },
+});
+
+/**
+ * The `state_report` names the entity the case verified. The class alone says
+ * the reply claims to report linked work; only the URL says it reports the
+ * *right* work, which is what the gate resolves against the mirror.
+ */
+export const groundingEntity = createScorer<In, Out, Expected>({
+  description: "State reports name the expected issue / PR URL.",
+  name: "Grounding Entity",
+  scorer: ({ output, expected }) => {
+    const wanted = expected?.expectedGroundingEntityUrl;
+    if (!wanted) {
+      return { score: 1, metadata: { skipped: true } };
+    }
+
+    const replies = primaryReplies(output);
+    if (replies.length === 0) {
+      return { score: 0, metadata: { reason: "no_primary_reply" } };
+    }
+
+    const actual = replies.map(
+      (reply) => reply.grounding?.entityUrl?.trim() ?? ""
+    );
+
+    return {
+      score: actual.every((url) => url === wanted) ? 1 : 0,
+      metadata: { actual, expected: wanted },
     };
   },
 });
@@ -463,16 +511,22 @@ export const groundingSources = createScorer<In, Out, Expected>({
       return { score: 1, metadata: { skipped: true } };
     }
 
-    const reply = output.raw.primary.find((action) => action.kind === "reply");
-    const actual = (
-      reply?.kind === "reply" ? (reply.grounding?.sources ?? []) : []
-    )
-      .map((source) => source.trim())
-      .sort();
+    const replies = primaryReplies(output);
+    if (replies.length === 0) {
+      return { score: 0, metadata: { reason: "no_primary_reply" } };
+    }
+
     const wanted = [...expectedSources].sort();
+    const actual = replies.map((reply) =>
+      (reply.grounding?.sources ?? []).map((source) => source.trim()).sort()
+    );
 
     return {
-      score: JSON.stringify(actual) === JSON.stringify(wanted) ? 1 : 0,
+      score: actual.every(
+        (sources) => JSON.stringify(sources) === JSON.stringify(wanted)
+      )
+        ? 1
+        : 0,
       metadata: { actual, expected: wanted },
     };
   },

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/agent-scorers.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/agent-scorers.ts
@@ -407,3 +407,73 @@ export const reasoningUserSafe = createScorer<In, Out, Expected>({
     };
   },
 });
+
+/**
+ * The reply's declared [grounding](../../../../../../CONTEXT.md) class matches
+ * what the case's evidence supports.
+ *
+ * Scored asymmetrically on purpose. Under-claiming costs a suggestion a human
+ * still sees; over-claiming sends a wrong answer with nobody in the loop. Only
+ * the second is a product failure, so it scores 0 and the first scores 0.5 —
+ * the metric must not chase the cheap mistake into the expensive one.
+ */
+export const groundingCalibration = createScorer<In, Out, Expected>({
+  description: "Reply grounding class matches the evidence the case supplies.",
+  name: "Grounding Calibration",
+  scorer: ({ output, expected }) => {
+    const expectedClass = expected?.expectedGroundingClass;
+    if (!expectedClass) {
+      return { score: 1, metadata: { skipped: true } };
+    }
+
+    const reply = output.raw.primary.find((action) => action.kind === "reply");
+    if (!reply || reply.kind !== "reply") {
+      return { score: 0, metadata: { reason: "no_primary_reply" } };
+    }
+
+    const actualClass = reply.grounding?.class ?? "inferred";
+    const overClaimed =
+      expectedClass === "inferred" && actualClass !== "inferred";
+
+    const score = actualClass === expectedClass ? 1 : overClaimed ? 0 : 0.5;
+
+    return {
+      score,
+      metadata: {
+        actualClass,
+        expectedClass,
+        overClaimed,
+        sources: reply.grounding?.sources ?? [],
+      },
+    };
+  },
+});
+
+/**
+ * A `documented` reply cites exactly the pages the case expects — the half of
+ * grounding that is mechanically checkable. A right label with scattergun
+ * citations would otherwise pass the scorer above.
+ */
+export const groundingSources = createScorer<In, Out, Expected>({
+  description: "Documented replies cite exactly the expected page URLs.",
+  name: "Grounding Sources",
+  scorer: ({ output, expected }) => {
+    const expectedSources = expected?.expectedGroundingSources;
+    if (!expectedSources) {
+      return { score: 1, metadata: { skipped: true } };
+    }
+
+    const reply = output.raw.primary.find((action) => action.kind === "reply");
+    const actual = (
+      reply?.kind === "reply" ? (reply.grounding?.sources ?? []) : []
+    )
+      .map((source) => source.trim())
+      .sort();
+    const wanted = [...expectedSources].sort();
+
+    return {
+      score: JSON.stringify(actual) === JSON.stringify(wanted) ? 1 : 0,
+      metadata: { actual, expected: wanted },
+    };
+  },
+});

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/synthesis-agent.eval.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/synthesis-agent.eval.ts
@@ -13,6 +13,7 @@ import {
   expectedLinkPrUrl,
   forbiddenPrimaryKinds,
   groundingCalibration,
+  groundingEntity,
   groundingSources,
   minimumToolCalls,
   nonEmptyPrimaryWhenExpected,
@@ -164,6 +165,7 @@ evalite("Synthesis Agent (Model In Loop)", {
     expectedLinkPrUrl,
     recommendationPrLink,
     groundingCalibration,
+    groundingEntity,
     groundingSources,
   ],
   task: async (input) => {

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/synthesis-agent.eval.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/synthesis-agent.eval.ts
@@ -12,6 +12,8 @@ import {
   atMostOneLinkPr,
   expectedLinkPrUrl,
   forbiddenPrimaryKinds,
+  groundingCalibration,
+  groundingSources,
   minimumToolCalls,
   nonEmptyPrimaryWhenExpected,
   recommendationPrLink,
@@ -161,6 +163,8 @@ evalite("Synthesis Agent (Model In Loop)", {
     atMostOneLinkPr,
     expectedLinkPrUrl,
     recommendationPrLink,
+    groundingCalibration,
+    groundingSources,
   ],
   task: async (input) => {
     const start = Date.now();

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/grounding-verification.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/grounding-verification.ts
@@ -81,6 +81,12 @@ export const collectRetrievedDocUrls = (
  *
  * `state_report` is checked later instead, by the gate: it needs the
  * post-policy action set, which does not exist yet here.
+ *
+ * Either way the returned grounding is canonical for its class — fields the
+ * class does not use are cleared rather than passed through. `state_report`
+ * with a stray `sources` array (or `documented` with a stray `entityUrl`) would
+ * otherwise vary `replyStateFingerprint` without the reported state moving,
+ * which is exactly the signal the consecutive-reply guard reads.
  */
 export const verifyReplyGrounding = (
   grounding: ReplyGrounding | undefined,
@@ -91,7 +97,11 @@ export const verifyReplyGrounding = (
   }
 
   if (grounding.class === "state_report") {
-    return grounding;
+    return {
+      class: "state_report",
+      entityUrl: grounding.entityUrl?.trim() || null,
+      sources: [],
+    };
   }
 
   const sources = grounding.sources
@@ -105,5 +115,5 @@ export const verifyReplyGrounding = (
     return inferredGrounding();
   }
 
-  return { ...grounding, sources };
+  return { class: "documented", entityUrl: null, sources };
 };

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/grounding-verification.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/grounding-verification.ts
@@ -1,0 +1,109 @@
+import type { Hints, ReplyGrounding } from "@workspace/schemas/signals";
+import { inferredGrounding } from "@workspace/schemas/signals";
+import z from "zod";
+
+interface ToolStep {
+  toolResults: {
+    toolName: string;
+    output: unknown;
+  }[];
+}
+
+const searchDocumentationOutputSchema = z.object({
+  hits: z.array(z.object({ pageUrl: z.string().optional() })).optional(),
+});
+
+const readDocumentationPageOutputSchema = z.object({
+  chunks: z.array(z.object({ pageUrl: z.string().optional() })).optional(),
+  pageUrl: z.string().optional(),
+});
+
+/**
+ * Every documentation page this run actually retrieved: the `related_docs` hint
+ * bag plus anything the agent pulled with its own tools. Both halves are
+ * needed — `search_documentation` exists because the bag misses things, and the
+ * best-grounded replies are the ones where the agent went looking.
+ *
+ * A page read with no chunks does not count. The tool returns empty on backend
+ * failure, and "we tried to read it" is not evidence.
+ */
+export const collectRetrievedDocUrls = (
+  steps: ToolStep[],
+  hints: Hints
+): Set<string> => {
+  const retrieved = new Set<string>();
+
+  for (const doc of hints.related_docs?.evidence?.docs ?? []) {
+    const url = doc.url?.trim() || doc.docId.trim();
+    if (url) {
+      retrieved.add(url);
+    }
+  }
+
+  for (const step of steps) {
+    for (const result of step.toolResults) {
+      if (result.toolName === "search_documentation") {
+        const parsed = searchDocumentationOutputSchema.safeParse(result.output);
+        for (const hit of parsed.success ? (parsed.data.hits ?? []) : []) {
+          const url = hit.pageUrl?.trim();
+          if (url) {
+            retrieved.add(url);
+          }
+        }
+        continue;
+      }
+
+      if (result.toolName === "read_documentation_page") {
+        const parsed = readDocumentationPageOutputSchema.safeParse(
+          result.output
+        );
+        if (!parsed.success || (parsed.data.chunks?.length ?? 0) === 0) {
+          continue;
+        }
+        const url = parsed.data.pageUrl?.trim();
+        if (url) {
+          retrieved.add(url);
+        }
+      }
+    }
+  }
+
+  return retrieved;
+};
+
+/**
+ * The trust boundary for a reply's [grounding](../../../../../CONTEXT.md): a
+ * `documented` claim survives only if every page it cites was retrieved on this
+ * run. Anything else degrades to `inferred` — the honest description of a draft
+ * whose sources cannot be shown. Degrade rather than drop: a fabricated
+ * citation is a reason to withhold autonomy, not to throw away a draft a human
+ * might still want to send.
+ *
+ * `state_report` is checked later instead, by the gate: it needs the
+ * post-policy action set, which does not exist yet here.
+ */
+export const verifyReplyGrounding = (
+  grounding: ReplyGrounding | undefined,
+  retrievedDocUrls: Set<string>
+): ReplyGrounding => {
+  if (!grounding || grounding.class === "inferred") {
+    return inferredGrounding();
+  }
+
+  if (grounding.class === "state_report") {
+    return grounding;
+  }
+
+  const sources = grounding.sources
+    .map((source) => source.trim())
+    .filter(Boolean);
+
+  if (
+    sources.length === 0 ||
+    sources.some((source) => !retrievedDocUrls.has(source))
+  ) {
+    return inferredGrounding();
+  }
+
+  return { ...grounding, sources };
+};

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/normalize.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/normalize.ts
@@ -1,5 +1,6 @@
 import type { Action, ThreadRead } from "@workspace/schemas/signals";
 import {
+  inferredGrounding,
   isIssueAction,
   sanitizeAgentReadReasoning,
   threadReadSchema,
@@ -30,7 +31,13 @@ const normalizeAction = (
     if (draftMarkdown.length === 0) {
       return null;
     }
-    return { draftMarkdown, kind: "reply" };
+    // Kept: the gate reads it, and a human reviewing a held-back draft sees
+    // its citations.
+    return {
+      draftMarkdown,
+      grounding: action.grounding ?? inferredGrounding(),
+      kind: "reply",
+    };
   }
 
   if (action.kind === "mark_duplicate") {

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/processor.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/processor.ts
@@ -6,6 +6,7 @@ import { createAILogger, createLogger } from "@workspace/utils/logging";
 
 import { AI_PRICING } from "../../../../lib/ai-pricing";
 import { isRetryableError } from "../../../../lib/logging";
+import { sortMessagesByTime } from "../../../../lib/message-order";
 import { threadHasTeamReply } from "../../../../lib/message-roles";
 import type { ParsedSummary } from "../../../../types";
 import { applySynthesisAutonomy } from "../../../core/autonomy-stage";
@@ -24,22 +25,10 @@ import { createSynthesisTools } from "./tools";
 const computeSha256 = (data: string): string =>
   createHash("sha256").update(data).digest("hex");
 
-const messageTimestamp = (createdAt: unknown): number => {
-  const time = new Date(createdAt as string | number | Date).getTime();
-  return Number.isNaN(time) ? 0 : time;
-};
-
-// Order by `createdAt` (with `id` as a stable tie-breaker) so the last element
-// is the true newest message. Sorting by `id` alone is wrong for Slack/Discord
-// backfills, where ids are ULIDs at insert time but `createdAt` reflects the
-// original external timestamp.
 const sortedMessages = (
   messages: ProcessorExecuteContext["thread"]["messages"]
 ): NonNullable<ProcessorExecuteContext["thread"]["messages"]> =>
-  [...(messages ?? [])].toSorted((a, b) => {
-    const delta = messageTimestamp(a.createdAt) - messageTimestamp(b.createdAt);
-    return delta === 0 ? a.id.localeCompare(b.id) : delta;
-  });
+  sortMessagesByTime(messages);
 
 const sortedAppliedLabelIds = (
   thread: ProcessorExecuteContext["thread"]

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
@@ -2,6 +2,7 @@ import { google } from "@ai-sdk/google";
 import type {
   ActionAvailability,
   Hints,
+  ReplyGrounding,
   ThreadReadTrigger,
 } from "@workspace/schemas/signals";
 import {
@@ -18,6 +19,10 @@ import z from "zod";
 
 import type { WorkerLogger } from "../../../../lib/logging";
 import type { ParsedSummary } from "../../../../types";
+import {
+  collectRetrievedDocUrls,
+  verifyReplyGrounding,
+} from "./grounding-verification";
 import {
   collectVerifiedIssueUrlsFromToolSteps,
   filterActionSetToVerifiedLinkIssue,
@@ -223,7 +228,7 @@ Say that engineering has been made aware and that you will follow up. Nothing mo
   // Kept in step with the parse schema above: the create_issue variant appears
   // in the documented shape only when the org can actually file one.
   const actionUnionDoc = [
-    '{ "kind": "reply", "draftMarkdown": string }',
+    '{ "kind": "reply", "draftMarkdown": string, "grounding": { "class": "documented" | "state_report" | "inferred", "sources": string[], "entityUrl": string | null } }',
     '{ "kind": "mark_duplicate", "targetThreadId": string }',
     '{ "kind": "link_pr", "prUrl": string }',
     '{ "kind": "link_issue", "issueUrl": string }',
@@ -294,6 +299,16 @@ Customer display name (use only in the greeting): ${JSON.stringify(customerName)
 When hasTeamReply is true, alternatives may be any allowed action kind (including standalone close, mark_duplicate, link_pr, or link_issue).
 
 ${replyCitationRule}
+
+## Every reply must declare its grounding (critical)
+
+Each \`reply\` action carries a \`grounding\` object saying what backs the draft. Be honest here — this is not a confidence score to talk yourself into, it is a claim about evidence, and it is checked.
+
+- **\`documented\`** — the draft answers the customer using documentation you retrieved this run. \`sources\` must list the exact \`pageUrl\` values of the pages you used, as returned by search_documentation, read_documentation_page, or the \`related_docs\` hint (its \`docId\` is the page URL). Only claim this when the cited pages answer **the question the customer actually asked**. A page about the same feature that does not resolve their problem is \`inferred\`, not \`documented\` — if you have to stretch to connect the page to the question, it is \`inferred\`.
+- **\`state_report\`** — the draft asserts nothing about how the product behaves; it only tells the customer the state of work already tracked on this thread ("we're aware, it's being worked on", "the fix has merged"). Set \`entityUrl\` to the exact URL of the issue or pull request whose state you are reporting. That entity must already be linked to this thread, or be linked by a link_pr / link_issue in the same primary array.
+- **\`inferred\`** — anything else: a reasonable answer from general knowledge, a guess, a clarifying question, a greeting. This is the correct and expected class for most replies. Choosing it is not a failure.
+
+\`sources\` must be \`[]\` unless the class is \`documented\`. \`entityUrl\` must be \`null\` unless the class is \`state_report\`. Never invent a page URL: a citation that was not returned by a tool or hint this run invalidates the claim.
 
 ## summary, recommendation, and reasoning (critical)
 
@@ -384,9 +399,32 @@ Return a single valid JSON object with exactly this shape:
     verifiedIssueUrls
   );
 
+  // Trust boundary for `documented`: a cited page must have been retrieved on
+  // this run. Unlike link_pr / link_issue this does not discard the action —
+  // an unverifiable citation costs the reply its autonomy, not its existence.
+  const retrievedDocUrls = collectRetrievedDocUrls(steps, input.hints ?? {});
+  const groundReplies = <
+    T extends { kind: string; grounding?: ReplyGrounding },
+  >(
+    actions: T[]
+  ): T[] =>
+    actions.map((action) =>
+      action.kind === "reply"
+        ? {
+            ...action,
+            grounding: verifyReplyGrounding(action.grounding, retrievedDocUrls),
+          }
+        : action
+    );
+
+  const grounded = {
+    alternatives: groundReplies(filtered.alternatives),
+    primary: groundReplies(filtered.primary),
+  };
+
   const recommendation = ensureVerifiedPrRecommendationLink(
     raw.recommendation,
-    filtered.primary,
+    grounded.primary,
     verifiedPrDetails
   );
 
@@ -403,8 +441,8 @@ Return a single valid JSON object with exactly this shape:
 
   return {
     ...raw,
-    alternatives: filtered.alternatives,
-    primary: filtered.primary,
+    alternatives: grounded.alternatives,
+    primary: grounded.primary,
     recommendation,
   };
 };

--- a/docs/adr/0013-grounded-auto-reply.md
+++ b/docs/adr/0013-grounded-auto-reply.md
@@ -1,0 +1,28 @@
+# 0013 — Auto-reply is gated on grounding, not capped at `suggest`
+
+**Status:** Accepted **Date:** 2026-08-09
+
+## Context
+
+`AUTO_CAPABLE_ACTIONS` deliberately excluded every customer-facing action, with `reply` capped at `suggest` on the reasoning that free-form generated prose has no structural check on it — unlike `link_pr` (requires a verified `read_pr`), `mark_duplicate` (requires a scored hint), or `create_issue` (requires a default target). That reasoning was right about the problem and wrong about the conclusion: the fix is to give reply a check, not to withhold the action.
+
+## Decision
+
+`reply` becomes auto-capable, gated on **[grounding](../../CONTEXT.md)** — a named class the synthesis agent must emit alongside the draft, where only `documented` and `state_report` may auto-send.
+
+**A class, not a scalar.** A self-reported 0–1 confidence is uncheckable; models emit `0.9` on hallucinations. A class that must name its sources is verifiable against what the run actually retrieved — the same move already made for `link_pr` and `link_issue`. Applicability (does the source answer _this_ question?) is folded into the class definition rather than split into a second field, because a separate `sufficiency` dimension would be collapsed straight back to a boolean by the gate.
+
+**Gated in the autonomy stage, via a generic action-gate registry.** Synthesis keeps emitting its best draft regardless; permission is the autonomy stage's job, and a low-grounding reply still reaches a human as a `suggest` rather than vanishing. The gate is a per-kind entry in a registry so future kinds can register one, but grounding itself stays on `replyActionSchema` — no other kind grows a field it will never use.
+
+**The gate runs after per-kind autonomy partitioning.** It has to: `link_pr` defaults to `off`, so a `state_report` reply citing a link established in the same bundle must be able to see whether that sibling is actually executing. Without this ordering the modal first-time configuration auto-sends a customer a reference to a link that was silently dropped.
+
+**Degradation is per-action.** A failed gate downgrades the reply only; reversible siblings still auto-execute, leaving the ADR-0003 partial state ("prefix committed, reply still owed") the UI already handles.
+
+**The Agent may not send two consecutive replies reporting the same state.** The customer speaking and a linked entity changing (a PR merging) both count as the state moving; elapsed time alone does not, since a clock keeps ticking but state transitions are finite.
+
+## Consequences
+
+- Orgs see `Auto` for reply as a normal third option, with an informational panel on selection explaining the restrictions. The stored enum stays three-valued.
+- An auto-sent reply is irreversible and its receipt carries no undo. The safety mechanisms are the gate, the consecutive-reply invariant, and `off` by default — not reversal.
+- Orgs with no crawled documentation can still enable it; only `state_report` replies will qualify, and the settings panel says so.
+- Grounding's honesty is a calibration property, so its failure mode is silent. Adversarial cases (adjacent-but-not-answering docs, plausible ungrounded prose, `state_report` with no linked entity) belong in the existing `synthesis-agent.eval.ts`, which already carries documentation fixtures.

--- a/packages/schemas/src/signals.ts
+++ b/packages/schemas/src/signals.ts
@@ -49,25 +49,38 @@ export const inferredGrounding = (): ReplyGrounding => ({
  * Digest of what a reply reported, compared across runs so the Agent cannot
  * send two replies in a row saying the same thing. `entityState` is what makes
  * a PR going open → merged worth speaking about again.
+ *
+ * Hashed over JSON rather than a joined string: sources and `entityUrl` are
+ * URLs, where `,` is a legal sub-delimiter, so `["a,b"]` and `["a", "b"]` would
+ * flatten to the same segment. This digest decides whether a reply may auto-
+ * send, so equivalent replies must be its only collisions.
  */
 export const replyStateFingerprint = (
   grounding: ReplyGrounding,
   entityState?: string | null
 ): string =>
-  [
-    grounding.class,
-    [...grounding.sources].sort().join(","),
-    grounding.entityUrl?.trim() ?? "",
-    entityState ?? "",
-  ].join("|");
+  stableHash(
+    JSON.stringify([
+      grounding.class,
+      [...grounding.sources].sort(),
+      grounding.entityUrl?.trim() ?? "",
+      entityState ?? "",
+    ])
+  );
 
 // --- Action vocabulary ----------------------------------------------------
 
 // Synthesis-track actions: composed by the synthesis LLM into a ThreadRead.
 export const replyActionSchema = z.object({
   draftMarkdown: z.string(),
-  /** Absent on a human-composed draft, and read as `inferred`. */
-  grounding: replyGroundingSchema.optional(),
+  /**
+   * Absent on a human-composed draft, and read as `inferred`. A malformed
+   * emission (`class: "confident"`, `sources` as a string) degrades to
+   * `inferred` here rather than failing the parse: the action set is parsed as
+   * a unit, so throwing would discard a whole synthesis run over a field whose
+   * only power is to *grant* autonomy.
+   */
+  grounding: replyGroundingSchema.optional().catch(inferredGrounding()),
   kind: z.literal("reply"),
 });
 export type ReplyAction = z.infer<typeof replyActionSchema>;

--- a/packages/schemas/src/signals.ts
+++ b/packages/schemas/src/signals.ts
@@ -46,27 +46,33 @@ export const inferredGrounding = (): ReplyGrounding => ({
 });
 
 /**
- * Digest of what a reply reported, compared across runs so the Agent cannot
- * send two replies in a row saying the same thing. `entityState` is what makes
- * a PR going open → merged worth speaking about again.
+ * Canonical form of what a reply reported, compared across runs so the Agent
+ * cannot send two replies in a row saying the same thing. `entityState` is what
+ * makes a PR going open → merged worth speaking about again.
  *
- * Hashed over JSON rather than a joined string: sources and `entityUrl` are
- * URLs, where `,` is a legal sub-delimiter, so `["a,b"]` and `["a", "b"]` would
- * flatten to the same segment. This digest decides whether a reply may auto-
- * send, so equivalent replies must be its only collisions.
+ * Canonical JSON rather than a digest, on purpose. This value decides whether a
+ * reply may auto-send, and it is only ever compared for equality and stored on
+ * the receipt — so hashing buys nothing and costs collisions, where two
+ * genuinely different states would read as "nothing new to say" and silently
+ * hold a reply the customer should have received. A digest small enough to be
+ * tidy is a digest big enough to collide; the exact value cannot. It also
+ * leaves the receipt readable, which is what anyone debugging a held reply
+ * wants to see.
+ *
+ * JSON rather than a joined string because sources and `entityUrl` are URLs,
+ * where `,` is a legal sub-delimiter: `["a,b"]` and `["a", "b"]` would flatten
+ * to the same segment.
  */
 export const replyStateFingerprint = (
   grounding: ReplyGrounding,
   entityState?: string | null
 ): string =>
-  stableHash(
-    JSON.stringify([
-      grounding.class,
-      [...grounding.sources].sort(),
-      grounding.entityUrl?.trim() ?? "",
-      entityState ?? "",
-    ])
-  );
+  JSON.stringify([
+    grounding.class,
+    [...grounding.sources].sort(),
+    grounding.entityUrl?.trim() ?? "",
+    entityState ?? "",
+  ]);
 
 // --- Action vocabulary ----------------------------------------------------
 
@@ -79,8 +85,11 @@ export const replyActionSchema = z.object({
    * `inferred` here rather than failing the parse: the action set is parsed as
    * a unit, so throwing would discard a whole synthesis run over a field whose
    * only power is to *grant* autonomy.
+   *
+   * The callback form matters: a bare value would hand every malformed reply
+   * the same object, and its `sources` array with it.
    */
-  grounding: replyGroundingSchema.optional().catch(inferredGrounding()),
+  grounding: replyGroundingSchema.optional().catch(() => inferredGrounding()),
   kind: z.literal("reply"),
 });
 export type ReplyAction = z.infer<typeof replyActionSchema>;

--- a/packages/schemas/src/signals.ts
+++ b/packages/schemas/src/signals.ts
@@ -14,11 +14,60 @@ const stableHash = (value: string): string => {
   return (hash % 4_294_967_296).toString(16).padStart(8, "0");
 };
 
+// --- Grounding (reply's action-gate input) --------------------------------
+
+/**
+ * A reply's [grounding](../../CONTEXT.md): its claim about what backs the draft
+ * (see ADR 0013). Named a class rather than a score because a class can name
+ * evidence and a number cannot — and because "confidence" already means
+ * {@link InlineSuggestion.confidence}, an unrelated 0–1 classifier output.
+ *
+ * Flat rather than a union on `class`: a malformed emission must degrade to
+ * `inferred`, never throw and take the whole synthesis run with it.
+ */
+export const replyGroundingSchema = z.object({
+  class: z.enum(["documented", "state_report", "inferred"]),
+  /** `state_report` only: URL of the issue / PR whose state the draft reports. */
+  entityUrl: z.string().nullish(),
+  /**
+   * `documented` only: pages the draft was written from. The documentation
+   * index keys pages by URL, so these are also `docId`s in `related_docs`.
+   */
+  sources: z.array(z.string()).default([]),
+});
+export type ReplyGrounding = z.infer<typeof replyGroundingSchema>;
+export type GroundingClass = ReplyGrounding["class"];
+
+/** A claim to nothing, which never auto-sends. */
+export const inferredGrounding = (): ReplyGrounding => ({
+  class: "inferred",
+  entityUrl: null,
+  sources: [],
+});
+
+/**
+ * Digest of what a reply reported, compared across runs so the Agent cannot
+ * send two replies in a row saying the same thing. `entityState` is what makes
+ * a PR going open → merged worth speaking about again.
+ */
+export const replyStateFingerprint = (
+  grounding: ReplyGrounding,
+  entityState?: string | null
+): string =>
+  [
+    grounding.class,
+    [...grounding.sources].sort().join(","),
+    grounding.entityUrl?.trim() ?? "",
+    entityState ?? "",
+  ].join("|");
+
 // --- Action vocabulary ----------------------------------------------------
 
 // Synthesis-track actions: composed by the synthesis LLM into a ThreadRead.
 export const replyActionSchema = z.object({
   draftMarkdown: z.string(),
+  /** Absent on a human-composed draft, and read as `inferred`. */
+  grounding: replyGroundingSchema.optional(),
   kind: z.literal("reply"),
 });
 export type ReplyAction = z.infer<typeof replyActionSchema>;
@@ -466,15 +515,18 @@ export function getDefaultActionAutonomy(): Record<ActionKind, AutonomyLevel> {
 
 /**
  * Kinds an org may raise all the way to `auto`. Reversible actions qualify by
- * construction (undo is a receipt away); `create_issue` is the one
- * non-reversible exception — `auto` mode has a deterministic destination in the
- * org's default issue target, and the setting's help text carries the warning.
- * Everything else is capped at `suggest` because it is destructive or
- * customer-facing.
+ * construction (undo is a receipt away). Two non-reversible kinds also qualify:
+ * `create_issue`, whose `auto` has a deterministic destination in the org's
+ * default issue target, and `reply`, which earns it only through its
+ * [action gate](../../CONTEXT.md) — `auto` on reply means "auto when grounded"
+ * (ADR 0013, which reverses the earlier cap on customer-facing actions).
+ *
+ * Everything else stays at `suggest`: destructive, with no gate to get past.
  */
 export const AUTO_CAPABLE_ACTIONS: ReadonlySet<ActionKind> = new Set([
   ...REVERSIBLE_ACTIONS,
   "create_issue",
+  "reply",
 ]);
 
 /**
@@ -520,6 +572,16 @@ export const autonomousActionMetadataSchema = z.discriminatedUnion("kind", [
     /** The link the thread carried before, restored verbatim on undo (null
      * when the thread had no issue linked). */
     previousIssueId: z.string().nullable(),
+  }),
+  /**
+   * The one receipt nothing can undo — a sent message cannot be recalled. It
+   * carries the fingerprint of what the Agent last told this customer, which is
+   * what the next run's reply gate compares against.
+   */
+  z.object({
+    grounding: replyGroundingSchema,
+    kind: z.literal("reply"),
+    stateFingerprint: z.string(),
   }),
 ]);
 export type AutonomousActionMetadata = z.infer<


### PR DESCRIPTION
Reply becomes auto-capable, reversing the rule that capped every customer-facing action at `suggest`. It qualifies only through a new **action gate**: synthesis declares what backs each draft, and only a `documented` or `state_report` claim sends itself. See [ADR 0013](docs/adr/0013-grounded-auto-reply.md).

## Design

**Grounding is a class, not a score.** A self-reported 0–1 confidence is uncheckable — models emit `0.9` on hallucinations. A class that must name its sources is verifiable against what the run actually retrieved, the same move already made for `link_pr`/`link_issue`.

- `documented` — the cited pages answer the question *as asked*. Adjacent-but-unhelpful is `inferred`.
- `state_report` — asserts nothing about the product, only reports the state of linked work.
- `inferred` — everything else. Never auto-sends.

**Gated in the autonomy stage, via a per-kind registry.** Synthesis still emits its best draft; permission is the autonomy stage's job, so a held-back reply reaches a human as a `suggest` rather than vanishing.

**The gate runs after per-kind partitioning.** It has to: `link_pr` defaults to `off`, so a `state_report` citing a link made in the same bundle must see whether that sibling is actually executing. Without this the modal first-time config auto-sends "tracked in #412" when nothing was linked.

**Degradation is per-action.** A failed gate holds back the reply only; reversible siblings still execute, leaving the ADR-0003 partial state the feed already handles.

**No two consecutive replies reporting the same state.** The customer speaking and a linked PR merging both count as movement; elapsed time does not.

## Notes

- An auto-sent reply is irreversible and its receipt carries no undo. `undo` now rejects non-reversible receipts — previously a reply receipt would fall through every branch and still be stamped `undoneAt`, claiming a retraction that never happened.
- The receipt does double duty: it is the audit trail *and* the durable record of what state the Agent last reported, which the next run's gate compares against.
- Settings keep the plain `Auto` label with a one-line notice while selected.

## Verification

`bun run typecheck`, `bun run lint`, and all 102 tests pass.

`eval:synthesis-agent` — 22 evals, **96%**, no regression on the 19 pre-existing cases. The three new adversarial cases each landed on their expected class:

| case | expected | actual |
|---|---|---|
| doc directly answers | `documented` | `documented`, cited the right page |
| adjacent doc (trap) | `inferred` | `inferred`, `sources: []` |
| status update on verified PR | `state_report` | `state_report`, correct `entityUrl` |

Calibration is a single sample of three cases — it shows the prompt isn't obviously miscalibrated, not that the class holds across the long tail.

## Review order

`CONTEXT.md` + ADR → `signals.ts` → `gates/reply-grounding.ts` → `autonomy-stage.ts` → `grounding-verification.ts` → everything else. The two things worth real scrutiny are the `state_report` sibling check and the gate-after-partitioning ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEhWXdFypjvQ16WpAqG7Xh

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds grounded auto-reply. Replies auto-send only when the draft is `documented` or a `state_report`; everything else stays a suggestion.

- **New Features**
  - Introduced an action‑gate framework with a reply grounding gate. Only `documented` or `state_report` replies auto‑send; unverifiable citations degrade to `inferred`.
  - Writes immutable reply receipts with a canonical state fingerprint; blocks consecutive same‑state replies using `latestReplyForThread`. Settings show an “Auto when grounded” notice; ADR‑0013 documents the approach.

- **Bug Fixes**
  - `undo` rejects non‑reversible receipts, and the web client mirrors undo only for `REVERSIBLE_ACTIONS`.
  - Grounding and state‑report robustness: compare `entity.externalKey`, return canonical grounding per class, store an exact JSON fingerprint (not a digest), and unify message ordering via a shared helper and an ordered, limited `latestReplyForThread` query.

<sup>Written for commit fb4b7599efecaa1ec932c9ae8eef7e668639af58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reply actions can now be sent automatically when supported by verified documentation or current conversation state.
  - Ungrounded or unverifiable replies remain drafts for review.
  - Automatic replies are prevented when conversation information has not changed, reducing duplicate responses.
  - Reply settings now explain when automatic sending is available and when review is required.

- **Bug Fixes**
  - Improved validation of documentation sources and linked issue or pull request status before sending replies.

- **Documentation**
  - Added guidance on reply grounding and automatic reply behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->