### PR TITLE
feat(ai): route text generation through the Respan gateway

### DIFF
--- a/apps/api/.env.local.example
+++ b/apps/api/.env.local.example
@@ -21,8 +21,11 @@ QDRANT_URL=http://localhost:6333
 # Optional: API port (defaults to 3333 if not set)
 PORT=
 
-# Google Generative AI
+# Google Generative AI (embeddings only)
 GOOGLE_GENERATIVE_AI_API_KEY=
+
+# Respan gateway (all text generation)
+RESPAN_API_KEY=
 
 # Redis
 REDIS_URL=redis://localhost:6379

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -36,7 +36,7 @@
     "eval:agent-chat": "evalite src/evals/agent-chat.eval.ts"
   },
   "dependencies": {
-    "@ai-sdk/google": "^3.0.7",
+    "@ai-sdk/google": "^4.0.42",
     "@connectors/framework": "workspace:*",
     "@dodopayments/express": "^0.2.1",
     "@keyv/redis": "^5.1.5",
@@ -49,7 +49,7 @@
     "@workspace/queue": "workspace:*",
     "@workspace/schemas": "workspace:*",
     "@workspace/utils": "workspace:*",
-    "ai": "^6.0.33",
+    "ai": "^7.0.62",
     "better-auth": "catalog:",
     "bullmq": "^5.0.0",
     "cors": "^2.8.5",

--- a/apps/api/src/evals/agent-chat.eval.ts
+++ b/apps/api/src/evals/agent-chat.eval.ts
@@ -1,4 +1,3 @@
-import { google } from "@ai-sdk/google";
 import { generateText, stepCountIs } from "ai";
 
 import "../env";
@@ -8,19 +7,25 @@ import { reportTrace } from "evalite/traces";
 import { OpenAI } from "openai";
 
 import {
+  agentModel,
+  RESPAN_OPENAI_BASE_URL,
+} from "../lib/ai/respan";
+import {
   buildAgentChatTools,
   buildSystemPrompt,
   formatThreadMetadata,
 } from "../live-state/router/agent-chat-core";
 
-// Configure autoevals to use Gemini via Google's OpenAI-compatible endpoint.
+// Configure autoevals to judge via the Respan gateway. autoevals only speaks the
+// OpenAI protocol, so it uses that endpoint (and its prefixed model ids) rather
+// than the Google-native passthrough the Agent itself runs on.
 // Cast through `never` — autoevals may resolve a different openai package instance.
 init({
   client: new OpenAI({
-    apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
-    baseURL: "https://generativelanguage.googleapis.com/v1beta/openai/",
+    apiKey: process.env.RESPAN_API_KEY,
+    baseURL: RESPAN_OPENAI_BASE_URL,
   }) as never,
-  defaultModel: "gemini-2.5-flash",
+  defaultModel: "gemini/gemini-2.5-flash",
 });
 import {
   toolSelectionDataset,
@@ -37,9 +42,9 @@ import {
   threadReferenceFormat,
 } from "./agent-chat.scorers";
 
-// Note: traceAISDKModel requires LanguageModelV2, but @ai-sdk/google exports V3.
+// Note: traceAISDKModel requires LanguageModelV2, but the provider exports V3.
 // Using reportTrace manually to capture LLM call metrics.
-const model = google("gemini-2.5-flash");
+const model = agentModel();
 
 const lowThinking = {
   providerOptions: {

--- a/apps/api/src/lib/ai/respan.ts
+++ b/apps/api/src/lib/ai/respan.ts
@@ -23,8 +23,14 @@ let provider: GoogleGenerativeAIProvider | undefined;
  * https://www.respan.ai/docs/integrations/gateway/vercel-ai-sdk
  */
 export const respan = (): GoogleGenerativeAIProvider => {
+  const apiKey = process.env.RESPAN_API_KEY;
+  if (!apiKey) {
+    // Without this guard the SDK falls back to GOOGLE_GENERATIVE_AI_API_KEY —
+    // our embeddings key — and quietly sends it to Respan.
+    throw new Error("RESPAN_API_KEY is required for text generation");
+  }
   provider ??= createGoogleGenerativeAI({
-    apiKey: process.env.RESPAN_API_KEY,
+    apiKey,
     baseURL: RESPAN_GOOGLE_BASE_URL,
   });
   return provider;

--- a/apps/api/src/lib/ai/respan.ts
+++ b/apps/api/src/lib/ai/respan.ts
@@ -1,0 +1,33 @@
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import type { GoogleGenerativeAIProvider } from "@ai-sdk/google";
+
+/** Same model the Agent has always used; ids stay unprefixed on this endpoint. */
+export const AGENT_MODEL = "gemini-2.5-flash";
+
+/**
+ * Google-native passthrough. Unlike Respan's OpenAI-compatible endpoint, this
+ * speaks Gemini's own protocol, so `providerOptions.google` — notably
+ * `thinkingConfig` — reaches the model instead of being silently dropped.
+ */
+export const RESPAN_GOOGLE_BASE_URL =
+  "https://api.respan.ai/api/google/gemini/v1beta";
+
+/** OpenAI-compatible endpoint, for clients that only speak that protocol. */
+export const RESPAN_OPENAI_BASE_URL = "https://api.respan.ai/api";
+
+let provider: GoogleGenerativeAIProvider | undefined;
+
+/**
+ * Respan gateway — one `RESPAN_API_KEY` covers every provider it routes to.
+ * Built lazily so the key is read after dotenv has loaded.
+ * https://www.respan.ai/docs/integrations/gateway/vercel-ai-sdk
+ */
+export const respan = (): GoogleGenerativeAIProvider => {
+  provider ??= createGoogleGenerativeAI({
+    apiKey: process.env.RESPAN_API_KEY,
+    baseURL: RESPAN_GOOGLE_BASE_URL,
+  });
+  return provider;
+};
+
+export const agentModel = () => respan()(AGENT_MODEL);

--- a/apps/api/src/live-state/router/agent-chat.ts
+++ b/apps/api/src/live-state/router/agent-chat.ts
@@ -1,11 +1,11 @@
 // TODO refactor with new live-state mental model
-import { google } from "@ai-sdk/google";
 import { parse } from "@workspace/utils/md-tiptap";
 import { jsonContentToPlainText, safeParseJSON } from "@workspace/utils/tiptap";
 import { stepCountIs, streamText } from "ai";
 import { ulid } from "ulid";
 import { z } from "zod";
 
+import { agentModel } from "../../lib/ai/respan";
 import {
   authorizeOwnedAgentChat,
   authorizeWorkspaceOrgMember,
@@ -647,7 +647,7 @@ export const agentChatRoute = privateRoute.withProcedures(({ mutation }) => ({
         };
 
         const result = streamText({
-          model: google("gemini-2.5-flash"),
+          model: agentModel(),
           system: systemPrompt,
           messages: conversationHistory,
           tools: buildAgentChatTools(toolImplementations),

--- a/apps/worker/.env.local.example
+++ b/apps/worker/.env.local.example
@@ -1,6 +1,9 @@
 NODE_ENV=development
-# Google Generative AI
+# Google Generative AI (embeddings only)
 GOOGLE_GENERATIVE_AI_API_KEY=
+
+# Respan gateway (all text generation)
+RESPAN_API_KEY=
 PR_MATCH_CANDIDATE_LIMIT=20
 PR_MATCH_RETRIEVAL_FLOOR=0.7
 PR_MATCH_RERANK_THRESHOLD=0.85

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -16,13 +16,13 @@
     "eval:synthesis-agent": "evalite src/pipeline/processors/synthesis-track/synthesis/eval/synthesis-agent.eval.ts"
   },
   "dependencies": {
-    "@ai-sdk/google": "^3.0.13",
+    "@ai-sdk/google": "^4.0.42",
     "@live-state/sync": "catalog:",
     "@qdrant/js-client-rest": "^1.16.2",
     "@workspace/queue": "workspace:*",
     "@workspace/schemas": "workspace:*",
     "@workspace/utils": "workspace:*",
-    "ai": "^6.0.174",
+    "ai": "^7.0.62",
     "api": "workspace:*",
     "bullmq": "^5.0.0",
     "ioredis": "^5.3.2",

--- a/apps/worker/src/lib/ai-pricing.ts
+++ b/apps/worker/src/lib/ai-pricing.ts
@@ -1,4 +1,6 @@
-// USD per 1M tokens. Keep in sync with https://ai.google.dev/gemini-api/docs/pricing.
+// USD per 1M tokens. Gemini (embeddings) tracks
+// https://ai.google.dev/gemini-api/docs/pricing; generation runs through the
+// Respan gateway, so those rates track https://api.respan.ai/api/models/public/.
 // Embedding models are billed as input-only; we set output=0 so
 // estimatedCost still computes correctly through the same code path.
 // Tiered models (Pro) use the >200k-token tier as a conservative upper bound.

--- a/apps/worker/src/lib/ai-pricing.ts
+++ b/apps/worker/src/lib/ai-pricing.ts
@@ -8,7 +8,7 @@ export const AI_PRICING = {
   "gemini-2.5-flash": { input: 0.3, output: 2.5 },
   "gemini-2.5-flash-lite": { input: 0.1, output: 0.4 },
   "gemini-2.5-pro": { input: 2.5, output: 15 },
-  "gemini-3-flash-preview": { input: 1.5, output: 9 },
+  "gemini-3-flash-preview": { input: 0.5, output: 3 },
   "gemini-3.1-flash-lite": { input: 0.25, output: 1.5 },
   "gemini-3.1-pro-preview": { input: 4, output: 18 },
   "gemini-3.5-flash": { input: 1.5, output: 9 },

--- a/apps/worker/src/lib/pr-match-reranker.ts
+++ b/apps/worker/src/lib/pr-match-reranker.ts
@@ -1,10 +1,10 @@
-import { google } from "@ai-sdk/google";
 import type { PrMatchJobData } from "@workspace/schemas/signals";
 import type { createAILogger } from "@workspace/utils/logging";
 import { generateText, Output } from "ai";
 import z from "zod";
 
 import { PR_MATCH_RERANK_THRESHOLD } from "./pr-match-config";
+import { generationModel } from "./respan";
 import type { ThreadHit } from "./qdrant/threads";
 
 const RERANK_MODEL = "gemini-2.5-flash-lite";
@@ -144,7 +144,7 @@ export const rerankPrMatches = async (
     return [];
   }
 
-  const baseModel = google(RERANK_MODEL);
+  const baseModel = generationModel(RERANK_MODEL);
   const threshold = PR_MATCH_RERANK_THRESHOLD;
   const { output } = await generateText({
     model: ai ? ai.wrap(baseModel) : baseModel,

--- a/apps/worker/src/lib/respan.ts
+++ b/apps/worker/src/lib/respan.ts
@@ -20,8 +20,14 @@ let provider: GoogleGenerativeAIProvider | undefined;
  * https://www.respan.ai/docs/integrations/gateway/vercel-ai-sdk
  */
 export const respan = (): GoogleGenerativeAIProvider => {
+  const apiKey = process.env.RESPAN_API_KEY;
+  if (!apiKey) {
+    // Without this guard the SDK falls back to GOOGLE_GENERATIVE_AI_API_KEY —
+    // our embeddings key — and quietly sends it to Respan.
+    throw new Error("RESPAN_API_KEY is required for text generation");
+  }
   provider ??= createGoogleGenerativeAI({
-    apiKey: process.env.RESPAN_API_KEY,
+    apiKey,
     baseURL: RESPAN_GOOGLE_BASE_URL,
   });
   return provider;

--- a/apps/worker/src/lib/respan.ts
+++ b/apps/worker/src/lib/respan.ts
@@ -1,0 +1,31 @@
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import type { GoogleGenerativeAIProvider } from "@ai-sdk/google";
+
+/** Default for pipeline generation; per-call overrides pass their own id. */
+export const GENERATION_MODEL = "gemini-2.5-flash";
+
+/**
+ * Google-native passthrough. Unlike Respan's OpenAI-compatible endpoint, this
+ * speaks Gemini's own protocol, so `providerOptions.google` — notably
+ * `thinkingConfig` — reaches the model instead of being silently dropped.
+ */
+export const RESPAN_GOOGLE_BASE_URL =
+  "https://api.respan.ai/api/google/gemini/v1beta";
+
+let provider: GoogleGenerativeAIProvider | undefined;
+
+/**
+ * Respan gateway — one `RESPAN_API_KEY` covers every provider it routes to.
+ * Built lazily so the key is read after dotenv has loaded.
+ * https://www.respan.ai/docs/integrations/gateway/vercel-ai-sdk
+ */
+export const respan = (): GoogleGenerativeAIProvider => {
+  provider ??= createGoogleGenerativeAI({
+    apiKey: process.env.RESPAN_API_KEY,
+    baseURL: RESPAN_GOOGLE_BASE_URL,
+  });
+  return provider;
+};
+
+export const generationModel = (model: string = GENERATION_MODEL) =>
+  respan()(model);

--- a/apps/worker/src/pipeline/processors/inline-track/label/classify.ts
+++ b/apps/worker/src/pipeline/processors/inline-track/label/classify.ts
@@ -1,8 +1,8 @@
-import { google } from "@ai-sdk/google";
 import type { createAILogger } from "@workspace/utils/logging";
 import { generateText, Output } from "ai";
 import z from "zod";
 
+import { generationModel } from "../../../../lib/respan";
 import type { SummarizeOutput } from "../../summarize";
 
 export interface ClassifyLabelInput {
@@ -72,7 +72,7 @@ ${
 
 Return the chosen label id (exactly as listed) or null. Confidence should reflect how confident you are; use values below 0.5 when uncertain, above 0.85 only when the match is unambiguous.`;
 
-  const baseModel = google("gemini-2.5-flash-lite");
+  const baseModel = generationModel("gemini-2.5-flash-lite");
   const { output } = await generateText({
     model: ai ? ai.wrap(baseModel) : baseModel,
     output: Output.object({ schema: responseSchema }),

--- a/apps/worker/src/pipeline/processors/summarize.ts
+++ b/apps/worker/src/pipeline/processors/summarize.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 
-import { google } from "@ai-sdk/google";
 import type { InferLiveObject } from "@live-state/sync";
 import { createAILogger, createLogger } from "@workspace/utils/logging";
 import { generateText, Output } from "ai";
@@ -8,6 +7,7 @@ import type { schema } from "api/schema";
 import z from "zod";
 
 import { AI_PRICING } from "../../lib/ai-pricing";
+import { generationModel } from "../../lib/respan";
 import { isRetryableError } from "../../lib/logging";
 import type { WorkerLogger } from "../../lib/logging";
 import type { ParsedSummary } from "../../types";
@@ -157,7 +157,7 @@ Think: "If another user has the exact same underlying problem with different wor
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const baseModel = google("gemini-3-flash-preview");
+      const baseModel = generationModel("gemini-3-flash-preview");
       const { output } = await generateText({
         model: ai ? ai.wrap(baseModel) : baseModel,
         output: Output.object({ schema: summarySchema }),

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
@@ -1,4 +1,3 @@
-import { google } from "@ai-sdk/google";
 import type {
   ActionAvailability,
   Hints,
@@ -19,6 +18,7 @@ import z from "zod";
 
 import type { WorkerLogger } from "../../../../lib/logging";
 import type { MessageRole } from "../../../../lib/message-roles";
+import { generationModel } from "../../../../lib/respan";
 import type { ParsedSummary } from "../../../../types";
 import {
   collectRetrievedDocUrls,
@@ -414,7 +414,7 @@ Return a single valid JSON object with exactly this shape:
 }
 `;
 
-  const baseModel = google("gemini-2.5-flash");
+  const baseModel = generationModel();
   const { text, steps } = await generateText({
     model: ai ? ai.wrap(baseModel) : baseModel,
     prompt,

--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
       "name": "api",
       "version": "0.0.0",
       "dependencies": {
-        "@ai-sdk/google": "^3.0.7",
+        "@ai-sdk/google": "^4.0.42",
         "@connectors/framework": "workspace:*",
         "@dodopayments/express": "^0.2.1",
         "@keyv/redis": "^5.1.5",
@@ -36,7 +36,7 @@
         "@workspace/queue": "workspace:*",
         "@workspace/schemas": "workspace:*",
         "@workspace/utils": "workspace:*",
-        "ai": "^6.0.33",
+        "ai": "^7.0.62",
         "better-auth": "catalog:",
         "bullmq": "^5.0.0",
         "cors": "^2.8.5",
@@ -184,13 +184,13 @@
     "apps/worker": {
       "name": "worker",
       "dependencies": {
-        "@ai-sdk/google": "^3.0.13",
+        "@ai-sdk/google": "^4.0.42",
         "@live-state/sync": "catalog:",
         "@qdrant/js-client-rest": "^1.16.2",
         "@workspace/queue": "workspace:*",
         "@workspace/schemas": "workspace:*",
         "@workspace/utils": "workspace:*",
-        "ai": "^6.0.174",
+        "ai": "^7.0.62",
         "api": "workspace:*",
         "bullmq": "^5.0.0",
         "ioredis": "^5.3.2",
@@ -441,7 +441,7 @@
         "@tiptap/extension-heading": "^3.4.1",
         "@tiptap/react": "^3.4.1",
         "date-fns": "^4.1.0",
-        "evlog": "^2.14.1",
+        "evlog": "^2.26.0",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
@@ -471,13 +471,13 @@
   "packages": {
     "@acemir/cssom": ["@acemir/cssom@0.9.30", "", {}, "sha512-9CnlMCI0LmCIq0olalQqdWrJHPzm0/tw3gzOA9zJSgvFX7Xau3D24mAGa4BtwxwY69nsuJW6kQqqCzf/mEcQgg=="],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.109", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-r6dOqThjODp1vOhGRJg2OCmyB/ZOQtGx1esZ2SDvwDX5XoX8dBqYaYjLg8MPXTzMGJSgOkJyCxWgUcZtAl16pw=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.49", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.27", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-qdSUr4FAN7e+MHBdVzkmbGMtpf7XQdQp1AgMI3jV0QPmld/4k4QbR7mXRQgjUsPeIfAwBzMPMPziHAPP1tXRwg=="],
 
-    "@ai-sdk/google": ["@ai-sdk/google@3.0.13", "", { "dependencies": { "@ai-sdk/provider": "3.0.5", "@ai-sdk/provider-utils": "4.0.9" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HYCh8miS4FLxOIpjo/BmoFVMO5BuxNpHVVDQkoJotoH8ZSFftkJJGGayIxQT/Lwx9GGvVVCOQ+lCdBBAnkl1sA=="],
+    "@ai-sdk/google": ["@ai-sdk/google@4.0.42", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-wFo4SmIEKd7kr+x0HvIRQG1E5ye+aW+Lqsg2IM54de4YxaN27iXb7AAvAvp496MNar7DrxgE1QHQ0vZ7hMFG3w=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.9", "", { "dependencies": { "@ai-sdk/provider": "3.0.5", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bB4r6nfhBOpmoS9mePxjRoCy+LnzP3AfhyMGCkGL4Mn9clVNlqEeKj26zEKEtB6yoSVcT1IQ0Zh9fytwMCDnow=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.27", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-EzAn4pdgG5g0xXtH6lE2zyNmfjDQIDjATkfqzuidEI35g++hh4+07vnjzkT/RmGmIClPZiRj/Q2GMPV2V7mkHw=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -2085,6 +2085,8 @@
 
     "@wll8/express-ws": ["@wll8/express-ws@1.0.6", "", { "dependencies": { "@types/express": "^4.17.13", "@types/ws": "8.5.3", "path-to-regexp": "0.1.7", "ws": "7.5.5" } }, "sha512-SvMVWwugfMI13hfKmsl4grJ7ZqHo94y1L4E9Ov7SvzkZtCs89BUE+cJ2+79DiS5P5Lcd28TXQH1H6H511qTHeg=="],
 
+    "@workflow/serde": ["@workflow/serde@4.1.0", "", {}, "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ=="],
+
     "@workspace/emails": ["@workspace/emails@workspace:packages/emails"],
 
     "@workspace/queue": ["@workspace/queue@workspace:packages/queue"],
@@ -2113,7 +2115,7 @@
 
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
-    "ai": ["ai@6.0.174", "", { "dependencies": { "@ai-sdk/gateway": "3.0.109", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bTrfLUWHWtkjzWyCY4bmyuk4Qvmj4S4NSNsXyNSVVqkmftQNtxRj7dzUoMeQDBBwlJO6fC7m2Q/lNOPqQQfAGA=="],
+    "ai": ["ai@7.0.62", "", { "dependencies": { "@ai-sdk/gateway": "4.0.49", "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-/YiuaaFIUPAiGqzHphnu9NuHQKbToZjlZkKoqGsQx6TFd7CZj6Z3eQUNeK6er1kXb9Ou5hRntRX4dvvE/kHYiQ=="],
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
@@ -2639,7 +2641,7 @@
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
-    "evlog": ["evlog@2.14.1", "", { "peerDependencies": { "@nestjs/common": ">=11.1.19", "@nuxt/kit": "^4.4.2", "@tanstack/start-client-core": "^1.167.20", "ai": ">=6.0.168", "elysia": ">=1.4.28", "express": ">=5.2.1", "fastify": ">=5.8.5", "h3": "^1.15.11", "hono": "", "next": ">=16.2.4", "nitro": "^3.0.260311-beta", "nitropack": "^2.13.3", "ofetch": "^1.5.1", "react": ">=19.2.5", "react-router": ">=7.14.2", "vite": "^7.0.0 || ^8.0.0" }, "optionalPeers": ["@nestjs/common", "@nuxt/kit", "@tanstack/start-client-core", "ai", "elysia", "express", "fastify", "h3", "hono", "next", "nitro", "nitropack", "ofetch", "react", "react-router", "vite"] }, "sha512-fLLPLsio6BOb6sjbecB5AkikW5KzmLXj8fMxp/PauaZrrwzmzA6J1J5II+BMQIrosh/nPN6snF1mqsbwkajfYQ=="],
+    "evlog": ["evlog@2.26.0", "", { "peerDependencies": { "@nestjs/common": ">=11.1.28", "@nuxt/kit": "^4.4.2", "@orpc/server": ">=1.14.8", "@tanstack/start-client-core": "^1.170.14", "ai": ">=6.0.168 <8.0.0", "elysia": ">=1.4.29", "eve": ">=0.30.0", "express": ">=5.2.1", "fastify": ">=5.10.0", "h3": "^1.15.11", "hono": ">=4.12.30", "next": ">=16.2.10", "nitro": "^3.0.260311-beta", "nitropack": "^2.13.4", "ofetch": "^1.5.1", "react": ">=19.2.7", "react-router": ">=7.18.1", "vite": "^7.0.0 || ^8.0.0" }, "optionalPeers": ["@nestjs/common", "@nuxt/kit", "@orpc/server", "@tanstack/start-client-core", "ai", "elysia", "eve", "express", "fastify", "h3", "hono", "next", "nitro", "nitropack", "ofetch", "react", "react-router", "vite"] }, "sha512-5/UrfWGJEIuPdOk2m2lBqxJcDoH+71bejl/D1U4q42A/+UPPZ11h35GvVdzn6HTMfnkfbBiRIfLBR5C8Osg47g=="],
 
     "evt": ["evt@2.5.9", "", { "dependencies": { "minimal-polyfills": "^2.2.3", "run-exclusive": "^2.2.19", "tsafe": "^1.8.5" } }, "sha512-GpjX476FSlttEGWHT8BdVMoI8wGXQGbEOtKcP4E+kggg+yJzXBZN2n4x7TS/zPBJ1DZqWI+rguZZApjjzQ0HpA=="],
 
@@ -4135,13 +4137,15 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@ai-sdk/gateway/@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+    "@ai-sdk/gateway/@ai-sdk/provider": ["@ai-sdk/provider@4.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q=="],
 
-    "@ai-sdk/gateway/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
+    "@ai-sdk/google/@ai-sdk/provider": ["@ai-sdk/provider@4.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q=="],
 
-    "@ai-sdk/google/@ai-sdk/provider": ["@ai-sdk/provider@3.0.5", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-2Xmoq6DBJqmSl80U6V9z5jJSJP7ehaJJQMy2iFUqTay06wdCqTnPVBBQbtEL8RCChenL+q5DC5H5WzU3vV3v8w=="],
+    "@ai-sdk/provider-utils/@ai-sdk/provider": ["@ai-sdk/provider@4.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q=="],
 
-    "@ai-sdk/provider-utils/@ai-sdk/provider": ["@ai-sdk/provider@3.0.5", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-2Xmoq6DBJqmSl80U6V9z5jJSJP7ehaJJQMy2iFUqTay06wdCqTnPVBBQbtEL8RCChenL+q5DC5H5WzU3vV3v8w=="],
+    "@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
+
+    "@ai-sdk/provider-utils/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "@aws-crypto/crc32/@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
 
@@ -4915,6 +4919,8 @@
 
     "@trigger.dev/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@trigger.dev/sdk/ai": ["ai@6.0.174", "", { "dependencies": { "@ai-sdk/gateway": "3.0.109", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bTrfLUWHWtkjzWyCY4bmyuk4Qvmj4S4NSNsXyNSVVqkmftQNtxRj7dzUoMeQDBBwlJO6fC7m2Q/lNOPqQQfAGA=="],
+
     "@trigger.dev/sdk/ulid": ["ulid@2.4.0", "", { "bin": { "ulid": "bin/cli.js" } }, "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg=="],
 
     "@trigger.dev/sdk/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
@@ -4955,9 +4961,7 @@
 
     "accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
-    "ai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
-
-    "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
+    "ai/@ai-sdk/provider": ["@ai-sdk/provider@4.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -5228,8 +5232,6 @@
     "zod-error/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zod-validation-error/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "@ai-sdk/gateway/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
     "@aws-crypto/crc32/@aws-sdk/types/@smithy/types": ["@smithy/types@4.11.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-mlrmL0DRDVe3mNrjTcVcZEgkFmufITfUAPBEA+AHYiIeYyJebso/He1qLbP3PssRe22KUzLRpQSdBPbXdgZ2VA=="],
 
@@ -5923,6 +5925,12 @@
 
     "@trigger.dev/core/socket.io/engine.io": ["engine.io@6.5.5", "", { "dependencies": { "@types/cookie": "^0.4.1", "@types/cors": "^2.8.12", "@types/node": ">=10.0.0", "accepts": "~1.3.4", "base64id": "2.0.0", "cookie": "~0.4.1", "cors": "~2.8.5", "debug": "~4.3.1", "engine.io-parser": "~5.2.1", "ws": "~8.17.1" } }, "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA=="],
 
+    "@trigger.dev/sdk/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.109", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-r6dOqThjODp1vOhGRJg2OCmyB/ZOQtGx1esZ2SDvwDX5XoX8dBqYaYjLg8MPXTzMGJSgOkJyCxWgUcZtAl16pw=="],
+
+    "@trigger.dev/sdk/ai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+
+    "@trigger.dev/sdk/ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
+
     "@types/body-parser/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "@types/connect/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
@@ -5968,8 +5976,6 @@
     "@workspace/ui/vitest/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
 
     "accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
-
-    "ai/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
     "body-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -6500,6 +6506,8 @@
     "@trigger.dev/core/socket.io/engine.io/cookie": ["cookie@0.4.2", "", {}, "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="],
 
     "@trigger.dev/core/socket.io/engine.io/ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
+
+    "@trigger.dev/sdk/ai/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
     "giget/nypm/pkg-types/confbox": ["confbox@0.2.2", "", {}, "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ=="],
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,7 +19,7 @@
     "@tiptap/extension-heading": "^3.4.1",
     "@tiptap/react": "^3.4.1",
     "date-fns": "^4.1.0",
-    "evlog": "^2.14.1",
+    "evlog": "^2.26.0",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",


### PR DESCRIPTION
Routes all generative Gemini calls through [Respan](https://www.respan.ai/docs/integrations/gateway/vercel-ai-sdk) instead of Google directly, so a single `RESPAN_API_KEY` covers them and usage lands in one dashboard.

**Models are unchanged** — same ids, same prompts, same provider options. Only the transport moved.

| Call site | Model |
|---|---|
| `agent-chat.ts` | `gemini-2.5-flash` |
| `summarize.ts` | `gemini-3-flash-preview` |
| `classify.ts` | `gemini-2.5-flash-lite` |
| `synthesize.ts` | `gemini-2.5-flash` |
| `pr-match-reranker.ts` | `gemini-2.5-flash-lite` |

**Embeddings are untouched** and still hit Google directly on `GOOGLE_GENERATIVE_AI_API_KEY`.

## Why the Google-native passthrough

Respan exposes two endpoints. This PR uses the Google-native one (`/api/google/gemini/v1beta`) rather than the OpenAI-compatible one, because the OpenAI-compatible path silently drops `providerOptions.google` — which would have disabled `thinkingConfig` on the Agent chat call without any error. Verified the passthrough preserves it: a request with `thinkingBudget: 1024` came back with `thoughtsTokenCount: 868`.

Net effect: each `respan.ts` is a `createGoogleGenerativeAI` instance with an `apiKey` and `baseURL`, and call sites keep their original shape.

One exception — the autoevals judge in `agent-chat.eval.ts` stays on the OpenAI-compatible endpoint with a `gemini/`-prefixed id, because autoevals only speaks that protocol. Both base URLs are exported and commented.

## Dependency bumps

`ai` 6 → 7 and `@ai-sdk/google` 3 → 4 (no code changes needed), plus `evlog` 2.14 → 2.26. **The evlog bump is required, not incidental:** `evlog/ai` imports `bindTelemetryIntegration` from `ai`, which v7 removed. Without it the worker throws on import — this surfaced only at runtime, not in typecheck.

## Setup

Add `RESPAN_API_KEY` to `apps/api/.env.local` and `apps/worker/.env.local` (both `.env.local.example` files updated). Deploy envs need it too.

## Verification

- Full repo typecheck: 12/12 tasks
- Worker tests: 8 files, 46 tests
- API tests: 9 files, 49 tests
- `eval:agent-chat`: 86% across 75 cases, zero API errors
- `eval:labels`: 97% across 31 cases

⚠️ Eval scores here are single unseeded runs and are noisy — the label eval produced 91–97% across this session with no functional change between several runs. Treat them as confirmation the wiring works end to end, not as a quality comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEhWXdFypjvQ16WpAqG7Xh

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes all Gemini text generation through the Respan gateway’s Google-native passthrough instead of Google, consolidating billing under one `RESPAN_API_KEY` while preserving model IDs, prompts, and `providerOptions.google`. Embeddings remain on `GOOGLE_GENERATIVE_AI_API_KEY`.

- Adds `apps/api/src/lib/ai/respan.ts` and `apps/worker/src/lib/respan.ts` with a lazy `createGoogleGenerativeAI` and `agentModel()`/`generationModel()` helpers using `https://api.respan.ai/api/google/gemini/v1beta`.
- Switches generation in `agent-chat.ts`, `summarize.ts`, `classify.ts`, `synthesize.ts`, and `pr-match-reranker.ts`; model strings are unchanged.
- Keeps the Agent on the Google-native endpoint; the autoevals judge uses Respan’s OpenAI-compatible endpoint (`RESPAN_OPENAI_BASE_URL`) with `gemini/`-prefixed IDs.
- Enforces `RESPAN_API_KEY` (throws if unset) to prevent fallback to the embeddings key; updates pricing for `gemini-3-flash-preview` to 0.5/3 in `ai-pricing.ts`.
- Upgrades dependencies: `ai` 6 → 7, `@ai-sdk/google` 3 → 4, `evlog` 2.14 → 2.26 (required to avoid a runtime import error with `evlog/ai`).

**Setup and rollout**
- Required: add `RESPAN_API_KEY` to `apps/api/.env.local`, `apps/worker/.env.local`, and all deploy environments.
- Embeddings stay on `GOOGLE_GENERATIVE_AI_API_KEY`; no model or prompt migrations.

<sup>Written for commit 09773bb4442999e74bd78014a5ef9d4adb6362c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Respan-backed text generation for agent chat, reranking, classification, summarization, and synthesis.
  - Added configuration support through `RESPAN_API_KEY`.
  - Preserved Google-based embeddings while routing generation through Respan.

- **Improvements**
  - Updated AI tooling and model integrations.
  - Clarified AI pricing documentation and environment configuration.
  - Upgraded logging utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->