### PR TITLE
feat(agent): add forensic pipeline audit ledger

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,6 +48,22 @@ A [processor](#processor) that produces zero or one [read hint](#read-hint) for 
 
 One execution of the pipeline over a single [thread](#thread). A run is the scope [processors](#processor) execute within, and the scope [read hints](#read-hint), [action availability](#action-availability) and the [autonomy stage](#autonomy-stage) share: a hint written by a [hint processor](#hint-processor) early in a run is visible to [synthesis](#synthesis) later in the same run, and availability is resolved once for the whole run. Several [triggers](#trigger) may coalesce into one run, so a run has _causes_ rather than a cause. _Avoid_: "batch" — a run covers exactly one thread, never several.
 
+### Run record
+
+A durable forensic record of one [run](#run), kept so the team can understand how the Agent reached a position or took an action after the run has finished. It preserves the run's causes, relevant inputs, observations, decisions, and outcomes without replacing the [thread read](#thread-read) or becoming a customer-facing activity history. _Avoid_: treating the run record as the current Agent surface or as a single log line.
+
+### Run attempt
+
+One actual worker execution of a [run](#run), including a retry after a queue failure. A run record keeps one attempt for each execution so a later investigation can distinguish the first failure from the retry that completed, rather than overwriting the earlier evidence. _Avoid_: calling a retry a new logical run when the queue job is the same cause.
+
+### Run event
+
+An ordered observation within a [run record](#run-record): a pipeline stage, model interaction, tool use, policy decision, gate result, or action outcome. Run events describe what happened and what the Agent was allowed to see at that point, so a sequence can be reconstructed instead of inferred only from the final [thread read](#thread-read). _Avoid_: using "event" for a new customer or queue trigger when the domain term is [trigger](#trigger).
+
+### Agent-visible context
+
+The thread state, [read hints](#read-hint), [trigger](#trigger) context, processor outputs, and tool results actually supplied to [synthesis](#synthesis) during a [run](#run). It is the evidence boundary for a [run record](#run-record): server-only configuration, credentials, and unrelated storage are outside it. _Avoid_: treating everything the worker can access as Agent-visible.
+
 ### Processor
 
 A unit of work in the pipeline with declared dependencies, run in dependency order. "Entry", "hint", and "synthesis" are _conceptual categories_ of processor, not different code shapes — they all share one definition. The label classifier behind [inline suggestions](#inline-suggestion) is also a processor, on a self-contained fast path: one cheap LLM call, no [action gate](#action-gate), applying autonomy itself before writing a chip.

--- a/apps/api/src/lib/agent-run-audit.test.ts
+++ b/apps/api/src/lib/agent-run-audit.test.ts
@@ -12,10 +12,16 @@ interface Row {
   [key: string]: unknown;
 }
 
+const uniqueViolation = (message: string): Error & { code: string } =>
+  Object.assign(new Error(message), { code: "23505" });
+
 interface DbOptions {
   attemptInsertRace?: boolean;
+  attemptInsertError?: Error;
   eventInsertRace?: boolean;
+  eventInsertError?: Error;
   runInsertRace?: boolean;
+  runInsertError?: Error;
 }
 
 const createDb = (options: DbOptions = {}) => {
@@ -24,6 +30,7 @@ const createDb = (options: DbOptions = {}) => {
     events: new Map<string, Row>(),
     runs: new Map<string, Row>(),
   };
+  const lookups = { attempts: 0, runs: 0 };
 
   const updateRow = (
     table: Map<string, Row>,
@@ -80,7 +87,12 @@ const createDb = (options: DbOptions = {}) => {
 
   const db = {
     agentRun: {
-      one: (id: string) => ({ get: async () => rows.runs.get(id) ?? null }),
+      one: (id: string) => ({
+        get: async () => {
+          lookups.runs += 1;
+          return rows.runs.get(id) ?? null;
+        },
+      }),
       update: async (id: string, values: Row) => {
         updateRow(rows.runs, id, values);
       },
@@ -88,7 +100,10 @@ const createDb = (options: DbOptions = {}) => {
     },
     agentRunAttempt: {
       one: (id: string) => ({
-        get: async () => rows.attempts.get(id) ?? null,
+        get: async () => {
+          lookups.attempts += 1;
+          return rows.attempts.get(id) ?? null;
+        },
       }),
       update: async (id: string, values: Row) => {
         updateRow(rows.attempts, id, values);
@@ -111,28 +126,37 @@ const createDb = (options: DbOptions = {}) => {
       ),
     insert: async (_model: unknown, row: Row) => {
       if ("type" in row) {
+        if (options.eventInsertError) {
+          throw options.eventInsertError;
+        }
         rows.events.set(row.id, row);
         if (options.eventInsertRace) {
           options.eventInsertRace = false;
-          throw new Error("concurrent event insert");
+          throw uniqueViolation("concurrent event insert");
         }
       } else if ("attemptNumber" in row) {
+        if (options.attemptInsertError) {
+          throw options.attemptInsertError;
+        }
         rows.attempts.set(row.id, row);
         if (options.attemptInsertRace) {
           options.attemptInsertRace = false;
-          throw new Error("concurrent attempt insert");
+          throw uniqueViolation("concurrent attempt insert");
         }
       } else {
+        if (options.runInsertError) {
+          throw options.runInsertError;
+        }
         rows.runs.set(row.id, row);
         if (options.runInsertRace) {
           options.runInsertRace = false;
-          throw new Error("concurrent run insert");
+          throw uniqueViolation("concurrent run insert");
         }
       }
     },
   };
 
-  return { db, rows };
+  return { db, lookups, rows };
 };
 
 describe("agent run audit persistence", () => {
@@ -185,6 +209,42 @@ describe("agent run audit persistence", () => {
     expect(rows.events.size).toBe(1);
   });
 
+  it("validates one run and attempt scope per append batch", async () => {
+    const { db, lookups } = createDb();
+    const startedAt = new Date("2026-08-18T12:00:00.000Z");
+
+    await runStartAgentRun(db as never, {
+      attemptId: "attempt-1",
+      attemptNumber: 1,
+      organizationId: "org-1",
+      runId: "run-1",
+      startedAt,
+      threadId: "thread-1",
+    });
+
+    const beforeAppend = { ...lookups };
+    const event = {
+      agentRunId: "run-1",
+      attemptId: "attempt-1",
+      emittedAt: startedAt,
+      id: "event-1",
+      occurredAt: startedAt,
+      organizationId: "org-1",
+      payloadHash: "hash",
+      payloadStr: "{}",
+      sequence: 0,
+      threadId: "thread-1",
+      type: "output.parsed",
+    };
+
+    await runAppendAgentRunEvents(db as never, {
+      events: [event, { ...event, id: "event-2", sequence: 1 }],
+    });
+
+    expect(lookups.runs - beforeAppend.runs).toBe(1);
+    expect(lookups.attempts - beforeAppend.attempts).toBe(1);
+  });
+
   it("folds a concurrent event insert into one accepted event", async () => {
     const { db, rows } = createDb({ eventInsertRace: true });
     const startedAt = new Date("2026-08-18T12:00:00.000Z");
@@ -216,6 +276,41 @@ describe("agent run audit persistence", () => {
       runAppendAgentRunEvents(db as never, { events: [event] })
     ).resolves.toStrictEqual({ inserted: 1 });
     expect(rows.events.size).toBe(1);
+  });
+
+  it("rethrows non-unique event insert failures", async () => {
+    const insertError = new Error("database unavailable");
+    const { db } = createDb({ eventInsertError: insertError });
+    const startedAt = new Date("2026-08-18T12:00:00.000Z");
+
+    await runStartAgentRun(db as never, {
+      attemptId: "attempt-1",
+      attemptNumber: 1,
+      organizationId: "org-1",
+      runId: "run-1",
+      startedAt,
+      threadId: "thread-1",
+    });
+
+    await expect(
+      runAppendAgentRunEvents(db as never, {
+        events: [
+          {
+            agentRunId: "run-1",
+            attemptId: "attempt-1",
+            emittedAt: startedAt,
+            id: "event-1",
+            occurredAt: startedAt,
+            organizationId: "org-1",
+            payloadHash: "hash",
+            payloadStr: "{}",
+            sequence: 0,
+            threadId: "thread-1",
+            type: "output.parsed",
+          },
+        ],
+      })
+    ).rejects.toBe(insertError);
   });
 
   it("rejects cross-scope starts and event appends", async () => {

--- a/apps/api/src/lib/agent-run-audit.test.ts
+++ b/apps/api/src/lib/agent-run-audit.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  runAppendAgentRunEvents,
+  runCompleteAgentRun,
+  runLatestAgentRunForThread,
+  runStartAgentRun,
+} from "./agent-run-audit";
+
+interface Row {
+  id: string;
+  [key: string]: unknown;
+}
+
+const createDb = () => {
+  const rows = {
+    attempts: new Map<string, Row>(),
+    events: new Map<string, Row>(),
+    runs: new Map<string, Row>(),
+  };
+
+  const updateRow = (
+    table: Map<string, Row>,
+    id: string,
+    values: Row
+  ): void => {
+    const row = table.get(id);
+    if (row) {
+      Object.assign(row, values);
+    }
+  };
+
+  const tableFor = (name: "attempts" | "events" | "runs") => rows[name];
+  const query = (name: "attempts" | "events" | "runs", filters: Row) => {
+    const matches = [...tableFor(name).values()].filter((row) =>
+      Object.entries(filters).every(([key, value]) => row[key] === value)
+    );
+
+    const makeQuery = (result: Row[]) => ({
+      get: async () => result,
+      limit: (count: number) => makeQuery(result.slice(0, count)),
+      orderBy: (field: string, direction: "asc" | "desc") =>
+        makeQuery(
+          [...result].toSorted((left, right) => {
+            const delta = String(left[field]).localeCompare(
+              String(right[field])
+            );
+            return direction === "desc" ? -delta : delta;
+          })
+        ),
+    });
+
+    return makeQuery(matches);
+  };
+
+  const db = {
+    agentRun: {
+      one: (id: string) => ({ get: async () => rows.runs.get(id) ?? null }),
+      update: async (id: string, values: Row) => {
+        updateRow(rows.runs, id, values);
+      },
+      where: (filters: Row) => query("runs", filters),
+    },
+    agentRunAttempt: {
+      one: (id: string) => ({
+        get: async () => rows.attempts.get(id) ?? null,
+      }),
+      update: async (id: string, values: Row) => {
+        updateRow(rows.attempts, id, values);
+      },
+      where: (filters: Row) => query("attempts", filters),
+    },
+    agentRunEvent: {
+      one: (id: string) => ({ get: async () => rows.events.get(id) ?? null }),
+      where: (filters: Row) => query("events", filters),
+    },
+    find: async (
+      _model: unknown,
+      options: { where: { id: { $in: string[] } } }
+    ) =>
+      Object.fromEntries(
+        options.where.id.$in
+          .map((id) => rows.events.get(id))
+          .filter((row): row is Row => Boolean(row))
+          .map((row) => [row.id, row])
+      ),
+    insert: async (_model: unknown, row: Row) => {
+      if ("type" in row) {
+        rows.events.set(row.id, row);
+      } else if ("attemptNumber" in row) {
+        rows.attempts.set(row.id, row);
+      } else {
+        rows.runs.set(row.id, row);
+      }
+    },
+  };
+
+  return { db, rows };
+};
+
+describe("agent run audit persistence", () => {
+  it("links attempts, deduplicates immutable events, and returns the latest run", async () => {
+    const { db, rows } = createDb();
+    const startedAt = new Date("2026-08-18T12:00:00.000Z");
+
+    await runStartAgentRun(db as never, {
+      attemptId: "attempt-1",
+      attemptNumber: 1,
+      organizationId: "org-1",
+      runId: "run-1",
+      startedAt,
+      threadId: "thread-1",
+    });
+
+    const event = {
+      agentRunId: "run-1",
+      attemptId: "attempt-1",
+      emittedAt: startedAt,
+      id: "event-1",
+      occurredAt: startedAt,
+      organizationId: "org-1",
+      payloadHash: "hash",
+      payloadStr: JSON.stringify({ decision: "reply" }),
+      sequence: 0,
+      threadId: "thread-1",
+      type: "output.parsed",
+    };
+
+    await expect(
+      runAppendAgentRunEvents(db as never, { events: [event, event] })
+    ).resolves.toStrictEqual({ inserted: 1 });
+
+    await runCompleteAgentRun(db as never, {
+      attemptId: "attempt-1",
+      completedAt: new Date("2026-08-18T12:00:01.000Z"),
+      runId: "run-1",
+      status: "completed",
+    });
+
+    const latest = await runLatestAgentRunForThread(db as never, {
+      organizationId: "org-1",
+      threadId: "thread-1",
+    });
+
+    expect(latest?.run.status).toBe("completed");
+    expect(latest?.attempts).toHaveLength(1);
+    expect(latest?.events).toHaveLength(1);
+    expect(rows.events.size).toBe(1);
+  });
+});

--- a/apps/api/src/lib/agent-run-audit.test.ts
+++ b/apps/api/src/lib/agent-run-audit.test.ts
@@ -12,7 +12,13 @@ interface Row {
   [key: string]: unknown;
 }
 
-const createDb = () => {
+interface DbOptions {
+  attemptInsertRace?: boolean;
+  eventInsertRace?: boolean;
+  runInsertRace?: boolean;
+}
+
+const createDb = (options: DbOptions = {}) => {
   const rows = {
     attempts: new Map<string, Row>(),
     events: new Map<string, Row>(),
@@ -36,18 +42,37 @@ const createDb = () => {
       Object.entries(filters).every(([key, value]) => row[key] === value)
     );
 
-    const makeQuery = (result: Row[]) => ({
-      get: async () => result,
-      limit: (count: number) => makeQuery(result.slice(0, count)),
+    const compare = (left: unknown, right: unknown): number => {
+      if (typeof left === "number" && typeof right === "number") {
+        return left - right;
+      }
+      if (left instanceof Date && right instanceof Date) {
+        return left.getTime() - right.getTime();
+      }
+      return String(left).localeCompare(String(right));
+    };
+
+    const makeQuery = (
+      orderBys: { direction: "asc" | "desc"; field: string }[] = [],
+      limitCount?: number
+    ) => ({
+      get: async () => {
+        const ordered = [...matches].toSorted((left, right) => {
+          for (const { direction, field } of orderBys) {
+            const delta = compare(left[field], right[field]);
+            if (delta !== 0) {
+              return direction === "desc" ? -delta : delta;
+            }
+          }
+          return 0;
+        });
+        return limitCount === undefined
+          ? ordered
+          : ordered.slice(0, limitCount);
+      },
+      limit: (count: number) => makeQuery(orderBys, count),
       orderBy: (field: string, direction: "asc" | "desc") =>
-        makeQuery(
-          [...result].toSorted((left, right) => {
-            const delta = String(left[field]).localeCompare(
-              String(right[field])
-            );
-            return direction === "desc" ? -delta : delta;
-          })
-        ),
+        makeQuery([...orderBys, { direction, field }], limitCount),
     });
 
     return makeQuery(matches);
@@ -76,10 +101,10 @@ const createDb = () => {
     },
     find: async (
       _model: unknown,
-      options: { where: { id: { $in: string[] } } }
+      findOptions: { where: { id: { $in: string[] } } }
     ) =>
       Object.fromEntries(
-        options.where.id.$in
+        findOptions.where.id.$in
           .map((id) => rows.events.get(id))
           .filter((row): row is Row => Boolean(row))
           .map((row) => [row.id, row])
@@ -87,10 +112,22 @@ const createDb = () => {
     insert: async (_model: unknown, row: Row) => {
       if ("type" in row) {
         rows.events.set(row.id, row);
+        if (options.eventInsertRace) {
+          options.eventInsertRace = false;
+          throw new Error("concurrent event insert");
+        }
       } else if ("attemptNumber" in row) {
         rows.attempts.set(row.id, row);
+        if (options.attemptInsertRace) {
+          options.attemptInsertRace = false;
+          throw new Error("concurrent attempt insert");
+        }
       } else {
         rows.runs.set(row.id, row);
+        if (options.runInsertRace) {
+          options.runInsertRace = false;
+          throw new Error("concurrent run insert");
+        }
       }
     },
   };
@@ -146,5 +183,195 @@ describe("agent run audit persistence", () => {
     expect(latest?.attempts).toHaveLength(1);
     expect(latest?.events).toHaveLength(1);
     expect(rows.events.size).toBe(1);
+  });
+
+  it("folds a concurrent event insert into one accepted event", async () => {
+    const { db, rows } = createDb({ eventInsertRace: true });
+    const startedAt = new Date("2026-08-18T12:00:00.000Z");
+
+    await runStartAgentRun(db as never, {
+      attemptId: "attempt-1",
+      attemptNumber: 1,
+      organizationId: "org-1",
+      runId: "run-1",
+      startedAt,
+      threadId: "thread-1",
+    });
+
+    const event = {
+      agentRunId: "run-1",
+      attemptId: "attempt-1",
+      emittedAt: startedAt,
+      id: "event-1",
+      occurredAt: startedAt,
+      organizationId: "org-1",
+      payloadHash: "hash",
+      payloadStr: JSON.stringify({ decision: "reply" }),
+      sequence: 0,
+      threadId: "thread-1",
+      type: "output.parsed",
+    };
+
+    await expect(
+      runAppendAgentRunEvents(db as never, { events: [event] })
+    ).resolves.toStrictEqual({ inserted: 1 });
+    expect(rows.events.size).toBe(1);
+  });
+
+  it("rejects cross-scope starts and event appends", async () => {
+    const { db } = createDb();
+    const startedAt = new Date("2026-08-18T12:00:00.000Z");
+
+    await runStartAgentRun(db as never, {
+      attemptId: "attempt-1",
+      attemptNumber: 1,
+      organizationId: "org-1",
+      runId: "run-1",
+      startedAt,
+      threadId: "thread-1",
+    });
+
+    await expect(
+      runStartAgentRun(db as never, {
+        attemptId: "attempt-1",
+        attemptNumber: 1,
+        organizationId: "org-2",
+        runId: "run-1",
+        startedAt,
+        threadId: "thread-2",
+      })
+    ).rejects.toThrow("AGENT_RUN_SCOPE_MISMATCH");
+
+    await expect(
+      runAppendAgentRunEvents(db as never, {
+        events: [
+          {
+            agentRunId: "run-1",
+            attemptId: "attempt-1",
+            emittedAt: startedAt,
+            id: "event-1",
+            occurredAt: startedAt,
+            organizationId: "org-2",
+            payloadHash: "hash",
+            payloadStr: "{}",
+            sequence: 0,
+            threadId: "thread-2",
+            type: "output.parsed",
+          },
+        ],
+      })
+    ).rejects.toThrow("AGENT_RUN_EVENT_SCOPE_MISMATCH");
+  });
+
+  it("handles concurrent run and attempt starts idempotently", async () => {
+    const { db, rows } = createDb({
+      attemptInsertRace: true,
+      runInsertRace: true,
+    });
+    const startedAt = new Date("2026-08-18T12:00:00.000Z");
+
+    await expect(
+      runStartAgentRun(db as never, {
+        attemptId: "attempt-1",
+        attemptNumber: 1,
+        organizationId: "org-1",
+        runId: "run-1",
+        startedAt,
+        threadId: "thread-1",
+      })
+    ).resolves.toStrictEqual({ attemptId: "attempt-1", runId: "run-1" });
+    expect(rows.runs.size).toBe(1);
+    expect(rows.attempts.size).toBe(1);
+  });
+
+  it("orders numeric attempts and ties latest runs by id", async () => {
+    const { db, rows } = createDb();
+    const startedAt = new Date("2026-08-18T12:00:00.000Z");
+
+    rows.runs.set("run-a", {
+      id: "run-a",
+      organizationId: "org-1",
+      startedAt,
+      threadId: "thread-1",
+    });
+    rows.runs.set("run-z", {
+      id: "run-z",
+      organizationId: "org-1",
+      startedAt,
+      threadId: "thread-1",
+    });
+    rows.attempts.set("attempt-10", {
+      agentRunId: "run-z",
+      attemptNumber: 10,
+      id: "attempt-10",
+      organizationId: "org-1",
+      threadId: "thread-1",
+    });
+    rows.attempts.set("attempt-2", {
+      agentRunId: "run-z",
+      attemptNumber: 2,
+      id: "attempt-2",
+      organizationId: "org-1",
+      threadId: "thread-1",
+    });
+
+    const latest = await runLatestAgentRunForThread(db as never, {
+      organizationId: "org-1",
+      threadId: "thread-1",
+    });
+
+    expect(latest?.run.id).toBe("run-z");
+    expect(latest?.attempts.map((attempt) => attempt.id)).toStrictEqual([
+      "attempt-2",
+      "attempt-10",
+    ]);
+  });
+
+  it("rejects completion for a missing run before updating an attempt", async () => {
+    const { db, rows } = createDb();
+    const startedAt = new Date("2026-08-18T12:00:00.000Z");
+
+    await runStartAgentRun(db as never, {
+      attemptId: "attempt-1",
+      attemptNumber: 1,
+      organizationId: "org-1",
+      runId: "run-1",
+      startedAt,
+      threadId: "thread-1",
+    });
+
+    rows.attempts.set("attempt-other", {
+      agentRunId: "run-other",
+      id: "attempt-other",
+      organizationId: "org-1",
+      threadId: "thread-1",
+    });
+    await expect(
+      runCompleteAgentRun(db as never, {
+        attemptId: "attempt-other",
+        completedAt: startedAt,
+        runId: "run-1",
+        status: "completed",
+      })
+    ).rejects.toThrow("AGENT_RUN_ATTEMPT_NOT_FOUND");
+
+    await expect(
+      runCompleteAgentRun(db as never, {
+        attemptId: "attempt-1",
+        completedAt: startedAt,
+        runId: "run-2",
+        status: "completed",
+      })
+    ).rejects.toThrow("AGENT_RUN_NOT_FOUND");
+
+    rows.runs.delete("run-1");
+    await expect(
+      runCompleteAgentRun(db as never, {
+        attemptId: "attempt-1",
+        completedAt: startedAt,
+        runId: "run-1",
+        status: "completed",
+      })
+    ).rejects.toThrow("AGENT_RUN_NOT_FOUND");
   });
 });

--- a/apps/api/src/lib/agent-run-audit.ts
+++ b/apps/api/src/lib/agent-run-audit.ts
@@ -1,5 +1,4 @@
 import type { ServerDB } from "@live-state/sync/server";
-import { ulid } from "ulid";
 import { z } from "zod";
 
 import { schema } from "../live-state/schema";
@@ -99,6 +98,82 @@ type LatestAgentRunInput = z.infer<typeof latestAgentRunInputSchema>;
 
 const now = () => new Date();
 
+const assertRunScope = (
+  run: { organizationId: string; threadId: string },
+  input: { organizationId: string; threadId: string }
+): void => {
+  if (
+    run.organizationId !== input.organizationId ||
+    run.threadId !== input.threadId
+  ) {
+    throw new Error("AGENT_RUN_SCOPE_MISMATCH");
+  }
+};
+
+const assertAttemptScope = (
+  attempt: {
+    agentRunId: string;
+    organizationId: string;
+    threadId: string;
+  },
+  input: {
+    agentRunId: string;
+    organizationId: string;
+    threadId: string;
+  }
+): void => {
+  if (
+    attempt.agentRunId !== input.agentRunId ||
+    attempt.organizationId !== input.organizationId ||
+    attempt.threadId !== input.threadId
+  ) {
+    throw new Error("AGENT_RUN_ATTEMPT_SCOPE_MISMATCH");
+  }
+};
+
+const assertEventScope = async (
+  db: AgentRunDb,
+  event: AppendAgentRunEventsInput["events"][number]
+): Promise<void> => {
+  const run = await db.agentRun.one(event.agentRunId).get();
+  if (
+    !run ||
+    run.organizationId !== event.organizationId ||
+    run.threadId !== event.threadId
+  ) {
+    throw new Error("AGENT_RUN_EVENT_SCOPE_MISMATCH");
+  }
+
+  const attempt = await db.agentRunAttempt.one(event.attemptId).get();
+  if (
+    !attempt ||
+    attempt.agentRunId !== event.agentRunId ||
+    attempt.organizationId !== event.organizationId ||
+    attempt.threadId !== event.threadId
+  ) {
+    throw new Error("AGENT_RUN_EVENT_SCOPE_MISMATCH");
+  }
+};
+
+const assertStoredEventScope = (
+  stored: {
+    agentRunId: string;
+    attemptId: string;
+    organizationId: string;
+    threadId: string;
+  },
+  event: AppendAgentRunEventsInput["events"][number]
+): void => {
+  if (
+    stored.agentRunId !== event.agentRunId ||
+    stored.attemptId !== event.attemptId ||
+    stored.organizationId !== event.organizationId ||
+    stored.threadId !== event.threadId
+  ) {
+    throw new Error("AGENT_RUN_EVENT_SCOPE_MISMATCH");
+  }
+};
+
 export const runStartAgentRun = async (
   db: AgentRunDb,
   input: StartAgentRunInput
@@ -107,7 +182,8 @@ export const runStartAgentRun = async (
   const run = await db.agentRun.one(input.runId).get();
 
   if (run) {
-    await db.agentRun.update(run.id, {
+    assertRunScope(run, input);
+    const values = {
       auditIncomplete: run.auditIncomplete,
       completedAt: null,
       metadataStr: input.metadataStr ?? run.metadataStr,
@@ -117,28 +193,53 @@ export const runStartAgentRun = async (
       startedAt: input.startedAt,
       status: "running",
       updatedAt: timestamp,
-    });
+    };
+    await db.agentRun.update(run.id, values);
   } else {
-    await db.insert(schema.agentRun, {
-      auditIncomplete: false,
-      completedAt: null,
-      createdAt: timestamp,
-      id: input.runId,
-      metadataStr: input.metadataStr ?? null,
-      organizationId: input.organizationId,
-      pipelineJobId: input.pipelineJobId ?? null,
-      queueJobId: input.queueJobId ?? null,
-      queueName: input.queueName ?? null,
-      startedAt: input.startedAt,
-      status: "running",
-      threadId: input.threadId,
-      updatedAt: timestamp,
-    });
+    try {
+      await db.insert(schema.agentRun, {
+        auditIncomplete: false,
+        completedAt: null,
+        createdAt: timestamp,
+        id: input.runId,
+        metadataStr: input.metadataStr ?? null,
+        organizationId: input.organizationId,
+        pipelineJobId: input.pipelineJobId ?? null,
+        queueJobId: input.queueJobId ?? null,
+        queueName: input.queueName ?? null,
+        startedAt: input.startedAt,
+        status: "running",
+        threadId: input.threadId,
+        updatedAt: timestamp,
+      });
+    } catch {
+      const concurrent = await db.agentRun.one(input.runId).get();
+      if (!concurrent) {
+        throw new Error("AGENT_RUN_INSERT_FAILED");
+      }
+      assertRunScope(concurrent, input);
+      await db.agentRun.update(concurrent.id, {
+        auditIncomplete: concurrent.auditIncomplete,
+        completedAt: null,
+        metadataStr: input.metadataStr ?? concurrent.metadataStr,
+        pipelineJobId: input.pipelineJobId ?? concurrent.pipelineJobId,
+        queueJobId: input.queueJobId ?? concurrent.queueJobId,
+        queueName: input.queueName ?? concurrent.queueName,
+        startedAt: input.startedAt,
+        status: "running",
+        updatedAt: timestamp,
+      });
+    }
   }
 
   const attempt = await db.agentRunAttempt.one(input.attemptId).get();
   if (attempt) {
-    await db.agentRunAttempt.update(attempt.id, {
+    assertAttemptScope(attempt, {
+      agentRunId: input.runId,
+      organizationId: input.organizationId,
+      threadId: input.threadId,
+    });
+    const values = {
       auditIncomplete: attempt.auditIncomplete,
       bullmqJobId: input.bullmqJobId ?? attempt.bullmqJobId,
       completedAt: null,
@@ -148,25 +249,49 @@ export const runStartAgentRun = async (
       startedAt: input.startedAt,
       status: "running",
       updatedAt: timestamp,
-    });
+    };
+    await db.agentRunAttempt.update(attempt.id, values);
   } else {
-    await db.insert(schema.agentRunAttempt, {
-      agentRunId: input.runId,
-      auditIncomplete: false,
-      attemptNumber: input.attemptNumber,
-      bullmqJobId: input.bullmqJobId ?? null,
-      completedAt: null,
-      createdAt: timestamp,
-      id: input.attemptId,
-      metadataStr: input.metadataStr ?? null,
-      organizationId: input.organizationId,
-      pipelineJobId: input.pipelineJobId ?? null,
-      queueName: input.queueName ?? null,
-      startedAt: input.startedAt,
-      status: "running",
-      threadId: input.threadId,
-      updatedAt: timestamp,
-    });
+    try {
+      await db.insert(schema.agentRunAttempt, {
+        agentRunId: input.runId,
+        auditIncomplete: false,
+        attemptNumber: input.attemptNumber,
+        bullmqJobId: input.bullmqJobId ?? null,
+        completedAt: null,
+        createdAt: timestamp,
+        id: input.attemptId,
+        metadataStr: input.metadataStr ?? null,
+        organizationId: input.organizationId,
+        pipelineJobId: input.pipelineJobId ?? null,
+        queueName: input.queueName ?? null,
+        startedAt: input.startedAt,
+        status: "running",
+        threadId: input.threadId,
+        updatedAt: timestamp,
+      });
+    } catch {
+      const concurrent = await db.agentRunAttempt.one(input.attemptId).get();
+      if (!concurrent) {
+        throw new Error("AGENT_RUN_ATTEMPT_INSERT_FAILED");
+      }
+      assertAttemptScope(concurrent, {
+        agentRunId: input.runId,
+        organizationId: input.organizationId,
+        threadId: input.threadId,
+      });
+      await db.agentRunAttempt.update(concurrent.id, {
+        auditIncomplete: concurrent.auditIncomplete,
+        bullmqJobId: input.bullmqJobId ?? concurrent.bullmqJobId,
+        completedAt: null,
+        metadataStr: input.metadataStr ?? concurrent.metadataStr,
+        pipelineJobId: input.pipelineJobId ?? concurrent.pipelineJobId,
+        queueName: input.queueName ?? concurrent.queueName,
+        startedAt: input.startedAt,
+        status: "running",
+        updatedAt: timestamp,
+      });
+    }
   }
 
   return { attemptId: input.attemptId, runId: input.runId };
@@ -190,7 +315,13 @@ export const runAppendAgentRunEvents = async (
   let inserted = 0;
 
   for (const event of input.events) {
+    await assertEventScope(db, event);
+
     if (existingIds.has(event.id)) {
+      const stored = await db.agentRunEvent.one(event.id).get();
+      if (stored) {
+        assertStoredEventScope(stored, event);
+      }
       continue;
     }
 
@@ -200,7 +331,7 @@ export const runAppendAgentRunEvents = async (
         attemptId: event.attemptId,
         causationEventId: event.causationEventId ?? null,
         emittedAt: event.emittedAt,
-        id: event.id || ulid().toLowerCase(),
+        id: event.id,
         occurredAt: event.occurredAt,
         organizationId: event.organizationId,
         payloadHash: event.payloadHash ?? null,
@@ -222,6 +353,9 @@ export const runAppendAgentRunEvents = async (
       if (!concurrent) {
         throw new Error("AGENT_RUN_EVENT_INSERT_FAILED");
       }
+      assertStoredEventScope(concurrent, event);
+      existingIds.add(event.id);
+      inserted += 1;
     }
   }
 
@@ -232,6 +366,11 @@ export const runCompleteAgentRun = async (
   db: AgentRunDb,
   input: CompleteAgentRunInput
 ) => {
+  const run = await db.agentRun.one(input.runId).get();
+  if (!run) {
+    throw new Error("AGENT_RUN_NOT_FOUND");
+  }
+
   const attempt = await db.agentRunAttempt.one(input.attemptId).get();
   if (!attempt || attempt.agentRunId !== input.runId) {
     throw new Error("AGENT_RUN_ATTEMPT_NOT_FOUND");
@@ -245,11 +384,6 @@ export const runCompleteAgentRun = async (
     status: input.status,
     updatedAt: timestamp,
   });
-
-  const run = await db.agentRun.one(input.runId).get();
-  if (!run) {
-    throw new Error("AGENT_RUN_NOT_FOUND");
-  }
 
   await db.agentRun.update(run.id, {
     auditIncomplete: run.auditIncomplete || (input.auditIncomplete ?? false),
@@ -282,6 +416,7 @@ export const runLatestAgentRunForThread = async (
       threadId: input.threadId,
     })
     .orderBy("startedAt", "desc")
+    .orderBy("id", "desc")
     .limit(1)
     .get();
   const run = runs[0];

--- a/apps/api/src/lib/agent-run-audit.ts
+++ b/apps/api/src/lib/agent-run-audit.ts
@@ -1,0 +1,311 @@
+import type { ServerDB } from "@live-state/sync/server";
+import { ulid } from "ulid";
+import { z } from "zod";
+
+import { schema } from "../live-state/schema";
+
+const jsonStringSchema = z.string().refine(
+  (value) => {
+    try {
+      JSON.parse(value);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  { message: "value must be valid JSON" }
+);
+
+export const startAgentRunInputSchema = z
+  .object({
+    attemptId: z.string().min(1),
+    attemptNumber: z.number().int().min(1),
+    bullmqJobId: z.string().nullable().optional(),
+    createdAt: z.coerce.date().optional(),
+    metadataStr: jsonStringSchema.nullable().optional(),
+    organizationId: z.string().min(1),
+    pipelineJobId: z.string().nullable().optional(),
+    queueJobId: z.string().nullable().optional(),
+    queueName: z.string().nullable().optional(),
+    runId: z.string().min(1),
+    startedAt: z.coerce.date(),
+    threadId: z.string().min(1),
+  })
+  .strict();
+
+export const appendAgentRunEventsInputSchema = z
+  .object({
+    events: z
+      .array(
+        z
+          .object({
+            agentRunId: z.string().min(1),
+            attemptId: z.string().min(1),
+            causationEventId: z.string().nullable().optional(),
+            emittedAt: z.coerce.date(),
+            id: z.string().min(1),
+            occurredAt: z.coerce.date(),
+            organizationId: z.string().min(1),
+            payloadHash: z.string().nullable().optional(),
+            payloadStr: jsonStringSchema.nullable().optional(),
+            phase: z.string().nullable().optional(),
+            processor: z.string().nullable().optional(),
+            sequence: z.number().int().min(0),
+            stepIndex: z.number().int().min(0).nullable().optional(),
+            threadId: z.string().min(1),
+            toolCallId: z.string().nullable().optional(),
+            type: z.string().min(1),
+          })
+          .strict()
+      )
+      .max(500),
+  })
+  .strict();
+
+export const completeAgentRunInputSchema = z
+  .object({
+    attemptId: z.string().min(1),
+    completedAt: z.coerce.date(),
+    metadataStr: jsonStringSchema.nullable().optional(),
+    runId: z.string().min(1),
+    status: z.enum(["completed", "failed", "abandoned"]),
+    auditIncomplete: z.boolean().optional(),
+  })
+  .strict();
+
+export const latestAgentRunInputSchema = z
+  .object({
+    organizationId: z.string().min(1),
+    threadId: z.string().min(1),
+  })
+  .strict();
+
+type AgentRunDb = Pick<
+  ServerDB<typeof schema>,
+  | "agentRun"
+  | "agentRunAttempt"
+  | "agentRunEvent"
+  | "find"
+  | "insert"
+  | "update"
+>;
+
+type StartAgentRunInput = z.infer<typeof startAgentRunInputSchema>;
+type AppendAgentRunEventsInput = z.infer<
+  typeof appendAgentRunEventsInputSchema
+>;
+type CompleteAgentRunInput = z.infer<typeof completeAgentRunInputSchema>;
+type LatestAgentRunInput = z.infer<typeof latestAgentRunInputSchema>;
+
+const now = () => new Date();
+
+export const runStartAgentRun = async (
+  db: AgentRunDb,
+  input: StartAgentRunInput
+) => {
+  const timestamp = input.createdAt ?? now();
+  const run = await db.agentRun.one(input.runId).get();
+
+  if (run) {
+    await db.agentRun.update(run.id, {
+      auditIncomplete: run.auditIncomplete,
+      completedAt: null,
+      metadataStr: input.metadataStr ?? run.metadataStr,
+      pipelineJobId: input.pipelineJobId ?? run.pipelineJobId,
+      queueJobId: input.queueJobId ?? run.queueJobId,
+      queueName: input.queueName ?? run.queueName,
+      startedAt: input.startedAt,
+      status: "running",
+      updatedAt: timestamp,
+    });
+  } else {
+    await db.insert(schema.agentRun, {
+      auditIncomplete: false,
+      completedAt: null,
+      createdAt: timestamp,
+      id: input.runId,
+      metadataStr: input.metadataStr ?? null,
+      organizationId: input.organizationId,
+      pipelineJobId: input.pipelineJobId ?? null,
+      queueJobId: input.queueJobId ?? null,
+      queueName: input.queueName ?? null,
+      startedAt: input.startedAt,
+      status: "running",
+      threadId: input.threadId,
+      updatedAt: timestamp,
+    });
+  }
+
+  const attempt = await db.agentRunAttempt.one(input.attemptId).get();
+  if (attempt) {
+    await db.agentRunAttempt.update(attempt.id, {
+      auditIncomplete: attempt.auditIncomplete,
+      bullmqJobId: input.bullmqJobId ?? attempt.bullmqJobId,
+      completedAt: null,
+      metadataStr: input.metadataStr ?? attempt.metadataStr,
+      pipelineJobId: input.pipelineJobId ?? attempt.pipelineJobId,
+      queueName: input.queueName ?? attempt.queueName,
+      startedAt: input.startedAt,
+      status: "running",
+      updatedAt: timestamp,
+    });
+  } else {
+    await db.insert(schema.agentRunAttempt, {
+      agentRunId: input.runId,
+      auditIncomplete: false,
+      attemptNumber: input.attemptNumber,
+      bullmqJobId: input.bullmqJobId ?? null,
+      completedAt: null,
+      createdAt: timestamp,
+      id: input.attemptId,
+      metadataStr: input.metadataStr ?? null,
+      organizationId: input.organizationId,
+      pipelineJobId: input.pipelineJobId ?? null,
+      queueName: input.queueName ?? null,
+      startedAt: input.startedAt,
+      status: "running",
+      threadId: input.threadId,
+      updatedAt: timestamp,
+    });
+  }
+
+  return { attemptId: input.attemptId, runId: input.runId };
+};
+
+export const runAppendAgentRunEvents = async (
+  db: AgentRunDb,
+  input: AppendAgentRunEventsInput
+) => {
+  if (input.events.length === 0) {
+    return { inserted: 0 };
+  }
+
+  const eventIds = [...new Set(input.events.map((event) => event.id))];
+  const existing = Object.values(
+    await db.find(schema.agentRunEvent, {
+      where: { id: { $in: eventIds } },
+    })
+  );
+  const existingIds = new Set(existing.map((event) => event.id));
+  let inserted = 0;
+
+  for (const event of input.events) {
+    if (existingIds.has(event.id)) {
+      continue;
+    }
+
+    try {
+      await db.insert(schema.agentRunEvent, {
+        agentRunId: event.agentRunId,
+        attemptId: event.attemptId,
+        causationEventId: event.causationEventId ?? null,
+        emittedAt: event.emittedAt,
+        id: event.id || ulid().toLowerCase(),
+        occurredAt: event.occurredAt,
+        organizationId: event.organizationId,
+        payloadHash: event.payloadHash ?? null,
+        payloadStr: event.payloadStr ?? null,
+        phase: event.phase ?? null,
+        processor: event.processor ?? null,
+        sequence: event.sequence,
+        stepIndex: event.stepIndex ?? null,
+        threadId: event.threadId,
+        toolCallId: event.toolCallId ?? null,
+        type: event.type,
+      });
+      existingIds.add(event.id);
+      inserted += 1;
+    } catch {
+      // A concurrent flush may have inserted the same immutable event. Verify
+      // that case rather than making a harmless duplicate race fail the run.
+      const concurrent = await db.agentRunEvent.one(event.id).get();
+      if (!concurrent) {
+        throw new Error("AGENT_RUN_EVENT_INSERT_FAILED");
+      }
+    }
+  }
+
+  return { inserted };
+};
+
+export const runCompleteAgentRun = async (
+  db: AgentRunDb,
+  input: CompleteAgentRunInput
+) => {
+  const attempt = await db.agentRunAttempt.one(input.attemptId).get();
+  if (!attempt || attempt.agentRunId !== input.runId) {
+    throw new Error("AGENT_RUN_ATTEMPT_NOT_FOUND");
+  }
+
+  const timestamp = now();
+  await db.agentRunAttempt.update(attempt.id, {
+    auditIncomplete: input.auditIncomplete ?? attempt.auditIncomplete,
+    completedAt: input.completedAt,
+    metadataStr: input.metadataStr ?? attempt.metadataStr,
+    status: input.status,
+    updatedAt: timestamp,
+  });
+
+  const run = await db.agentRun.one(input.runId).get();
+  if (!run) {
+    throw new Error("AGENT_RUN_NOT_FOUND");
+  }
+
+  await db.agentRun.update(run.id, {
+    auditIncomplete: run.auditIncomplete || (input.auditIncomplete ?? false),
+    completedAt: input.completedAt,
+    metadataStr: input.metadataStr ?? run.metadataStr,
+    status: input.status,
+    updatedAt: timestamp,
+  });
+
+  return { attemptId: input.attemptId, runId: input.runId };
+};
+
+const sortByTimeAndSequence = <
+  T extends { occurredAt: Date; sequence: number },
+>(
+  rows: T[]
+): T[] =>
+  rows.toSorted((a, b) => {
+    const time = a.occurredAt.getTime() - b.occurredAt.getTime();
+    return time !== 0 ? time : a.sequence - b.sequence;
+  });
+
+export const runLatestAgentRunForThread = async (
+  db: AgentRunDb,
+  input: LatestAgentRunInput
+) => {
+  const runs = await db.agentRun
+    .where({
+      organizationId: input.organizationId,
+      threadId: input.threadId,
+    })
+    .orderBy("startedAt", "desc")
+    .limit(1)
+    .get();
+  const run = runs[0];
+  if (!run) {
+    return null;
+  }
+
+  const attempts = await db.agentRunAttempt
+    .where({
+      agentRunId: run.id,
+      organizationId: input.organizationId,
+      threadId: input.threadId,
+    })
+    .orderBy("attemptNumber", "asc")
+    .get();
+  const events = sortByTimeAndSequence(
+    await db.agentRunEvent
+      .where({
+        agentRunId: run.id,
+        organizationId: input.organizationId,
+        threadId: input.threadId,
+      })
+      .get()
+  );
+
+  return { attempts, events, run };
+};

--- a/apps/api/src/lib/agent-run-audit.ts
+++ b/apps/api/src/lib/agent-run-audit.ts
@@ -24,7 +24,6 @@ export const startAgentRunInputSchema = z
     metadataStr: jsonStringSchema.nullable().optional(),
     organizationId: z.string().min(1),
     pipelineJobId: z.string().nullable().optional(),
-    queueJobId: z.string().nullable().optional(),
     queueName: z.string().nullable().optional(),
     runId: z.string().min(1),
     startedAt: z.coerce.date(),
@@ -95,8 +94,6 @@ type AppendAgentRunEventsInput = z.infer<
 >;
 type CompleteAgentRunInput = z.infer<typeof completeAgentRunInputSchema>;
 type LatestAgentRunInput = z.infer<typeof latestAgentRunInputSchema>;
-
-const now = () => new Date();
 
 const assertRunScope = (
   run: { organizationId: string; threadId: string },
@@ -185,13 +182,16 @@ const assertEventScope = (
   }
 };
 
+/** The tenant and run an event row belongs to — all a duplicate must match. */
+interface EventScope {
+  agentRunId: string;
+  attemptId: string;
+  organizationId: string;
+  threadId: string;
+}
+
 const assertStoredEventScope = (
-  stored: {
-    agentRunId: string;
-    attemptId: string;
-    organizationId: string;
-    threadId: string;
-  },
+  stored: EventScope,
   event: AppendAgentRunEventsInput["events"][number]
 ): void => {
   if (
@@ -208,164 +208,144 @@ export const runStartAgentRun = async (
   db: AgentRunDb,
   input: StartAgentRunInput
 ) => {
-  const timestamp = input.createdAt ?? now();
-  const run = await db.agentRun.one(input.runId).get();
+  const timestamp = input.createdAt ?? new Date();
+  const shared = {
+    completedAt: null,
+    startedAt: input.startedAt,
+    status: "running",
+    updatedAt: timestamp,
+  };
+  const attemptScope = {
+    agentRunId: input.runId,
+    organizationId: input.organizationId,
+    threadId: input.threadId,
+  };
 
-  if (run) {
-    assertRunScope(run, input);
-    const values = {
-      auditIncomplete: run.auditIncomplete,
-      completedAt: null,
-      metadataStr: input.metadataStr ?? run.metadataStr,
-      pipelineJobId: input.pipelineJobId ?? run.pipelineJobId,
-      queueJobId: input.queueJobId ?? run.queueJobId,
-      queueName: input.queueName ?? run.queueName,
-      startedAt: input.startedAt,
-      status: "running",
-      updatedAt: timestamp,
-    };
-    await db.agentRun.update(run.id, values);
-  } else {
-    try {
-      await db.insert(schema.agentRun, {
+  await upsertStartedRow({
+    assertScope: (row) => assertRunScope(row, input),
+    insert: () =>
+      db.insert(schema.agentRun, {
+        ...shared,
         auditIncomplete: false,
-        completedAt: null,
+        bullmqJobId: input.bullmqJobId ?? null,
         createdAt: timestamp,
         id: input.runId,
         metadataStr: input.metadataStr ?? null,
         organizationId: input.organizationId,
         pipelineJobId: input.pipelineJobId ?? null,
-        queueJobId: input.queueJobId ?? null,
         queueName: input.queueName ?? null,
-        startedAt: input.startedAt,
-        status: "running",
         threadId: input.threadId,
-        updatedAt: timestamp,
-      });
-    } catch (error) {
-      if (!isUniqueViolation(error)) {
-        throw error;
-      }
-      const concurrent = await db.agentRun.one(input.runId).get();
-      if (!concurrent) {
-        throw new Error("AGENT_RUN_INSERT_FAILED", { cause: error });
-      }
-      assertRunScope(concurrent, input);
-      await db.agentRun.update(concurrent.id, {
-        auditIncomplete: concurrent.auditIncomplete,
-        completedAt: null,
-        metadataStr: input.metadataStr ?? concurrent.metadataStr,
-        pipelineJobId: input.pipelineJobId ?? concurrent.pipelineJobId,
-        queueJobId: input.queueJobId ?? concurrent.queueJobId,
-        queueName: input.queueName ?? concurrent.queueName,
-        startedAt: input.startedAt,
-        status: "running",
-        updatedAt: timestamp,
-      });
-    }
-  }
+      }),
+    insertFailedError: "AGENT_RUN_INSERT_FAILED",
+    read: () => db.agentRun.one(input.runId).get(),
+    update: (row) =>
+      db.agentRun.update(row.id, {
+        ...shared,
+        bullmqJobId: input.bullmqJobId ?? row.bullmqJobId,
+        metadataStr: input.metadataStr ?? row.metadataStr,
+        pipelineJobId: input.pipelineJobId ?? row.pipelineJobId,
+        queueName: input.queueName ?? row.queueName,
+      }),
+  });
 
-  const attempt = await db.agentRunAttempt.one(input.attemptId).get();
-  if (attempt) {
-    assertAttemptScope(attempt, {
-      agentRunId: input.runId,
-      organizationId: input.organizationId,
-      threadId: input.threadId,
-    });
-    const values = {
-      auditIncomplete: attempt.auditIncomplete,
-      bullmqJobId: input.bullmqJobId ?? attempt.bullmqJobId,
-      completedAt: null,
-      metadataStr: input.metadataStr ?? attempt.metadataStr,
-      pipelineJobId: input.pipelineJobId ?? attempt.pipelineJobId,
-      queueName: input.queueName ?? attempt.queueName,
-      startedAt: input.startedAt,
-      status: "running",
-      updatedAt: timestamp,
-    };
-    await db.agentRunAttempt.update(attempt.id, values);
-  } else {
-    try {
-      await db.insert(schema.agentRunAttempt, {
-        agentRunId: input.runId,
-        auditIncomplete: false,
+  await upsertStartedRow({
+    assertScope: (row) => assertAttemptScope(row, attemptScope),
+    insert: () =>
+      db.insert(schema.agentRunAttempt, {
+        ...shared,
+        ...attemptScope,
         attemptNumber: input.attemptNumber,
+        auditIncomplete: false,
         bullmqJobId: input.bullmqJobId ?? null,
-        completedAt: null,
         createdAt: timestamp,
         id: input.attemptId,
         metadataStr: input.metadataStr ?? null,
-        organizationId: input.organizationId,
         pipelineJobId: input.pipelineJobId ?? null,
         queueName: input.queueName ?? null,
-        startedAt: input.startedAt,
-        status: "running",
-        threadId: input.threadId,
-        updatedAt: timestamp,
-      });
-    } catch (error) {
-      if (!isUniqueViolation(error)) {
-        throw error;
-      }
-      const concurrent = await db.agentRunAttempt.one(input.attemptId).get();
-      if (!concurrent) {
-        throw new Error("AGENT_RUN_ATTEMPT_INSERT_FAILED", { cause: error });
-      }
-      assertAttemptScope(concurrent, {
-        agentRunId: input.runId,
-        organizationId: input.organizationId,
-        threadId: input.threadId,
-      });
-      await db.agentRunAttempt.update(concurrent.id, {
-        auditIncomplete: concurrent.auditIncomplete,
-        bullmqJobId: input.bullmqJobId ?? concurrent.bullmqJobId,
-        completedAt: null,
-        metadataStr: input.metadataStr ?? concurrent.metadataStr,
-        pipelineJobId: input.pipelineJobId ?? concurrent.pipelineJobId,
-        queueName: input.queueName ?? concurrent.queueName,
-        startedAt: input.startedAt,
-        status: "running",
-        updatedAt: timestamp,
-      });
-    }
-  }
+      }),
+    insertFailedError: "AGENT_RUN_ATTEMPT_INSERT_FAILED",
+    read: () => db.agentRunAttempt.one(input.attemptId).get(),
+    update: (row) =>
+      db.agentRunAttempt.update(row.id, {
+        ...shared,
+        bullmqJobId: input.bullmqJobId ?? row.bullmqJobId,
+        metadataStr: input.metadataStr ?? row.metadataStr,
+        pipelineJobId: input.pipelineJobId ?? row.pipelineJobId,
+        queueName: input.queueName ?? row.queueName,
+      }),
+  });
 
   return { attemptId: input.attemptId, runId: input.runId };
+};
+
+/**
+ * Insert the row, or reset the one already there back to "running" — restarting
+ * a run or attempt is idempotent. The unique-violation retry covers a
+ * concurrent start inserting the same id between the read and the insert.
+ */
+const upsertStartedRow = async <T extends { id: string }>({
+  assertScope,
+  insert,
+  insertFailedError,
+  read,
+  update,
+}: {
+  assertScope: (row: T) => void;
+  insert: () => Promise<unknown>;
+  insertFailedError: string;
+  read: () => Promise<T | null | undefined>;
+  update: (row: T) => Promise<unknown>;
+}): Promise<void> => {
+  const existing = await read();
+  if (existing) {
+    assertScope(existing);
+    await update(existing);
+    return;
+  }
+
+  try {
+    await insert();
+  } catch (error) {
+    if (!isUniqueViolation(error)) {
+      throw error;
+    }
+    const concurrent = await read();
+    if (!concurrent) {
+      throw new Error(insertFailedError, { cause: error });
+    }
+    assertScope(concurrent);
+    await update(concurrent);
+  }
 };
 
 export const runAppendAgentRunEvents = async (
   db: AgentRunDb,
   input: AppendAgentRunEventsInput
 ) => {
-  if (input.events.length === 0) {
-    return { inserted: 0 };
-  }
-
-  const eventIds = [...new Set(input.events.map((event) => event.id))];
   const firstEvent = input.events[0];
   if (!firstEvent) {
     return { inserted: 0 };
   }
+
   const [run, attempt] = await Promise.all([
     db.agentRun.one(firstEvent.agentRunId).get(),
     db.agentRunAttempt.one(firstEvent.attemptId).get(),
   ]);
-  const existing = Object.values(
-    await db.find(schema.agentRunEvent, {
-      where: { id: { $in: eventIds } },
-    })
+  const stored = new Map<string, EventScope>(
+    Object.values(
+      await db.find(schema.agentRunEvent, {
+        where: { id: { $in: [...new Set(input.events.map((e) => e.id))] } },
+      })
+    ).map((event) => [event.id, event])
   );
-  const existingIds = new Set(existing.map((event) => event.id));
   let inserted = 0;
 
   for (const event of input.events) {
     assertEventScope(run, attempt, event);
 
-    if (existingIds.has(event.id)) {
-      const stored = await db.agentRunEvent.one(event.id).get();
-      if (stored) {
-        assertStoredEventScope(stored, event);
-      }
+    const already = stored.get(event.id);
+    if (already) {
+      assertStoredEventScope(already, event);
       continue;
     }
 
@@ -388,7 +368,7 @@ export const runAppendAgentRunEvents = async (
         toolCallId: event.toolCallId ?? null,
         type: event.type,
       });
-      existingIds.add(event.id);
+      stored.set(event.id, event);
       inserted += 1;
     } catch (error) {
       if (!isUniqueViolation(error)) {
@@ -401,7 +381,7 @@ export const runAppendAgentRunEvents = async (
         throw new Error("AGENT_RUN_EVENT_INSERT_FAILED", { cause: error });
       }
       assertStoredEventScope(concurrent, event);
-      existingIds.add(event.id);
+      stored.set(event.id, concurrent);
       inserted += 1;
     }
   }
@@ -423,7 +403,7 @@ export const runCompleteAgentRun = async (
     throw new Error("AGENT_RUN_ATTEMPT_NOT_FOUND");
   }
 
-  const timestamp = now();
+  const timestamp = new Date();
   await db.agentRunAttempt.update(attempt.id, {
     auditIncomplete: input.auditIncomplete ?? attempt.auditIncomplete,
     completedAt: input.completedAt,

--- a/apps/api/src/lib/agent-run-audit.ts
+++ b/apps/api/src/lib/agent-run-audit.ts
@@ -131,22 +131,52 @@ const assertAttemptScope = (
   }
 };
 
-const assertEventScope = async (
-  db: AgentRunDb,
+const isUniqueViolation = (error: unknown): boolean => {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  const candidate = error as { cause?: unknown; code?: unknown };
+  return (
+    candidate.code === "23505" ||
+    (candidate.cause !== undefined &&
+      candidate.cause !== error &&
+      isUniqueViolation(candidate.cause))
+  );
+};
+
+const assertEventScope = (
+  run:
+    | {
+        id: string;
+        organizationId: string;
+        threadId: string;
+      }
+    | null
+    | undefined,
+  attempt:
+    | {
+        agentRunId: string;
+        id: string;
+        organizationId: string;
+        threadId: string;
+      }
+    | null
+    | undefined,
   event: AppendAgentRunEventsInput["events"][number]
-): Promise<void> => {
-  const run = await db.agentRun.one(event.agentRunId).get();
+): void => {
   if (
     !run ||
+    run.id !== event.agentRunId ||
     run.organizationId !== event.organizationId ||
     run.threadId !== event.threadId
   ) {
     throw new Error("AGENT_RUN_EVENT_SCOPE_MISMATCH");
   }
 
-  const attempt = await db.agentRunAttempt.one(event.attemptId).get();
   if (
     !attempt ||
+    attempt.id !== event.attemptId ||
     attempt.agentRunId !== event.agentRunId ||
     attempt.organizationId !== event.organizationId ||
     attempt.threadId !== event.threadId
@@ -212,10 +242,13 @@ export const runStartAgentRun = async (
         threadId: input.threadId,
         updatedAt: timestamp,
       });
-    } catch {
+    } catch (error) {
+      if (!isUniqueViolation(error)) {
+        throw error;
+      }
       const concurrent = await db.agentRun.one(input.runId).get();
       if (!concurrent) {
-        throw new Error("AGENT_RUN_INSERT_FAILED");
+        throw new Error("AGENT_RUN_INSERT_FAILED", { cause: error });
       }
       assertRunScope(concurrent, input);
       await db.agentRun.update(concurrent.id, {
@@ -270,10 +303,13 @@ export const runStartAgentRun = async (
         threadId: input.threadId,
         updatedAt: timestamp,
       });
-    } catch {
+    } catch (error) {
+      if (!isUniqueViolation(error)) {
+        throw error;
+      }
       const concurrent = await db.agentRunAttempt.one(input.attemptId).get();
       if (!concurrent) {
-        throw new Error("AGENT_RUN_ATTEMPT_INSERT_FAILED");
+        throw new Error("AGENT_RUN_ATTEMPT_INSERT_FAILED", { cause: error });
       }
       assertAttemptScope(concurrent, {
         agentRunId: input.runId,
@@ -306,6 +342,14 @@ export const runAppendAgentRunEvents = async (
   }
 
   const eventIds = [...new Set(input.events.map((event) => event.id))];
+  const firstEvent = input.events[0];
+  if (!firstEvent) {
+    return { inserted: 0 };
+  }
+  const [run, attempt] = await Promise.all([
+    db.agentRun.one(firstEvent.agentRunId).get(),
+    db.agentRunAttempt.one(firstEvent.attemptId).get(),
+  ]);
   const existing = Object.values(
     await db.find(schema.agentRunEvent, {
       where: { id: { $in: eventIds } },
@@ -315,7 +359,7 @@ export const runAppendAgentRunEvents = async (
   let inserted = 0;
 
   for (const event of input.events) {
-    await assertEventScope(db, event);
+    assertEventScope(run, attempt, event);
 
     if (existingIds.has(event.id)) {
       const stored = await db.agentRunEvent.one(event.id).get();
@@ -346,12 +390,15 @@ export const runAppendAgentRunEvents = async (
       });
       existingIds.add(event.id);
       inserted += 1;
-    } catch {
+    } catch (error) {
+      if (!isUniqueViolation(error)) {
+        throw error;
+      }
       // A concurrent flush may have inserted the same immutable event. Verify
       // that case rather than making a harmless duplicate race fail the run.
       const concurrent = await db.agentRunEvent.one(event.id).get();
       if (!concurrent) {
-        throw new Error("AGENT_RUN_EVENT_INSERT_FAILED");
+        throw new Error("AGENT_RUN_EVENT_INSERT_FAILED", { cause: error });
       }
       assertStoredEventScope(concurrent, event);
       existingIds.add(event.id);

--- a/apps/api/src/live-state/router.ts
+++ b/apps/api/src/live-state/router.ts
@@ -49,6 +49,7 @@ import { notifyWaitlistSignup } from "../lib/waitlist-discord";
 import { sendWelcomeEmail } from "../trigger/send-welcome-email";
 import { privateRoute, publicRoute } from "./factories";
 import { agentChatRoute } from "./router/agent-chat";
+import { agentRunRoutes } from "./router/agent-run";
 import autonomousActionRoute from "./router/autonomous-action";
 import developerActionRoute from "./router/developer-action";
 import documentationSourcesRoute from "./router/documentation-sources";
@@ -1202,6 +1203,7 @@ export const router = createRouter({
     onboarding: onboardingRoute,
     documentationSource: documentationSourcesRoute,
     agentChat: agentChatRoute,
+    ...agentRunRoutes,
     ...labelsRoute,
     ...pipelineRoutes,
   },

--- a/apps/api/src/live-state/router/agent-run.ts
+++ b/apps/api/src/live-state/router/agent-run.ts
@@ -1,0 +1,44 @@
+import {
+  appendAgentRunEventsInputSchema,
+  completeAgentRunInputSchema,
+  latestAgentRunInputSchema,
+  runAppendAgentRunEvents,
+  runCompleteAgentRun,
+  runLatestAgentRunForThread,
+  runStartAgentRun,
+  startAgentRunInputSchema,
+} from "../../lib/agent-run-audit";
+import {
+  authorizeDeveloperAction,
+  requireInternalApiKey,
+} from "../../lib/authorize";
+import { publicRoute } from "../factories";
+
+export const agentRunRoutes = {
+  agentRun: publicRoute.withProcedures(({ mutation, query }) => ({
+    appendEvents: mutation(appendAgentRunEventsInputSchema).handler(
+      async ({ db, req }) => {
+        requireInternalApiKey(req.context);
+        return runAppendAgentRunEvents(db, req.input);
+      }
+    ),
+    complete: mutation(completeAgentRunInputSchema).handler(
+      async ({ db, req }) => {
+        requireInternalApiKey(req.context);
+        return runCompleteAgentRun(db, req.input);
+      }
+    ),
+    latestForThread: query(latestAgentRunInputSchema).handler(
+      async ({ db, req }) => {
+        authorizeDeveloperAction(req, req.input.organizationId, {
+          action: "agent_run.read",
+        });
+        return runLatestAgentRunForThread(db, req.input);
+      }
+    ),
+    start: mutation(startAgentRunInputSchema).handler(async ({ db, req }) => {
+      requireInternalApiKey(req.context);
+      return runStartAgentRun(db, req.input);
+    }),
+  })),
+};

--- a/apps/api/src/live-state/schema.ts
+++ b/apps/api/src/live-state/schema.ts
@@ -397,6 +397,88 @@ const pipelineJob = object("pipelineJob", {
   updatedAt: timestamp(),
 });
 
+/**
+ * Server-only forensic records for background Agent pipeline executions. These
+ * rows are deliberately not part of the client-synced surface; the developer
+ * tool reads them through the scoped `agentRun.latestForThread` procedure.
+ */
+const agentRun = object("agentRun", {
+  auditIncomplete: boolean().default(false),
+  completedAt: timestamp().nullable(),
+  createdAt: timestamp().index(),
+  id: id(),
+  metadataStr: string().nullable(),
+  organizationId: reference("organization.id").index(),
+  pipelineJobId: string().nullable().index(),
+  queueJobId: string().nullable().index(),
+  queueName: string().nullable(),
+  startedAt: timestamp().index(),
+  status: string().index(),
+  threadId: reference("thread.id").index(),
+  updatedAt: timestamp().index(),
+});
+
+const agentRunAttempt = object("agentRunAttempt", {
+  agentRunId: reference("agentRun.id").index(),
+  auditIncomplete: boolean().default(false),
+  attemptNumber: number().index(),
+  bullmqJobId: string().nullable().index(),
+  completedAt: timestamp().nullable(),
+  createdAt: timestamp().index(),
+  id: id(),
+  metadataStr: string().nullable(),
+  organizationId: reference("organization.id").index(),
+  pipelineJobId: string().nullable().index(),
+  queueName: string().nullable(),
+  startedAt: timestamp().index(),
+  status: string().index(),
+  threadId: reference("thread.id").index(),
+  updatedAt: timestamp().index(),
+});
+
+const agentRunEvent = object("agentRunEvent", {
+  agentRunId: reference("agentRun.id").index(),
+  attemptId: reference("agentRunAttempt.id").index(),
+  causationEventId: string().nullable(),
+  emittedAt: timestamp().index(),
+  id: id(),
+  occurredAt: timestamp().index(),
+  organizationId: reference("organization.id").index(),
+  payloadHash: string().nullable(),
+  payloadStr: string().nullable(),
+  phase: string().nullable(),
+  processor: string().nullable(),
+  sequence: number().index(),
+  stepIndex: number().nullable(),
+  threadId: reference("thread.id").index(),
+  toolCallId: string().nullable(),
+  type: string().index(),
+});
+
+const agentRunRelations = createRelations(agentRun, ({ one, many }) => ({
+  attempts: many(agentRunAttempt, "agentRunId"),
+  events: many(agentRunEvent, "agentRunId"),
+  organization: one(organization, "organizationId"),
+  thread: one(thread, "threadId"),
+}));
+
+const agentRunAttemptRelations = createRelations(
+  agentRunAttempt,
+  ({ one, many }) => ({
+    events: many(agentRunEvent, "attemptId"),
+    organization: one(organization, "organizationId"),
+    run: one(agentRun, "agentRunId"),
+    thread: one(thread, "threadId"),
+  })
+);
+
+const agentRunEventRelations = createRelations(agentRunEvent, ({ one }) => ({
+  attempt: one(agentRunAttempt, "attemptId"),
+  organization: one(organization, "organizationId"),
+  run: one(agentRun, "agentRunId"),
+  thread: one(thread, "threadId"),
+}));
+
 const migration = object("migration", {
   appliedAt: timestamp(),
   id: id(),
@@ -432,6 +514,9 @@ export const schema = createSchema({
   label,
   threadLabel,
   autonomousAction,
+  agentRun,
+  agentRunAttempt,
+  agentRunEvent,
   pipelineIdempotencyKey,
   pipelineJob,
   onboarding,
@@ -459,4 +544,7 @@ export const schema = createSchema({
   agentChatRelations,
   agentChatMessageRelations,
   externalEntityRelations,
+  agentRunRelations,
+  agentRunAttemptRelations,
+  agentRunEventRelations,
 });

--- a/apps/api/src/live-state/schema.ts
+++ b/apps/api/src/live-state/schema.ts
@@ -410,7 +410,7 @@ const agentRun = object("agentRun", {
   metadataStr: string().nullable(),
   organizationId: reference("organization.id").index(),
   pipelineJobId: string().nullable().index(),
-  queueJobId: string().nullable().index(),
+  bullmqJobId: string().nullable().index(),
   queueName: string().nullable(),
   startedAt: timestamp().index(),
   status: string().index(),

--- a/apps/web/src/components/devtools/developer-commands.tsx
+++ b/apps/web/src/components/devtools/developer-commands.tsx
@@ -6,6 +6,7 @@ import { githubIntegrationSchema } from "@workspace/schemas/integration/github";
 import {
   Archive,
   Bug,
+  Clipboard,
   EyeOff,
   Flag,
   GitPullRequest,
@@ -30,6 +31,7 @@ import { reflagClient } from "~/lib/feature-flag";
 import { fetchClient, query } from "~/lib/live-state";
 import { buildThreadParam } from "~/utils/thread";
 
+import { copyLatestAgentRunDataFromParam } from "./devtools-menu/copy-latest-agent-run-command";
 import { CreateThreadDialog } from "./devtools-menu/create-thread-dialog";
 import { duplicateThreadFromParam } from "./devtools-menu/duplicate-thread-command";
 import type { DuplicatedThread } from "./devtools-menu/duplicate-thread-command";
@@ -227,6 +229,13 @@ export const DeveloperToolsCommands = ({
     });
   }, [organizationId, rawThreadParam]);
 
+  const handleCopyLatestAgentRunData = useCallback(() => {
+    void copyLatestAgentRunDataFromParam({
+      activeOrganizationId: organizationId,
+      rawParam: rawThreadParam,
+    });
+  }, [organizationId, rawThreadParam]);
+
   const threadsPage: CommandPage = {
     commands: [
       {
@@ -248,6 +257,13 @@ export const DeveloperToolsCommands = ({
         id: "developer-tools.retrigger-thread-read",
         label: "Retrigger current thread read",
         onSelect: handleRetriggerThreadRead,
+      },
+      {
+        disabled: !rawThreadParam,
+        icon: <Clipboard />,
+        id: "developer-tools.copy-latest-agent-run",
+        label: "Copy latest agent run data",
+        onSelect: handleCopyLatestAgentRunData,
       },
     ],
     icon: <Terminal />,
@@ -538,7 +554,12 @@ export const DeveloperToolsCommands = ({
 
   useCommandPage(
     () => threadsPage,
-    [handleDuplicateThread, handleRetriggerThreadRead, rawThreadParam]
+    [
+      handleCopyLatestAgentRunData,
+      handleDuplicateThread,
+      handleRetriggerThreadRead,
+      rawThreadParam,
+    ]
   );
   useCommandPage(
     () => githubPrPage,

--- a/apps/web/src/components/devtools/devtools-menu/copy-latest-agent-run-command.ts
+++ b/apps/web/src/components/devtools/devtools-menu/copy-latest-agent-run-command.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { toast } from "sonner";
+
+import { fetchClient } from "~/lib/live-state";
+
+import { resolveThreadUlid } from "./thread-route-for-devtools";
+
+const parseStoredJson = (value: string | null): unknown => {
+  if (value === null) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+};
+
+export const copyLatestAgentRunDataFromParam = async ({
+  activeOrganizationId,
+  rawParam,
+}: {
+  activeOrganizationId?: string;
+  rawParam: string | null;
+}): Promise<void> => {
+  if (!rawParam) {
+    toast.error("Open a thread first to copy its latest Agent run");
+    return;
+  }
+
+  if (!activeOrganizationId) {
+    toast.error("No active organization");
+    return;
+  }
+
+  try {
+    const threadId = await resolveThreadUlid(rawParam);
+    if (!threadId) {
+      toast.error("Thread not found");
+      return;
+    }
+
+    const result = await fetchClient.query.agentRun.latestForThread({
+      organizationId: activeOrganizationId,
+      threadId,
+    });
+
+    if (!result) {
+      toast.info("No Agent run record exists for this thread yet");
+      return;
+    }
+
+    const output = {
+      attempts: result.attempts.map(({ metadataStr, ...attempt }) => ({
+        ...attempt,
+        metadata: parseStoredJson(metadataStr),
+      })),
+      events: result.events.map(({ payloadStr, ...event }) => ({
+        ...event,
+        payload: parseStoredJson(payloadStr),
+      })),
+      run: {
+        ...result.run,
+        metadata: parseStoredJson(result.run.metadataStr),
+      },
+    };
+
+    await navigator.clipboard.writeText(JSON.stringify(output, null, 2));
+    toast.success("Latest Agent run data copied");
+  } catch (error) {
+    console.error("Failed to copy latest Agent run data:", error);
+    toast.error("Failed to copy latest Agent run data");
+  }
+};

--- a/apps/web/src/components/devtools/devtools-menu/copy-latest-agent-run-command.ts
+++ b/apps/web/src/components/devtools/devtools-menu/copy-latest-agent-run-command.ts
@@ -52,6 +52,7 @@ export const copyLatestAgentRunDataFromParam = async ({
       return;
     }
 
+    const { metadataStr: runMetadataStr, ...run } = result.run;
     const output = {
       attempts: result.attempts.map(({ metadataStr, ...attempt }) => ({
         ...attempt,
@@ -62,8 +63,8 @@ export const copyLatestAgentRunDataFromParam = async ({
         payload: parseStoredJson(payloadStr),
       })),
       run: {
-        ...result.run,
-        metadata: parseStoredJson(result.run.metadataStr),
+        ...run,
+        metadata: parseStoredJson(runMetadataStr),
       },
     };
 

--- a/apps/worker/src/lib/documentation-embedding.ts
+++ b/apps/worker/src/lib/documentation-embedding.ts
@@ -1,10 +1,9 @@
-import { createHash } from "node:crypto";
-
 import { google } from "@ai-sdk/google";
 import { log } from "@workspace/utils/logging";
 import { embed } from "ai";
 
 import type { AgentRunAudit } from "../pipeline/core/agent-run-audit";
+import { auditEmbedding } from "../pipeline/core/model-audit";
 import { errorFields } from "./logging";
 
 const EMBEDDING_MODEL = "gemini-embedding-001";
@@ -32,23 +31,11 @@ export const generateDocumentationQueryEmbedding = async (
     return null;
   }
 
-  const startedAt = performance.now();
-  const model = {
+  const span = auditEmbedding(audit, {
     modelId: EMBEDDING_MODEL,
-    provider: "google",
-  };
-  const metadata = {
-    input: {
-      chars: query.length,
-      hash: createHash("sha256").update(query).digest("hex"),
-    },
-    kind: "embedding",
-    model,
-    providerOptions: { google: { taskType: "RETRIEVAL_QUERY" } },
-  };
-  audit?.record("model.requested", metadata, {
-    phase: "model",
     processor,
+    taskType: "RETRIEVAL_QUERY",
+    text: query,
   });
 
   try {
@@ -59,33 +46,10 @@ export const generateDocumentationQueryEmbedding = async (
       },
       value: query,
     });
-    audit?.record(
-      "model.completed",
-      {
-        ...metadata,
-        dimensions: embedding.length,
-        durationMs: performance.now() - startedAt,
-        embeddingHash: createHash("sha256")
-          .update(JSON.stringify(embedding))
-          .digest("hex"),
-        normalized: false,
-        status: "completed",
-        usage,
-      },
-      { phase: "model", processor }
-    );
+    span.completed(embedding, usage, { normalized: false });
     return embedding;
   } catch (error) {
-    audit?.record(
-      "model.failed",
-      {
-        ...metadata,
-        durationMs: performance.now() - startedAt,
-        error,
-        status: "failed",
-      },
-      { phase: "model", processor }
-    );
+    span.failed(error);
     log.error({
       action: "worker.documentation_search",
       operation: "query_embedding.generate",

--- a/apps/worker/src/lib/documentation-embedding.ts
+++ b/apps/worker/src/lib/documentation-embedding.ts
@@ -25,7 +25,8 @@ const embeddingModel = google.embedding(EMBEDDING_MODEL);
  */
 export const generateDocumentationQueryEmbedding = async (
   query: string,
-  audit?: AgentRunAudit
+  audit?: AgentRunAudit,
+  processor = "synthesis"
 ): Promise<number[] | null> => {
   if (!query.trim()) {
     return null;
@@ -47,7 +48,7 @@ export const generateDocumentationQueryEmbedding = async (
   };
   audit?.record("model.requested", metadata, {
     phase: "model",
-    processor: "synthesis",
+    processor,
   });
 
   try {
@@ -71,7 +72,7 @@ export const generateDocumentationQueryEmbedding = async (
         status: "completed",
         usage,
       },
-      { phase: "model", processor: "synthesis" }
+      { phase: "model", processor }
     );
     return embedding;
   } catch (error) {
@@ -83,7 +84,7 @@ export const generateDocumentationQueryEmbedding = async (
         error,
         status: "failed",
       },
-      { phase: "model", processor: "synthesis" }
+      { phase: "model", processor }
     );
     log.error({
       action: "worker.documentation_search",

--- a/apps/worker/src/lib/documentation-embedding.ts
+++ b/apps/worker/src/lib/documentation-embedding.ts
@@ -1,7 +1,10 @@
+import { createHash } from "node:crypto";
+
 import { google } from "@ai-sdk/google";
 import { log } from "@workspace/utils/logging";
 import { embed } from "ai";
 
+import type { AgentRunAudit } from "../pipeline/core/agent-run-audit";
 import { errorFields } from "./logging";
 
 const EMBEDDING_MODEL = "gemini-embedding-001";
@@ -21,22 +24,67 @@ const embeddingModel = google.embedding(EMBEDDING_MODEL);
  * ranking (see ADR 0012).
  */
 export const generateDocumentationQueryEmbedding = async (
-  query: string
+  query: string,
+  audit?: AgentRunAudit
 ): Promise<number[] | null> => {
   if (!query.trim()) {
     return null;
   }
 
+  const startedAt = performance.now();
+  const model = {
+    modelId: EMBEDDING_MODEL,
+    provider: "google",
+  };
+  const metadata = {
+    input: {
+      chars: query.length,
+      hash: createHash("sha256").update(query).digest("hex"),
+    },
+    kind: "embedding",
+    model,
+    providerOptions: { google: { taskType: "RETRIEVAL_QUERY" } },
+  };
+  audit?.record("model.requested", metadata, {
+    phase: "model",
+    processor: "synthesis",
+  });
+
   try {
-    const { embedding } = await embed({
+    const { embedding, usage } = await embed({
       model: embeddingModel,
       providerOptions: {
         google: { taskType: "RETRIEVAL_QUERY" },
       },
       value: query,
     });
+    audit?.record(
+      "model.completed",
+      {
+        ...metadata,
+        dimensions: embedding.length,
+        durationMs: performance.now() - startedAt,
+        embeddingHash: createHash("sha256")
+          .update(JSON.stringify(embedding))
+          .digest("hex"),
+        normalized: false,
+        status: "completed",
+        usage,
+      },
+      { phase: "model", processor: "synthesis" }
+    );
     return embedding;
   } catch (error) {
+    audit?.record(
+      "model.failed",
+      {
+        ...metadata,
+        durationMs: performance.now() - startedAt,
+        error,
+        status: "failed",
+      },
+      { phase: "model", processor: "synthesis" }
+    );
     log.error({
       action: "worker.documentation_search",
       operation: "query_embedding.generate",

--- a/apps/worker/src/lib/entity-embedding.ts
+++ b/apps/worker/src/lib/entity-embedding.ts
@@ -1,6 +1,9 @@
+import { createHash } from "node:crypto";
+
 import { google } from "@ai-sdk/google";
 import { embed } from "ai";
 
+import type { AgentRunAudit } from "../pipeline/core/agent-run-audit";
 import type { WorkerLogger } from "./logging";
 
 const EMBEDDING_MODEL = "gemini-embedding-001";
@@ -13,27 +16,93 @@ const embeddingModel = google.embedding(EMBEDDING_MODEL);
  */
 export const generateSimilarityEmbedding = async (
   text: string,
-  requestLog?: WorkerLogger
+  requestLog?: WorkerLogger,
+  audit?: AgentRunAudit
 ): Promise<number[] | null> => {
   if (!text || text.trim().length === 0) {
     return null;
   }
 
-  const { embedding } = await embed({
-    model: embeddingModel,
-    providerOptions: {
-      google: { taskType: "SEMANTIC_SIMILARITY" },
+  const startedAt = performance.now();
+  const model = {
+    modelId: EMBEDDING_MODEL,
+    provider: "google",
+  };
+  const metadata = {
+    input: {
+      chars: text.length,
+      hash: createHash("sha256").update(text).digest("hex"),
     },
-    value: text,
+    kind: "embedding",
+    model,
+    providerOptions: { google: { taskType: "SEMANTIC_SIMILARITY" } },
+  };
+  audit?.record("model.requested", metadata, {
+    phase: "model",
+    processor: "synthesis",
   });
 
-  const norm = Math.hypot(...embedding);
-  if (!Number.isFinite(norm) || norm === 0) {
-    requestLog?.warn("Embedding normalization produced an invalid norm", {
-      embedding: { dimensions: embedding.length, norm },
-      step: "normalize_embedding",
+  try {
+    const { embedding, usage } = await embed({
+      model: embeddingModel,
+      providerOptions: {
+        google: { taskType: "SEMANTIC_SIMILARITY" },
+      },
+      value: text,
     });
-    return embedding;
+
+    const norm = Math.hypot(...embedding);
+    if (!Number.isFinite(norm) || norm === 0) {
+      requestLog?.warn("Embedding normalization produced an invalid norm", {
+        embedding: { dimensions: embedding.length, norm },
+        step: "normalize_embedding",
+      });
+      audit?.record(
+        "model.completed",
+        {
+          ...metadata,
+          dimensions: embedding.length,
+          durationMs: performance.now() - startedAt,
+          embeddingHash: createHash("sha256")
+            .update(JSON.stringify(embedding))
+            .digest("hex"),
+          normalized: false,
+          status: "completed",
+          usage,
+        },
+        { phase: "model", processor: "synthesis" }
+      );
+      return embedding;
+    }
+
+    const normalizedEmbedding = embedding.map((value) => value / norm);
+    audit?.record(
+      "model.completed",
+      {
+        ...metadata,
+        dimensions: normalizedEmbedding.length,
+        durationMs: performance.now() - startedAt,
+        embeddingHash: createHash("sha256")
+          .update(JSON.stringify(normalizedEmbedding))
+          .digest("hex"),
+        normalized: true,
+        status: "completed",
+        usage,
+      },
+      { phase: "model", processor: "synthesis" }
+    );
+    return normalizedEmbedding;
+  } catch (error) {
+    audit?.record(
+      "model.failed",
+      {
+        ...metadata,
+        durationMs: performance.now() - startedAt,
+        error,
+        status: "failed",
+      },
+      { phase: "model", processor: "synthesis" }
+    );
+    throw error;
   }
-  return embedding.map((value) => value / norm);
 };

--- a/apps/worker/src/lib/entity-embedding.ts
+++ b/apps/worker/src/lib/entity-embedding.ts
@@ -1,9 +1,8 @@
-import { createHash } from "node:crypto";
-
 import { google } from "@ai-sdk/google";
 import { embed } from "ai";
 
 import type { AgentRunAudit } from "../pipeline/core/agent-run-audit";
+import { auditEmbedding } from "../pipeline/core/model-audit";
 import type { WorkerLogger } from "./logging";
 
 const EMBEDDING_MODEL = "gemini-embedding-001";
@@ -23,86 +22,39 @@ export const generateSimilarityEmbedding = async (
     return null;
   }
 
-  const startedAt = performance.now();
-  const model = {
+  const span = auditEmbedding(audit, {
     modelId: EMBEDDING_MODEL,
-    provider: "google",
-  };
-  const metadata = {
-    input: {
-      chars: text.length,
-      hash: createHash("sha256").update(text).digest("hex"),
-    },
-    kind: "embedding",
-    model,
-    providerOptions: { google: { taskType: "SEMANTIC_SIMILARITY" } },
-  };
-  audit?.record("model.requested", metadata, {
-    phase: "model",
     processor: "synthesis",
+    taskType: "SEMANTIC_SIMILARITY",
+    text,
   });
 
+  let embedding: number[];
+  let usage: unknown;
   try {
-    const { embedding, usage } = await embed({
+    ({ embedding, usage } = await embed({
       model: embeddingModel,
       providerOptions: {
         google: { taskType: "SEMANTIC_SIMILARITY" },
       },
       value: text,
-    });
-
-    const norm = Math.hypot(...embedding);
-    if (!Number.isFinite(norm) || norm === 0) {
-      requestLog?.warn("Embedding normalization produced an invalid norm", {
-        embedding: { dimensions: embedding.length, norm },
-        step: "normalize_embedding",
-      });
-      audit?.record(
-        "model.completed",
-        {
-          ...metadata,
-          dimensions: embedding.length,
-          durationMs: performance.now() - startedAt,
-          embeddingHash: createHash("sha256")
-            .update(JSON.stringify(embedding))
-            .digest("hex"),
-          normalized: false,
-          status: "completed",
-          usage,
-        },
-        { phase: "model", processor: "synthesis" }
-      );
-      return embedding;
-    }
-
-    const normalizedEmbedding = embedding.map((value) => value / norm);
-    audit?.record(
-      "model.completed",
-      {
-        ...metadata,
-        dimensions: normalizedEmbedding.length,
-        durationMs: performance.now() - startedAt,
-        embeddingHash: createHash("sha256")
-          .update(JSON.stringify(normalizedEmbedding))
-          .digest("hex"),
-        normalized: true,
-        status: "completed",
-        usage,
-      },
-      { phase: "model", processor: "synthesis" }
-    );
-    return normalizedEmbedding;
+    }));
   } catch (error) {
-    audit?.record(
-      "model.failed",
-      {
-        ...metadata,
-        durationMs: performance.now() - startedAt,
-        error,
-        status: "failed",
-      },
-      { phase: "model", processor: "synthesis" }
-    );
+    span.failed(error);
     throw error;
   }
+
+  const norm = Math.hypot(...embedding);
+  if (!Number.isFinite(norm) || norm === 0) {
+    requestLog?.warn("Embedding normalization produced an invalid norm", {
+      embedding: { dimensions: embedding.length, norm },
+      step: "normalize_embedding",
+    });
+    span.completed(embedding, usage, { normalized: false });
+    return embedding;
+  }
+
+  const normalized = embedding.map((value) => value / norm);
+  span.completed(normalized, usage, { normalized: true });
+  return normalized;
 };

--- a/apps/worker/src/pipeline/core/agent-run-audit.test.ts
+++ b/apps/worker/src/pipeline/core/agent-run-audit.test.ts
@@ -44,6 +44,7 @@ const startInput = () => ({
   options: {},
   organizationId: "org-1",
   pipelineJobId: "pipeline-1",
+  queueGeneration: 1,
   queueJobId: "queue-1",
   queueName: "thread-pipeline",
   rawQueuePayload: {
@@ -75,6 +76,12 @@ describe("agent run audit transport", () => {
     };
 
     expect(agentRunIdFor(identity)).toBe(agentRunIdFor(identity));
+    expect(agentRunIdFor({ ...identity, queueGeneration: 1 })).toBe(
+      agentRunIdFor({ ...identity, queueGeneration: 1 })
+    );
+    expect(agentRunIdFor({ ...identity, queueGeneration: 1 })).not.toBe(
+      agentRunIdFor({ ...identity, queueGeneration: 2 })
+    );
     expect(agentRunAttemptIdFor("run-1", 1)).not.toBe(
       agentRunAttemptIdFor("run-1", 2)
     );
@@ -84,21 +91,31 @@ describe("agent run audit transport", () => {
     const audit = await createAgentRunAudit(startInput());
     const circular: Record<string, unknown> = {};
     circular.self = circular;
+    const shared = { kind: "reply", value: "same object twice" };
 
-    audit.record("context.captured", { circular, count: 3n });
+    audit.record("context.captured", {
+      circular,
+      count: 3n,
+      first: shared,
+      second: shared,
+    });
+    audit.record("hint.computed", { status: "complete" });
     await audit.flush();
 
     const firstBatch = auditMocks.appendEvents.mock.calls[0]?.[0];
-    if (!firstBatch?.events[0]) {
+    if (!firstBatch?.events[0] || !firstBatch.events[1]) {
       throw new Error("Expected an audit event batch");
     }
-    const event = firstBatch.events[0];
-    expect(event.sequence).toBe(0);
-    expect(JSON.parse(event.payloadStr)).toStrictEqual({
+    expect(firstBatch.events.map((event) => event.sequence)).toStrictEqual([
+      0, 1,
+    ]);
+    expect(JSON.parse(firstBatch.events[0].payloadStr)).toStrictEqual({
       circular: { self: "[Circular]" },
       count: "3n",
+      first: shared,
+      second: shared,
     });
-    expect(event.payloadHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(firstBatch.events[0].payloadHash).toMatch(/^[a-f0-9]{64}$/);
 
     await audit.complete("completed", { httpStatus: 200 });
 
@@ -145,5 +162,59 @@ describe("agent run audit transport", () => {
     } finally {
       warning.mockRestore();
     }
+  });
+
+  it("reconciles a start that settles after its timeout", async () => {
+    let resolveStart!: (response: AuditResponse) => void;
+    auditMocks.start.mockReturnValueOnce(
+      new Promise<AuditResponse>((resolve) => {
+        resolveStart = resolve;
+      })
+    );
+
+    const audit = await createAgentRunAudit(startInput());
+    const completion = audit.complete("completed");
+    setTimeout(
+      () =>
+        resolveStart({
+          attemptId: "attempt-1",
+          runId: "run-1",
+        }),
+      25
+    );
+
+    await completion;
+
+    expect(auditMocks.complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auditIncomplete: true,
+        status: "completed",
+      })
+    );
+  });
+
+  it("reconciles a completion that settles after its timeout", async () => {
+    auditMocks.complete
+      .mockReturnValueOnce(
+        new Promise<AuditResponse>((resolve) => {
+          setTimeout(
+            () => resolve({ attemptId: "attempt-1", runId: "run-1" }),
+            600
+          );
+        })
+      )
+      .mockResolvedValueOnce({ attemptId: "attempt-1", runId: "run-1" });
+
+    const audit = await createAgentRunAudit(startInput());
+    await audit.complete("completed");
+    await new Promise((resolve) => setTimeout(resolve, 650));
+
+    expect(auditMocks.complete).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        auditIncomplete: true,
+        status: "completed",
+      })
+    );
   });
 });

--- a/apps/worker/src/pipeline/core/agent-run-audit.test.ts
+++ b/apps/worker/src/pipeline/core/agent-run-audit.test.ts
@@ -92,10 +92,15 @@ describe("agent run audit transport", () => {
     const circular: Record<string, unknown> = {};
     circular.self = circular;
     const shared = { kind: "reply", value: "same object twice" };
+    const errorEvidence: Record<string, unknown> = {
+      error: new Error("model failed"),
+    };
+    errorEvidence.self = errorEvidence;
 
     audit.record("context.captured", {
       circular,
       count: 3n,
+      errorEvidence,
       first: shared,
       second: shared,
     });
@@ -112,6 +117,14 @@ describe("agent run audit transport", () => {
     expect(JSON.parse(firstBatch.events[0].payloadStr)).toStrictEqual({
       circular: { self: "[Circular]" },
       count: "3n",
+      errorEvidence: {
+        error: {
+          message: "model failed",
+          name: "Error",
+          stack: expect.any(String),
+        },
+        self: "[Circular]",
+      },
       first: shared,
       second: shared,
     });
@@ -180,10 +193,11 @@ describe("agent run audit transport", () => {
           attemptId: "attempt-1",
           runId: "run-1",
         }),
-      25
+      600
     );
 
     await completion;
+    await new Promise((resolve) => setTimeout(resolve, 150));
 
     expect(auditMocks.complete).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/worker/src/pipeline/core/agent-run-audit.test.ts
+++ b/apps/worker/src/pipeline/core/agent-run-audit.test.ts
@@ -1,0 +1,149 @@
+import { log } from "@workspace/utils/logging";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+interface AuditResponse {
+  attemptId: string;
+  runId: string;
+}
+
+interface AppendInput {
+  events: {
+    payloadHash: string;
+    payloadStr: string;
+    sequence: number;
+  }[];
+}
+
+const auditMocks = vi.hoisted(() => ({
+  appendEvents: vi.fn<(input: AppendInput) => Promise<{ inserted: number }>>(),
+  complete: vi.fn<(input: unknown) => Promise<AuditResponse>>(),
+  start: vi.fn<(input: unknown) => Promise<AuditResponse>>(),
+}));
+
+vi.mock(import("../../lib/database/client"), () => ({
+  fetchClient: {
+    mutate: {
+      agentRun: auditMocks,
+    },
+    query: {},
+  } as never,
+}));
+
+import {
+  agentRunAttemptIdFor,
+  agentRunIdFor,
+  createAgentRunAudit,
+} from "./agent-run-audit";
+
+const startInput = () => ({
+  attemptNumber: 1,
+  input: {
+    threadIds: ["thread-1"],
+    triggers: [{ kind: "message" as const }],
+  },
+  options: {},
+  organizationId: "org-1",
+  pipelineJobId: "pipeline-1",
+  queueJobId: "queue-1",
+  queueName: "thread-pipeline",
+  rawQueuePayload: {
+    threadId: "thread-1",
+    triggers: [{ kind: "message" }],
+  },
+  threadId: "thread-1",
+});
+
+describe("agent run audit transport", () => {
+  beforeEach(() => {
+    auditMocks.appendEvents.mockReset().mockResolvedValue({ inserted: 1 });
+    auditMocks.complete.mockReset().mockResolvedValue({
+      attemptId: "attempt-1",
+      runId: "run-1",
+    });
+    auditMocks.start.mockReset().mockResolvedValue({
+      attemptId: "attempt-1",
+      runId: "run-1",
+    });
+  });
+
+  it("derives stable logical and attempt ids", () => {
+    const identity = {
+      pipelineJobId: "pipeline-1",
+      queueJobId: "queue-1",
+      queueName: "thread-pipeline",
+      threadId: "thread-1",
+    };
+
+    expect(agentRunIdFor(identity)).toBe(agentRunIdFor(identity));
+    expect(agentRunAttemptIdFor("run-1", 1)).not.toBe(
+      agentRunAttemptIdFor("run-1", 2)
+    );
+  });
+
+  it("serializes observable evidence and preserves event order", async () => {
+    const audit = await createAgentRunAudit(startInput());
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    audit.record("context.captured", { circular, count: 3n });
+    await audit.flush();
+
+    const firstBatch = auditMocks.appendEvents.mock.calls[0]?.[0];
+    if (!firstBatch?.events[0]) {
+      throw new Error("Expected an audit event batch");
+    }
+    const event = firstBatch.events[0];
+    expect(event.sequence).toBe(0);
+    expect(JSON.parse(event.payloadStr)).toStrictEqual({
+      circular: { self: "[Circular]" },
+      count: "3n",
+    });
+    expect(event.payloadHash).toMatch(/^[a-f0-9]{64}$/);
+
+    await audit.complete("completed", { httpStatus: 200 });
+
+    expect(auditMocks.complete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auditIncomplete: false,
+        status: "completed",
+      })
+    );
+  });
+
+  it("does not make audit transport failure affect the worker", async () => {
+    const warning = vi.spyOn(log, "warn").mockImplementation(() => {});
+    auditMocks.start.mockRejectedValueOnce(new Error("audit unavailable"));
+
+    try {
+      const audit = await createAgentRunAudit(startInput());
+      audit.record("run.failed", { reason: "pipeline failure" });
+
+      await expect(audit.complete("failed")).resolves.toBeUndefined();
+      expect(auditMocks.appendEvents).not.toHaveBeenCalled();
+      expect(auditMocks.complete).not.toHaveBeenCalled();
+      expect(warning).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "start_failed" })
+      );
+    } finally {
+      warning.mockRestore();
+    }
+  });
+
+  it("marks the run incomplete when an append fails but still completes", async () => {
+    auditMocks.appendEvents.mockRejectedValueOnce(new Error("write failed"));
+    const warning = vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    try {
+      const audit = await createAgentRunAudit(startInput());
+      audit.record("model.completed", { status: "completed" });
+
+      await audit.complete("completed");
+
+      expect(auditMocks.complete).toHaveBeenCalledWith(
+        expect.objectContaining({ auditIncomplete: true })
+      );
+    } finally {
+      warning.mockRestore();
+    }
+  });
+});

--- a/apps/worker/src/pipeline/core/agent-run-audit.test.ts
+++ b/apps/worker/src/pipeline/core/agent-run-audit.test.ts
@@ -45,7 +45,7 @@ const startInput = () => ({
   organizationId: "org-1",
   pipelineJobId: "pipeline-1",
   queueGeneration: 1,
-  queueJobId: "queue-1",
+  bullmqJobId: "queue-1",
   queueName: "thread-pipeline",
   rawQueuePayload: {
     threadId: "thread-1",
@@ -70,7 +70,7 @@ describe("agent run audit transport", () => {
   it("derives stable logical and attempt ids", () => {
     const identity = {
       pipelineJobId: "pipeline-1",
-      queueJobId: "queue-1",
+      bullmqJobId: "queue-1",
       queueName: "thread-pipeline",
       threadId: "thread-1",
     };

--- a/apps/worker/src/pipeline/core/agent-run-audit.ts
+++ b/apps/worker/src/pipeline/core/agent-run-audit.ts
@@ -1,0 +1,429 @@
+import { createHash } from "node:crypto";
+
+import { log } from "@workspace/utils/logging";
+import { ulid } from "ulid";
+
+import { fetchClient } from "../../lib/database/client";
+import { errorFields } from "../../lib/logging";
+import type { PipelineJobInput, PipelineJobOptions } from "./types";
+
+export const AGENT_RUN_EVENT_TYPES = [
+  "run.started",
+  "run.completed",
+  "run.failed",
+  "trigger.received",
+  "pipeline.plan",
+  "processor.started",
+  "processor.completed",
+  "processor.skipped",
+  "processor.failed",
+  "hint.computed",
+  "context.captured",
+  "model.requested",
+  "model.step",
+  "model.completed",
+  "model.failed",
+  "tool.called",
+  "tool.completed",
+  "output.parsed",
+  "autonomy.policy",
+  "action.filtered",
+  "gate.evaluated",
+  "action.executed",
+  "action.failed",
+  "action.suggested",
+  "read.published",
+  "audit.incomplete",
+] as const;
+
+export type AgentRunEventType = (typeof AGENT_RUN_EVENT_TYPES)[number];
+
+export interface AgentRunEventMetadata {
+  causationEventId?: string;
+  phase?: string;
+  processor?: string;
+  stepIndex?: number;
+  toolCallId?: string;
+}
+
+export interface AgentRunAuditStart {
+  attemptNumber: number;
+  bullmqJobId?: string;
+  organizationId: string;
+  pipelineJobId?: string;
+  queueJobId?: string;
+  queueName?: string;
+  threadId: string;
+  input: PipelineJobInput;
+  options: PipelineJobOptions;
+  rawQueuePayload?: unknown;
+}
+
+export interface AgentRunAudit {
+  readonly attemptId: string;
+  readonly runId: string;
+  record: (
+    type: AgentRunEventType,
+    payload: unknown,
+    metadata?: AgentRunEventMetadata
+  ) => void;
+  flush: () => Promise<void>;
+  complete: (
+    status: "completed" | "failed" | "abandoned",
+    payload?: unknown
+  ) => Promise<void>;
+}
+
+const FLUSH_TIMEOUT_MS = 500;
+const FLUSH_BATCH_SIZE = 100;
+
+const withTimeout = async <T>(
+  promise: Promise<T>,
+  timeoutMs: number
+): Promise<T | undefined> => {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<undefined>((resolve) => {
+        timeout = setTimeout(() => resolve(undefined), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+};
+
+const stableId = (value: string): string =>
+  createHash("sha256").update(value).digest("hex").slice(0, 32);
+
+export const agentRunIdFor = ({
+  pipelineJobId,
+  queueJobId,
+  queueName,
+  threadId,
+}: {
+  pipelineJobId?: string;
+  queueJobId?: string;
+  queueName?: string;
+  threadId: string;
+}): string =>
+  stableId(
+    [
+      queueName ?? "pipeline",
+      queueJobId ?? pipelineJobId ?? ulid(),
+      threadId,
+    ].join(":")
+  );
+
+export const agentRunAttemptIdFor = (
+  runId: string,
+  attemptNumber: number
+): string => stableId(`${runId}:attempt:${attemptNumber}`);
+
+const serializeForAudit = (value: unknown): string => {
+  try {
+    const seen = new WeakSet<object>();
+    const serialized = JSON.stringify(value, (_key, currentValue: unknown) => {
+      if (typeof currentValue === "bigint") {
+        return `${currentValue.toString()}n`;
+      }
+
+      if (currentValue instanceof Error) {
+        return {
+          message: currentValue.message,
+          name: currentValue.name,
+          stack: currentValue.stack,
+        };
+      }
+
+      if (typeof currentValue === "object" && currentValue !== null) {
+        if (seen.has(currentValue)) {
+          return "[Circular]";
+        }
+        seen.add(currentValue);
+      }
+
+      return currentValue;
+    });
+
+    return serialized === undefined ? "null" : serialized;
+  } catch (error) {
+    return JSON.stringify({
+      serializationError:
+        error instanceof Error ? error.message : String(error),
+      value: "[Unserializable]",
+    });
+  }
+};
+
+const payloadHash = (payloadStr: string): string =>
+  createHash("sha256").update(payloadStr).digest("hex");
+
+const auditLog = (event: string, fields: Record<string, unknown>) => {
+  // Keep audit transport failures on the operational logging path. This is
+  // deliberately not the same as the forensic ledger: the pipeline must not
+  // depend on the latter being reachable.
+  log.warn({
+    action: "worker.agent_run_audit",
+    event,
+    ...fields,
+  });
+};
+
+const startMetadata = (start: AgentRunAuditStart) => ({
+  captureMode: "full",
+  options: start.options,
+  queuePayload: start.rawQueuePayload ?? null,
+  triggers: start.input.audit?.normalizedTriggers ?? start.input.triggers ?? [],
+});
+
+class AgentRunAuditImpl implements AgentRunAudit {
+  readonly attemptId: string;
+  readonly runId: string;
+
+  #nextSequence = 0;
+  #pending: {
+    agentRunId: string;
+    attemptId: string;
+    causationEventId: string | null;
+    emittedAt: Date;
+    id: string;
+    occurredAt: Date;
+    organizationId: string;
+    payloadHash: string;
+    payloadStr: string;
+    phase: string | null;
+    processor: string | null;
+    sequence: number;
+    stepIndex: number | null;
+    threadId: string;
+    toolCallId: string | null;
+    type: string;
+  }[] = [];
+  #flushPromise: Promise<void> | null = null;
+  #flushScheduled = false;
+  #incomplete = false;
+  #incompleteEventRecorded = false;
+  #started = false;
+  #start: AgentRunAuditStart;
+
+  constructor(start: AgentRunAuditStart, runId: string, attemptId: string) {
+    this.#start = start;
+    this.runId = runId;
+    this.attemptId = attemptId;
+  }
+
+  async start(): Promise<void> {
+    try {
+      const result = await withTimeout(
+        fetchClient.mutate.agentRun.start({
+          attemptId: this.attemptId,
+          attemptNumber: this.#start.attemptNumber,
+          bullmqJobId: this.#start.bullmqJobId ?? null,
+          createdAt: new Date(),
+          metadataStr: JSON.stringify(startMetadata(this.#start)),
+          organizationId: this.#start.organizationId,
+          pipelineJobId: this.#start.pipelineJobId ?? null,
+          queueJobId: this.#start.queueJobId ?? null,
+          queueName: this.#start.queueName ?? null,
+          runId: this.runId,
+          startedAt: new Date(),
+          threadId: this.#start.threadId,
+        }),
+        FLUSH_TIMEOUT_MS
+      );
+
+      if (!result) {
+        this.markIncomplete("start_timeout");
+        return;
+      }
+
+      this.#started = true;
+    } catch (error) {
+      this.markIncomplete("start_failed");
+      auditLog("start_failed", {
+        attemptId: this.attemptId,
+        error: errorFields(error),
+        runId: this.runId,
+        threadId: this.#start.threadId,
+      });
+    }
+  }
+
+  record(
+    type: AgentRunEventType,
+    payload: unknown,
+    metadata: AgentRunEventMetadata = {}
+  ): void {
+    const payloadStr = serializeForAudit(payload);
+    const sequence = this.#nextSequence++;
+    const occurredAt = new Date();
+
+    this.#pending.push({
+      agentRunId: this.runId,
+      attemptId: this.attemptId,
+      causationEventId: metadata.causationEventId ?? null,
+      emittedAt: new Date(),
+      id: stableId(`${this.attemptId}:event:${sequence}`),
+      occurredAt,
+      organizationId: this.#start.organizationId,
+      payloadHash: payloadHash(payloadStr),
+      payloadStr,
+      phase: metadata.phase ?? null,
+      processor: metadata.processor ?? null,
+      sequence,
+      stepIndex: metadata.stepIndex ?? null,
+      threadId: this.#start.threadId,
+      toolCallId: metadata.toolCallId ?? null,
+      type,
+    });
+
+    this.scheduleFlush();
+  }
+
+  async flush(): Promise<void> {
+    if (this.#flushPromise) {
+      return this.#flushPromise;
+    }
+
+    this.#flushPromise = this.flushLoop().finally(() => {
+      this.#flushPromise = null;
+    });
+    return this.#flushPromise;
+  }
+
+  async complete(
+    status: "completed" | "failed" | "abandoned",
+    payload?: unknown
+  ): Promise<void> {
+    this.record(
+      status === "completed" ? "run.completed" : "run.failed",
+      payload ?? { status },
+      { phase: "run" }
+    );
+
+    // `flushLoop` applies the transport timeout per batch and marks the audit
+    // incomplete on timeout. Do not wrap this void-returning promise in
+    // another timeout: `undefined` is also the successful result of `flush()`.
+    await this.flush();
+
+    try {
+      if (!this.#started) {
+        this.markIncomplete("run_never_started");
+        return;
+      }
+
+      const result = await withTimeout(
+        fetchClient.mutate.agentRun.complete({
+          attemptId: this.attemptId,
+          auditIncomplete: this.#incomplete || this.#pending.length > 0,
+          completedAt: new Date(),
+          metadataStr: JSON.stringify({
+            ...(payload && typeof payload === "object" ? payload : {}),
+            auditIncomplete: this.#incomplete || this.#pending.length > 0,
+          }),
+          runId: this.runId,
+          status,
+        }),
+        FLUSH_TIMEOUT_MS
+      );
+
+      if (!result) {
+        this.markIncomplete("complete_timeout");
+      }
+    } catch (error) {
+      this.markIncomplete("complete_failed");
+      auditLog("complete_failed", {
+        attemptId: this.attemptId,
+        error: errorFields(error),
+        runId: this.runId,
+        threadId: this.#start.threadId,
+      });
+    }
+  }
+
+  private markIncomplete(reason: string): void {
+    if (this.#incomplete) {
+      return;
+    }
+    this.#incomplete = true;
+    if (this.#started && !this.#incompleteEventRecorded) {
+      this.#incompleteEventRecorded = true;
+      this.record("audit.incomplete", { reason }, { phase: "audit" });
+    }
+    auditLog("incomplete", {
+      attemptId: this.attemptId,
+      reason,
+      runId: this.runId,
+      threadId: this.#start.threadId,
+    });
+  }
+
+  private scheduleFlush(): void {
+    if (this.#flushScheduled) {
+      return;
+    }
+
+    this.#flushScheduled = true;
+    setTimeout(() => {
+      this.#flushScheduled = false;
+      void this.flush();
+    }, 0);
+  }
+
+  private async flushLoop(): Promise<void> {
+    if (!this.#started || this.#pending.length === 0) {
+      return;
+    }
+
+    while (this.#pending.length > 0) {
+      const batch = this.#pending.splice(0, FLUSH_BATCH_SIZE);
+      try {
+        const result = await withTimeout(
+          fetchClient.mutate.agentRun.appendEvents({ events: batch }),
+          FLUSH_TIMEOUT_MS
+        );
+        if (!result) {
+          this.#pending.unshift(...batch);
+          this.markIncomplete("append_timeout");
+          auditLog("append_timeout", {
+            attemptId: this.attemptId,
+            batchSize: batch.length,
+            runId: this.runId,
+            threadId: this.#start.threadId,
+          });
+          return;
+        }
+      } catch (error) {
+        this.#pending.unshift(...batch);
+        this.markIncomplete("append_failed");
+        auditLog("append_failed", {
+          attemptId: this.attemptId,
+          batchSize: batch.length,
+          error: errorFields(error),
+          runId: this.runId,
+          threadId: this.#start.threadId,
+        });
+        return;
+      }
+    }
+  }
+}
+
+export const createAgentRunAudit = async (
+  start: AgentRunAuditStart
+): Promise<AgentRunAudit> => {
+  const runId = agentRunIdFor({
+    pipelineJobId: start.pipelineJobId,
+    queueJobId: start.queueJobId,
+    queueName: start.queueName,
+    threadId: start.threadId,
+  });
+  const attemptId = agentRunAttemptIdFor(runId, start.attemptNumber);
+  const audit = new AgentRunAuditImpl(start, runId, attemptId);
+  await audit.start();
+  return audit;
+};

--- a/apps/worker/src/pipeline/core/agent-run-audit.ts
+++ b/apps/worker/src/pipeline/core/agent-run-audit.ts
@@ -52,7 +52,6 @@ export interface AgentRunAuditStart {
   organizationId: string;
   pipelineJobId?: string;
   queueGeneration?: number;
-  queueJobId?: string;
   queueName?: string;
   threadId: string;
   input: PipelineJobInput;
@@ -103,13 +102,13 @@ const stableId = (value: string): string =>
 export const agentRunIdFor = ({
   pipelineJobId,
   queueGeneration,
-  queueJobId,
+  bullmqJobId,
   queueName,
   threadId,
 }: {
   pipelineJobId?: string;
   queueGeneration?: number;
-  queueJobId?: string;
+  bullmqJobId?: string;
   queueName?: string;
   threadId: string;
 }): string =>
@@ -117,7 +116,7 @@ export const agentRunIdFor = ({
     [
       queueName ?? "pipeline",
       queueGeneration === undefined
-        ? (queueJobId ?? pipelineJobId ?? ulid())
+        ? (bullmqJobId ?? pipelineJobId ?? ulid())
         : `generation:${queueGeneration}`,
       threadId,
     ].join(":")
@@ -173,9 +172,6 @@ const serializeForAudit = (value: unknown): string => {
   }
 };
 
-const payloadHash = (payloadStr: string): string =>
-  createHash("sha256").update(payloadStr).digest("hex");
-
 const auditLog = (event: string, fields: Record<string, unknown>) => {
   // Keep audit transport failures on the operational logging path. This is
   // deliberately not the same as the forensic ledger: the pipeline must not
@@ -220,7 +216,7 @@ class AgentRunAuditImpl implements AgentRunAudit {
   }[] = [];
   #flushPromise: Promise<void> | null = null;
   #flushScheduled = false;
-  #incomplete = false;
+  #incompleteReason: string | null = null;
   #incompleteEventRecorded = false;
   #started = false;
   #start: AgentRunAuditStart;
@@ -244,7 +240,6 @@ class AgentRunAuditImpl implements AgentRunAudit {
         metadataStr: JSON.stringify(startMetadata(this.#start)),
         organizationId: this.#start.organizationId,
         pipelineJobId: this.#start.pipelineJobId ?? null,
-        queueJobId: this.#start.queueJobId ?? null,
         queueName: this.#start.queueName ?? null,
         runId: this.runId,
         startedAt: new Date(),
@@ -254,7 +249,7 @@ class AgentRunAuditImpl implements AgentRunAudit {
     this.#startPromise = startRequest
       .then(() => {
         this.#started = true;
-        this.recordIncompleteEvent("start_timeout");
+        this.recordIncompleteEvent();
         return true;
       })
       .catch((error) => {
@@ -294,7 +289,7 @@ class AgentRunAuditImpl implements AgentRunAudit {
       id: stableId(`${this.attemptId}:event:${sequence}`),
       occurredAt,
       organizationId: this.#start.organizationId,
-      payloadHash: payloadHash(payloadStr),
+      payloadHash: createHash("sha256").update(payloadStr).digest("hex"),
       payloadStr,
       phase: metadata.phase ?? null,
       processor: metadata.processor ?? null,
@@ -394,7 +389,8 @@ class AgentRunAuditImpl implements AgentRunAudit {
       return;
     }
 
-    const auditIncomplete = this.#incomplete || this.#pending.length > 0;
+    const auditIncomplete =
+      this.#incompleteReason !== null || this.#pending.length > 0;
     const metadataStr = JSON.stringify({
       ...(payload && typeof payload === "object" ? payload : {}),
       auditIncomplete,
@@ -464,17 +460,30 @@ class AgentRunAuditImpl implements AgentRunAudit {
     }
   }
 
-  private recordIncompleteEvent(reason: string): void {
-    if (this.#started && this.#incomplete && !this.#incompleteEventRecorded) {
+  /**
+   * Emits the `audit.incomplete` marker once, on the first reason. Skipped
+   * while the run row does not exist yet: the event has nothing to attach to,
+   * so `start` retries this the moment the row lands.
+   */
+  private recordIncompleteEvent(): void {
+    if (
+      this.#started &&
+      this.#incompleteReason &&
+      !this.#incompleteEventRecorded
+    ) {
       this.#incompleteEventRecorded = true;
-      this.record("audit.incomplete", { reason }, { phase: "audit" });
+      this.record(
+        "audit.incomplete",
+        { reason: this.#incompleteReason },
+        { phase: "audit" }
+      );
     }
   }
 
   private markIncomplete(reason: string): void {
-    const firstIncomplete = !this.#incomplete;
-    this.#incomplete = true;
-    this.recordIncompleteEvent(reason);
+    const firstIncomplete = !this.#incompleteReason;
+    this.#incompleteReason ??= reason;
+    this.recordIncompleteEvent();
     if (!firstIncomplete) {
       return;
     }
@@ -543,7 +552,7 @@ export const createAgentRunAudit = async (
   const runId = agentRunIdFor({
     pipelineJobId: start.pipelineJobId,
     queueGeneration: start.queueGeneration,
-    queueJobId: start.queueJobId,
+    bullmqJobId: start.bullmqJobId,
     queueName: start.queueName,
     threadId: start.threadId,
   });

--- a/apps/worker/src/pipeline/core/agent-run-audit.ts
+++ b/apps/worker/src/pipeline/core/agent-run-audit.ts
@@ -51,6 +51,7 @@ export interface AgentRunAuditStart {
   bullmqJobId?: string;
   organizationId: string;
   pipelineJobId?: string;
+  queueGeneration?: number;
   queueJobId?: string;
   queueName?: string;
   threadId: string;
@@ -101,11 +102,13 @@ const stableId = (value: string): string =>
 
 export const agentRunIdFor = ({
   pipelineJobId,
+  queueGeneration,
   queueJobId,
   queueName,
   threadId,
 }: {
   pipelineJobId?: string;
+  queueGeneration?: number;
   queueJobId?: string;
   queueName?: string;
   threadId: string;
@@ -113,7 +116,9 @@ export const agentRunIdFor = ({
   stableId(
     [
       queueName ?? "pipeline",
-      queueJobId ?? pipelineJobId ?? ulid(),
+      queueGeneration === undefined
+        ? (queueJobId ?? pipelineJobId ?? ulid())
+        : `generation:${queueGeneration}`,
       threadId,
     ].join(":")
   );
@@ -125,29 +130,36 @@ export const agentRunAttemptIdFor = (
 
 const serializeForAudit = (value: unknown): string => {
   try {
-    const seen = new WeakSet<object>();
-    const serialized = JSON.stringify(value, (_key, currentValue: unknown) => {
-      if (typeof currentValue === "bigint") {
-        return `${currentValue.toString()}n`;
-      }
-
-      if (currentValue instanceof Error) {
-        return {
-          message: currentValue.message,
-          name: currentValue.name,
-          stack: currentValue.stack,
-        };
-      }
-
-      if (typeof currentValue === "object" && currentValue !== null) {
-        if (seen.has(currentValue)) {
-          return "[Circular]";
+    const stack: unknown[] = [];
+    const serialized = JSON.stringify(
+      value,
+      function serializeReplacer(this: unknown, _key, currentValue: unknown) {
+        while (stack.length > 0 && stack.at(-1) !== this) {
+          stack.pop();
         }
-        seen.add(currentValue);
-      }
 
-      return currentValue;
-    });
+        if (typeof currentValue === "bigint") {
+          return `${currentValue.toString()}n`;
+        }
+
+        if (currentValue instanceof Error) {
+          return {
+            message: currentValue.message,
+            name: currentValue.name,
+            stack: currentValue.stack,
+          };
+        }
+
+        if (typeof currentValue === "object" && currentValue !== null) {
+          if (stack.includes(currentValue)) {
+            return "[Circular]";
+          }
+          stack.push(currentValue);
+        }
+
+        return currentValue;
+      }
+    );
 
     return serialized === undefined ? "null" : serialized;
   } catch (error) {
@@ -176,6 +188,7 @@ const auditLog = (event: string, fields: Record<string, unknown>) => {
 const startMetadata = (start: AgentRunAuditStart) => ({
   captureMode: "full",
   options: start.options,
+  queueGeneration: start.queueGeneration ?? null,
   queuePayload: start.rawQueuePayload ?? null,
   triggers: start.input.audit?.normalizedTriggers ?? start.input.triggers ?? [],
 });
@@ -209,6 +222,9 @@ class AgentRunAuditImpl implements AgentRunAudit {
   #incompleteEventRecorded = false;
   #started = false;
   #start: AgentRunAuditStart;
+  #startPromise: Promise<boolean> | null = null;
+  #startSettled = false;
+  #completionPromise: Promise<void> | null = null;
 
   constructor(start: AgentRunAuditStart, runId: string, attemptId: string) {
     this.#start = start;
@@ -217,39 +233,45 @@ class AgentRunAuditImpl implements AgentRunAudit {
   }
 
   async start(): Promise<void> {
-    try {
-      const result = await withTimeout(
-        fetchClient.mutate.agentRun.start({
-          attemptId: this.attemptId,
-          attemptNumber: this.#start.attemptNumber,
-          bullmqJobId: this.#start.bullmqJobId ?? null,
-          createdAt: new Date(),
-          metadataStr: JSON.stringify(startMetadata(this.#start)),
-          organizationId: this.#start.organizationId,
-          pipelineJobId: this.#start.pipelineJobId ?? null,
-          queueJobId: this.#start.queueJobId ?? null,
-          queueName: this.#start.queueName ?? null,
-          runId: this.runId,
-          startedAt: new Date(),
-          threadId: this.#start.threadId,
-        }),
-        FLUSH_TIMEOUT_MS
-      );
-
-      if (!result) {
-        this.markIncomplete("start_timeout");
-        return;
-      }
-
-      this.#started = true;
-    } catch (error) {
-      this.markIncomplete("start_failed");
-      auditLog("start_failed", {
+    const startRequest = Promise.resolve().then(() =>
+      fetchClient.mutate.agentRun.start({
         attemptId: this.attemptId,
-        error: errorFields(error),
+        attemptNumber: this.#start.attemptNumber,
+        bullmqJobId: this.#start.bullmqJobId ?? null,
+        createdAt: new Date(),
+        metadataStr: JSON.stringify(startMetadata(this.#start)),
+        organizationId: this.#start.organizationId,
+        pipelineJobId: this.#start.pipelineJobId ?? null,
+        queueJobId: this.#start.queueJobId ?? null,
+        queueName: this.#start.queueName ?? null,
         runId: this.runId,
+        startedAt: new Date(),
         threadId: this.#start.threadId,
+      })
+    );
+    this.#startPromise = startRequest
+      .then(() => {
+        this.#started = true;
+        this.recordIncompleteEvent("start_timeout");
+        return true;
+      })
+      .catch((error) => {
+        this.markIncomplete("start_failed");
+        auditLog("start_failed", {
+          attemptId: this.attemptId,
+          error: errorFields(error),
+          runId: this.runId,
+          threadId: this.#start.threadId,
+        });
+        return false;
+      })
+      .finally(() => {
+        this.#startSettled = true;
       });
+
+    const result = await withTimeout(this.#startPromise, FLUSH_TIMEOUT_MS);
+    if (result === undefined) {
+      this.markIncomplete("start_timeout");
     }
   }
 
@@ -299,40 +321,107 @@ class AgentRunAuditImpl implements AgentRunAudit {
     status: "completed" | "failed" | "abandoned",
     payload?: unknown
   ): Promise<void> {
+    if (this.#completionPromise) {
+      return this.#completionPromise;
+    }
+
+    this.#completionPromise = this.completeOnce(status, payload);
+    return this.#completionPromise;
+  }
+
+  private async completeOnce(
+    status: "completed" | "failed" | "abandoned",
+    payload?: unknown
+  ): Promise<void> {
     this.record(
       status === "completed" ? "run.completed" : "run.failed",
       payload ?? { status },
       { phase: "run" }
     );
 
+    const started = this.#started
+      ? true
+      : await withTimeout(
+          this.#startPromise ?? Promise.resolve(false),
+          FLUSH_TIMEOUT_MS
+        );
+
+    if (started === undefined) {
+      this.markIncomplete("complete_waiting_for_start");
+      if (this.#startPromise && !this.#startSettled) {
+        void this.#startPromise
+          .then((didStart) => {
+            if (!didStart) {
+              this.markIncomplete("run_never_started");
+              return;
+            }
+            return this.finishCompletion(status, payload);
+          })
+          .catch((error) => {
+            this.markIncomplete("complete_after_start_failed");
+            auditLog("complete_after_start_failed", {
+              attemptId: this.attemptId,
+              error: errorFields(error),
+              runId: this.runId,
+              threadId: this.#start.threadId,
+            });
+          });
+      }
+      return;
+    }
+
+    if (!started) {
+      this.markIncomplete("run_never_started");
+      return;
+    }
+
+    await this.finishCompletion(status, payload);
+  }
+
+  private async finishCompletion(
+    status: "completed" | "failed" | "abandoned",
+    payload?: unknown
+  ): Promise<void> {
     // `flushLoop` applies the transport timeout per batch and marks the audit
     // incomplete on timeout. Do not wrap this void-returning promise in
     // another timeout: `undefined` is also the successful result of `flush()`.
     await this.flush();
 
+    if (!this.#started) {
+      this.markIncomplete("run_never_started");
+      return;
+    }
+
+    const auditIncomplete = this.#incomplete || this.#pending.length > 0;
+    const metadataStr = JSON.stringify({
+      ...(payload && typeof payload === "object" ? payload : {}),
+      auditIncomplete,
+    });
+    const completionRequest = Promise.resolve().then(() =>
+      fetchClient.mutate.agentRun.complete({
+        attemptId: this.attemptId,
+        auditIncomplete,
+        completedAt: new Date(),
+        metadataStr,
+        runId: this.runId,
+        status,
+      })
+    );
+
     try {
-      if (!this.#started) {
-        this.markIncomplete("run_never_started");
-        return;
-      }
-
-      const result = await withTimeout(
-        fetchClient.mutate.agentRun.complete({
-          attemptId: this.attemptId,
-          auditIncomplete: this.#incomplete || this.#pending.length > 0,
-          completedAt: new Date(),
-          metadataStr: JSON.stringify({
-            ...(payload && typeof payload === "object" ? payload : {}),
-            auditIncomplete: this.#incomplete || this.#pending.length > 0,
-          }),
-          runId: this.runId,
-          status,
-        }),
-        FLUSH_TIMEOUT_MS
-      );
-
-      if (!result) {
+      const result = await withTimeout(completionRequest, FLUSH_TIMEOUT_MS);
+      if (result === undefined) {
         this.markIncomplete("complete_timeout");
+        void completionRequest
+          .catch((error) => {
+            auditLog("complete_failed_after_timeout", {
+              attemptId: this.attemptId,
+              error: errorFields(error),
+              runId: this.runId,
+              threadId: this.#start.threadId,
+            });
+          })
+          .then(() => this.reconcileCompletion(status, payload));
       }
     } catch (error) {
       this.markIncomplete("complete_failed");
@@ -345,14 +434,47 @@ class AgentRunAuditImpl implements AgentRunAudit {
     }
   }
 
-  private markIncomplete(reason: string): void {
-    if (this.#incomplete) {
-      return;
+  private async reconcileCompletion(
+    status: "completed" | "failed" | "abandoned",
+    payload?: unknown
+  ): Promise<void> {
+    await this.flush();
+    const metadataStr = JSON.stringify({
+      ...(payload && typeof payload === "object" ? payload : {}),
+      auditIncomplete: true,
+    });
+    try {
+      await fetchClient.mutate.agentRun.complete({
+        attemptId: this.attemptId,
+        auditIncomplete: true,
+        completedAt: new Date(),
+        metadataStr,
+        runId: this.runId,
+        status,
+      });
+    } catch (error) {
+      auditLog("complete_reconcile_failed", {
+        attemptId: this.attemptId,
+        error: errorFields(error),
+        runId: this.runId,
+        threadId: this.#start.threadId,
+      });
     }
-    this.#incomplete = true;
-    if (this.#started && !this.#incompleteEventRecorded) {
+  }
+
+  private recordIncompleteEvent(reason: string): void {
+    if (this.#started && this.#incomplete && !this.#incompleteEventRecorded) {
       this.#incompleteEventRecorded = true;
       this.record("audit.incomplete", { reason }, { phase: "audit" });
+    }
+  }
+
+  private markIncomplete(reason: string): void {
+    const firstIncomplete = !this.#incomplete;
+    this.#incomplete = true;
+    this.recordIncompleteEvent(reason);
+    if (!firstIncomplete) {
+      return;
     }
     auditLog("incomplete", {
       attemptId: this.attemptId,
@@ -418,6 +540,7 @@ export const createAgentRunAudit = async (
 ): Promise<AgentRunAudit> => {
   const runId = agentRunIdFor({
     pipelineJobId: start.pipelineJobId,
+    queueGeneration: start.queueGeneration,
     queueJobId: start.queueJobId,
     queueName: start.queueName,
     threadId: start.threadId,

--- a/apps/worker/src/pipeline/core/agent-run-audit.ts
+++ b/apps/worker/src/pipeline/core/agent-run-audit.ts
@@ -143,11 +143,13 @@ const serializeForAudit = (value: unknown): string => {
         }
 
         if (currentValue instanceof Error) {
-          return {
+          const serializedError = {
             message: currentValue.message,
             name: currentValue.name,
             stack: currentValue.stack,
           };
+          stack.push(serializedError);
+          return serializedError;
         }
 
         if (typeof currentValue === "object" && currentValue !== null) {

--- a/apps/worker/src/pipeline/core/autonomy-stage.ts
+++ b/apps/worker/src/pipeline/core/autonomy-stage.ts
@@ -115,11 +115,23 @@ export const applySynthesisAutonomy = async (
       run.recordAudit(
         "action.executed",
         {
-          actions: autoActions,
+          actions: result.succeeded,
           result,
         },
         { phase: "execution" }
       );
+
+      if (result.failed) {
+        run.recordAudit(
+          "action.failed",
+          {
+            action: result.failed.action,
+            error: result.failed.error,
+            result,
+          },
+          { phase: "execution" }
+        );
+      }
 
       await writeReplyReceipt(run, result.succeeded, fingerprints);
 

--- a/apps/worker/src/pipeline/core/autonomy-stage.ts
+++ b/apps/worker/src/pipeline/core/autonomy-stage.ts
@@ -35,11 +35,17 @@ export const applySynthesisAutonomy = async (
   rawActionSet: ThreadRead | null
 ): Promise<ThreadRead | null> => {
   if (!rawActionSet) {
+    run.recordAudit(
+      "action.filtered",
+      { reason: "no_raw_action_set" },
+      { phase: "autonomy" }
+    );
     await run.publishRead(null);
     return null;
   }
 
   const autonomy = await run.autonomy();
+  run.recordAudit("autonomy.policy", { autonomy }, { phase: "autonomy" });
 
   const primary = rawActionSet.primary.filter((action) =>
     keepForRead(action, autonomy)
@@ -48,16 +54,32 @@ export const applySynthesisAutonomy = async (
     keepForRead(action, autonomy)
   );
 
-  if (primary.length === 0) {
-    await run.publishRead(null);
-    return null;
-  }
-
   const filteredRead: ThreadRead = {
     ...rawActionSet,
     alternatives,
     primary,
   };
+
+  run.recordAudit(
+    "action.filtered",
+    {
+      alternatives: rawActionSet.alternatives ?? [],
+      filteredRead,
+      primary: rawActionSet.primary,
+      removedAlternatives: (rawActionSet.alternatives ?? []).filter(
+        (action) => !alternatives.includes(action)
+      ),
+      removedPrimary: rawActionSet.primary.filter(
+        (action) => !primary.includes(action)
+      ),
+    },
+    { phase: "autonomy" }
+  );
+
+  if (primary.length === 0) {
+    await run.publishRead(null);
+    return null;
+  }
 
   const permitted = primary.filter(
     (action) => autonomy[action.kind] === "auto"
@@ -90,6 +112,15 @@ export const applySynthesisAutonomy = async (
     try {
       const result = await run.executeBundle(autoActions);
 
+      run.recordAudit(
+        "action.executed",
+        {
+          actions: autoActions,
+          result,
+        },
+        { phase: "execution" }
+      );
+
       await writeReplyReceipt(run, result.succeeded, fingerprints);
 
       const afterAuto = nextAgentReadAfterExecution(
@@ -105,6 +136,11 @@ export const applySynthesisAutonomy = async (
         );
       }
     } catch (error) {
+      run.recordAudit(
+        "action.failed",
+        { actions: autoActions, error },
+        { phase: "execution" }
+      );
       // TODO(idempotency): On an RPC/transport error we don't know whether the
       // server actually executed the bundle, so re-suggesting `autoActions` here
       // can replay non-idempotent actions (e.g. a duplicate reply) if it did.
@@ -132,6 +168,16 @@ export const applySynthesisAutonomy = async (
     ...filteredRead,
     primary: finalPrimary,
   };
+
+  run.recordAudit(
+    "action.suggested",
+    {
+      actions: finalPrimary,
+      gated,
+      reason: "retained_for_review",
+    },
+    { phase: "autonomy" }
+  );
 
   await run.publishRead(agentRead);
   return agentRead;
@@ -170,6 +216,14 @@ const applyActionGates = async (
     })
     .toSorted((a, b) => gateRank(a.action.kind) - gateRank(b.action.kind));
 
+  for (const action of confirmed) {
+    run.recordAudit(
+      "gate.evaluated",
+      { action, allowed: true, reason: "no_gate" },
+      { phase: "gate" }
+    );
+  }
+
   for (const { action, gate } of toEvaluate) {
     const siblings = confirmed.filter((other) => other !== action);
     let result: ActionGateResult;
@@ -187,6 +241,19 @@ const applyActionGates = async (
         outcome: "downgraded_to_suggest",
       });
     }
+
+    run.recordAudit(
+      "gate.evaluated",
+      {
+        action,
+        allowed: result.allowed,
+        reason: result.allowed ? "allowed" : result.reason,
+        stateFingerprint: result.allowed
+          ? (result.stateFingerprint ?? null)
+          : null,
+      },
+      { phase: "gate" }
+    );
 
     if (result.allowed) {
       if (result.stateFingerprint) {

--- a/apps/worker/src/pipeline/core/model-audit.test.ts
+++ b/apps/worker/src/pipeline/core/model-audit.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { serializeObservableModelStep } from "./model-audit";
 
 describe("model audit serialization", () => {
-  it("keeps observable output while excluding reasoning parts and response messages", () => {
+  it("keeps observable output while excluding reasoning and provider metadata", () => {
     const serialized = serializeObservableModelStep({
       content: [
         { text: "visible", type: "text" },
@@ -17,6 +17,9 @@ describe("model audit serialization", () => {
         modelId: "model-1",
         timestamp: new Date().toISOString(),
       },
+      providerMetadata: {
+        google: { hiddenReasoning: "should not be copied" },
+      },
       text: "visible",
     });
 
@@ -29,5 +32,6 @@ describe("model audit serialization", () => {
       modelId: "model-1",
       timestamp: expect.any(String),
     });
+    expect(serialized).not.toHaveProperty("providerMetadata");
   });
 });

--- a/apps/worker/src/pipeline/core/model-audit.test.ts
+++ b/apps/worker/src/pipeline/core/model-audit.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { serializeObservableModelStep } from "./model-audit";
+
+describe("model audit serialization", () => {
+  it("keeps observable output while excluding reasoning parts and response messages", () => {
+    const serialized = serializeObservableModelStep({
+      content: [
+        { text: "visible", type: "text" },
+        { text: "hidden", type: "reasoning" },
+        { data: "hidden", type: "reasoning-file" },
+        { input: { query: "docs" }, type: "tool-call" },
+      ],
+      response: {
+        id: "response-1",
+        messages: [{ content: "should not be copied" }],
+        modelId: "model-1",
+        timestamp: new Date().toISOString(),
+      },
+      text: "visible",
+    });
+
+    expect(serialized.content).toStrictEqual([
+      { text: "visible", type: "text" },
+      { input: { query: "docs" }, type: "tool-call" },
+    ]);
+    expect(serialized.response).toStrictEqual({
+      id: "response-1",
+      modelId: "model-1",
+      timestamp: expect.any(String),
+    });
+  });
+});

--- a/apps/worker/src/pipeline/core/model-audit.ts
+++ b/apps/worker/src/pipeline/core/model-audit.ts
@@ -39,7 +39,6 @@ export const serializeObservableModelStep = (step: {
     content: observableContent(step.content),
     finishReason: step.finishReason,
     model: step.model,
-    providerMetadata: step.providerMetadata,
     rawFinishReason: step.rawFinishReason,
     response: response
       ? {

--- a/apps/worker/src/pipeline/core/model-audit.ts
+++ b/apps/worker/src/pipeline/core/model-audit.ts
@@ -1,22 +1,6 @@
-const asRecord = (value: unknown): Record<string, unknown> | null =>
-  value !== null && typeof value === "object"
-    ? (value as Record<string, unknown>)
-    : null;
+import { createHash } from "node:crypto";
 
-const observableContent = (content: unknown): unknown => {
-  if (!Array.isArray(content)) {
-    return content;
-  }
-
-  return content.filter((part) => {
-    const type = asRecord(part)?.type;
-    return (
-      type !== "reasoning" &&
-      type !== "reasoning-file" &&
-      type !== "redacted-reasoning"
-    );
-  });
-};
+import type { AgentRunAudit } from "./agent-run-audit";
 
 /** Keep model evidence useful without persisting hidden chain-of-thought. */
 export const serializeObservableModelStep = (step: {
@@ -54,4 +38,92 @@ export const serializeObservableModelStep = (step: {
     toolResults: step.toolResults,
     usage: step.usage,
   };
+};
+
+/**
+ * Opens an `embedding` model span on the audit. Every embedding call records the
+ * same request/completion/failure shape, so call sites only supply what differs:
+ * the task type, the processor, and whether they normalized the vector.
+ */
+export const auditEmbedding = (
+  audit: AgentRunAudit | undefined,
+  {
+    modelId,
+    processor,
+    taskType,
+    text,
+  }: {
+    modelId: string;
+    processor: string;
+    taskType: "RETRIEVAL_DOCUMENT" | "RETRIEVAL_QUERY" | "SEMANTIC_SIMILARITY";
+    text: string;
+  }
+) => {
+  const startedAt = performance.now();
+  const where = { phase: "model", processor } as const;
+  const request = {
+    input: { chars: text.length, hash: sha256(text) },
+    kind: "embedding",
+    model: { modelId, provider: "google" },
+    providerOptions: { google: { taskType } },
+  };
+
+  audit?.record("model.requested", request, where);
+
+  return {
+    completed: (
+      embedding: number[],
+      usage: unknown,
+      { normalized }: { normalized: boolean }
+    ) => {
+      audit?.record(
+        "model.completed",
+        {
+          ...request,
+          dimensions: embedding.length,
+          durationMs: performance.now() - startedAt,
+          embeddingHash: sha256(JSON.stringify(embedding)),
+          normalized,
+          status: "completed",
+          usage,
+        },
+        where
+      );
+    },
+    failed: (error: unknown) => {
+      audit?.record(
+        "model.failed",
+        {
+          ...request,
+          durationMs: performance.now() - startedAt,
+          error,
+          status: "failed",
+        },
+        where
+      );
+    },
+  };
+};
+
+const sha256 = (value: string): string =>
+  createHash("sha256").update(value).digest("hex");
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+
+const observableContent = (content: unknown): unknown => {
+  if (!Array.isArray(content)) {
+    return content;
+  }
+
+  return content.filter((part) => {
+    const type = asRecord(part)?.type;
+    return (
+      type !== "reasoning" &&
+      type !== "reasoning-file" &&
+      type !== "redacted-reasoning"
+    );
+  });
 };

--- a/apps/worker/src/pipeline/core/model-audit.ts
+++ b/apps/worker/src/pipeline/core/model-audit.ts
@@ -1,0 +1,58 @@
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+
+const observableContent = (content: unknown): unknown => {
+  if (!Array.isArray(content)) {
+    return content;
+  }
+
+  return content.filter((part) => {
+    const type = asRecord(part)?.type;
+    return (
+      type !== "reasoning" &&
+      type !== "reasoning-file" &&
+      type !== "redacted-reasoning"
+    );
+  });
+};
+
+/** Keep model evidence useful without persisting hidden chain-of-thought. */
+export const serializeObservableModelStep = (step: {
+  content?: unknown;
+  finishReason?: unknown;
+  model?: unknown;
+  providerMetadata?: unknown;
+  rawFinishReason?: unknown;
+  response?: unknown;
+  staticToolCalls?: unknown;
+  staticToolResults?: unknown;
+  text?: unknown;
+  toolCalls?: unknown;
+  toolResults?: unknown;
+  usage?: unknown;
+}) => {
+  const response = asRecord(step.response);
+
+  return {
+    content: observableContent(step.content),
+    finishReason: step.finishReason,
+    model: step.model,
+    providerMetadata: step.providerMetadata,
+    rawFinishReason: step.rawFinishReason,
+    response: response
+      ? {
+          id: response.id,
+          modelId: response.modelId,
+          timestamp: response.timestamp,
+        }
+      : null,
+    staticToolCalls: step.staticToolCalls,
+    staticToolResults: step.staticToolResults,
+    text: step.text,
+    toolCalls: step.toolCalls,
+    toolResults: step.toolResults,
+    usage: step.usage,
+  };
+};

--- a/apps/worker/src/pipeline/core/orchestrator.ts
+++ b/apps/worker/src/pipeline/core/orchestrator.ts
@@ -421,7 +421,17 @@ export const executePipeline = async (
     }
 
     const auditStart = input.audit;
-    const startedAudits = await Promise.all(
+    const effectiveTriggers = input.triggers ?? [];
+    const normalizedTriggers =
+      auditStart?.normalizedTriggers ?? effectiveTriggers;
+    // Mixed supersede + synthesis jobs clear the previous read in the worker
+    // preflight, before this pipeline gets its RunState. Preserve that
+    // observable write in the same logical run's sequence.
+    const supersedeClearedInPreflight =
+      normalizedTriggers.some((trigger) => trigger.kind === "supersede") &&
+      !effectiveTriggers.some((trigger) => trigger.kind === "supersede");
+
+    await Promise.all(
       [...runStates.entries()].map(async ([threadId, run]) => {
         const audit = await createAgentRunAudit({
           attemptNumber: auditStart?.attemptNumber ?? 1,
@@ -431,52 +441,36 @@ export const executePipeline = async (
           organizationId: run.organizationId,
           pipelineJobId,
           queueGeneration: auditStart?.queueGeneration,
-          queueJobId: auditStart?.queueJobId,
           queueName: auditStart?.queueName,
           rawQueuePayload: auditStart?.rawQueuePayload,
           threadId,
         });
         run.attachAudit(audit);
+        audits.set(threadId, audit);
+
         audit.record(
           "run.started",
-          {
-            pipelineJobId,
-            threadId,
-            triggers: input.triggers ?? [],
-          },
+          { pipelineJobId, threadId, triggers: effectiveTriggers },
           { phase: "run" }
         );
         audit.record(
           "trigger.received",
           {
-            effectiveTriggers: input.triggers ?? [],
-            normalizedTriggers:
-              input.audit?.normalizedTriggers ?? input.triggers ?? [],
-            rawQueuePayload: input.audit?.rawQueuePayload ?? null,
+            effectiveTriggers,
+            normalizedTriggers,
+            rawQueuePayload: auditStart?.rawQueuePayload ?? null,
           },
           { phase: "trigger" }
         );
-        return [threadId, audit] as const;
+        if (supersedeClearedInPreflight) {
+          audit.record(
+            "read.published",
+            { reason: "supersede", read: null, source: "worker_preflight" },
+            { phase: "supersede" }
+          );
+        }
       })
     );
-    for (const [threadId, audit] of startedAudits) {
-      audits.set(threadId, audit);
-      const normalizedTriggers =
-        input.audit?.normalizedTriggers ?? input.triggers ?? [];
-      const supersedeWasClearedBeforePipeline =
-        normalizedTriggers.some((trigger) => trigger.kind === "supersede") &&
-        !(input.triggers ?? []).some((trigger) => trigger.kind === "supersede");
-      if (supersedeWasClearedBeforePipeline) {
-        // Mixed supersede + synthesis jobs clear the previous read in the
-        // worker preflight, before this pipeline gets its RunState. Preserve
-        // that observable write in the same logical run's sequence.
-        audit.record(
-          "read.published",
-          { reason: "supersede", read: null, source: "worker_preflight" },
-          { phase: "supersede" }
-        );
-      }
-    }
 
     const context = new JobContext(pipelineJobId, input, options, runStates);
 
@@ -490,21 +484,19 @@ export const executePipeline = async (
       },
     });
     for (const [threadId, audit] of audits) {
+      const run = runStates.get(threadId);
       audit.record(
         "pipeline.plan",
-        {
-          processorCount: totalProcessors,
-          turns: executionOrder,
-        },
+        { processorCount: totalProcessors, turns: executionOrder },
         { phase: "pipeline" }
       );
       audit.record(
         "context.captured",
         {
-          hints: runStates.get(threadId)?.hints() ?? {},
+          hints: run?.hints() ?? {},
           options,
-          thread: runStates.get(threadId)?.thread ?? null,
-          triggers: input.triggers ?? [],
+          thread: run?.thread ?? null,
+          triggers: effectiveTriggers,
         },
         { phase: "context" }
       );

--- a/apps/worker/src/pipeline/core/orchestrator.ts
+++ b/apps/worker/src/pipeline/core/orchestrator.ts
@@ -430,6 +430,7 @@ export const executePipeline = async (
           options,
           organizationId: run.organizationId,
           pipelineJobId,
+          queueGeneration: auditStart?.queueGeneration,
           queueJobId: auditStart?.queueJobId,
           queueName: auditStart?.queueName,
           rawQueuePayload: auditStart?.rawQueuePayload,

--- a/apps/worker/src/pipeline/core/orchestrator.ts
+++ b/apps/worker/src/pipeline/core/orchestrator.ts
@@ -1,8 +1,12 @@
+import { createHash } from "node:crypto";
+
 import { createLogger } from "@workspace/utils/logging";
 
 import { isRetryableError } from "../../lib/logging";
 import type { WorkerLogger } from "../../lib/logging";
 import { processorRegistry } from "../processors/registry";
+import { createAgentRunAudit } from "./agent-run-audit";
+import type { AgentRunAudit } from "./agent-run-audit";
 import { JobContext } from "./context";
 import {
   batchCheckIdempotency,
@@ -33,6 +37,32 @@ import type {
 } from "./types";
 
 const DEFAULT_CONCURRENCY = 5;
+
+const processorResultForAudit = (result: ProcessorResult): ProcessorResult => {
+  if (!("data" in result) || !result.data || typeof result.data !== "object") {
+    return result;
+  }
+
+  const data = result.data as Record<string, unknown>;
+  if (!Array.isArray(data.embedding)) {
+    return result;
+  }
+
+  return {
+    ...result,
+    data: {
+      ...data,
+      // The vector itself is not useful for reconstructing a decision, but its
+      // shape and hash let us prove which generated output was used.
+      embedding: {
+        dimensions: data.embedding.length,
+        hash: createHash("sha256")
+          .update(JSON.stringify(data.embedding))
+          .digest("hex"),
+      },
+    },
+  } as ProcessorResult;
+};
 
 /**
  * Process a batch of threads with controlled concurrency
@@ -87,6 +117,15 @@ const executeProcessor = async (
       continue;
     }
 
+    run.recordAudit(
+      "processor.started",
+      {
+        dependencies,
+        processor: processor.name,
+      },
+      { phase: "processor", processor: processor.name }
+    );
+
     const execContext: ProcessorExecuteContext = {
       context,
       run,
@@ -137,6 +176,16 @@ const executeProcessor = async (
         threadId,
       });
       context.markProcessorSkipped(processor.name, threadId);
+      context.runState(threadId)?.recordAudit(
+        "processor.skipped",
+        {
+          processor: processor.name,
+          reason: keyExists
+            ? "dependencies-skipped"
+            : "dependencies-skipped-no-prior-run",
+        },
+        { phase: "processor", processor: processor.name }
+      );
     }
   }
 
@@ -199,6 +248,11 @@ const executeProcessor = async (
         threadId: item.threadId,
       });
       context.markProcessorSkipped(processor.name, item.threadId);
+      item.run.recordAudit(
+        "processor.skipped",
+        { hash: item.hash, processor: processor.name, reason: "idempotent" },
+        { phase: "processor", processor: processor.name }
+      );
     } else {
       toProcess.push(item);
     }
@@ -218,6 +272,7 @@ const executeProcessor = async (
         threadId: item.threadId,
       };
 
+      const processorStartedAt = performance.now();
       try {
         const result = await processor.execute(execContext);
 
@@ -229,6 +284,17 @@ const executeProcessor = async (
           );
         }
 
+        item.run.recordAudit(
+          result.success ? "processor.completed" : "processor.failed",
+          {
+            hash: item.hash,
+            processor: processor.name,
+            result: processorResultForAudit(result),
+            durationMs: performance.now() - processorStartedAt,
+          },
+          { phase: "processor", processor: processor.name }
+        );
+
         return { hash: item.hash, key: item.key, result };
       } catch (error) {
         const retryable = isRetryableError(error);
@@ -238,6 +304,17 @@ const executeProcessor = async (
           retryable,
           step: "processor.execute",
         });
+        item.run.recordAudit(
+          "processor.failed",
+          {
+            error,
+            hash: item.hash,
+            processor: processor.name,
+            retryable,
+            durationMs: performance.now() - processorStartedAt,
+          },
+          { phase: "processor", processor: processor.name }
+        );
         return {
           hash: item.hash,
           key: item.key,
@@ -294,6 +371,7 @@ export const executePipeline = async (
   });
   let status = 200;
   let jobId: string | undefined;
+  const audits = new Map<string, AgentRunAudit>();
 
   try {
     const pipelineJobId = await createPipelineJob(input.threadIds, options);
@@ -342,6 +420,63 @@ export const executePipeline = async (
       return result;
     }
 
+    const auditStart = input.audit;
+    const startedAudits = await Promise.all(
+      [...runStates.entries()].map(async ([threadId, run]) => {
+        const audit = await createAgentRunAudit({
+          attemptNumber: auditStart?.attemptNumber ?? 1,
+          bullmqJobId: auditStart?.bullmqJobId,
+          input,
+          options,
+          organizationId: run.organizationId,
+          pipelineJobId,
+          queueJobId: auditStart?.queueJobId,
+          queueName: auditStart?.queueName,
+          rawQueuePayload: auditStart?.rawQueuePayload,
+          threadId,
+        });
+        run.attachAudit(audit);
+        audit.record(
+          "run.started",
+          {
+            pipelineJobId,
+            threadId,
+            triggers: input.triggers ?? [],
+          },
+          { phase: "run" }
+        );
+        audit.record(
+          "trigger.received",
+          {
+            effectiveTriggers: input.triggers ?? [],
+            normalizedTriggers:
+              input.audit?.normalizedTriggers ?? input.triggers ?? [],
+            rawQueuePayload: input.audit?.rawQueuePayload ?? null,
+          },
+          { phase: "trigger" }
+        );
+        return [threadId, audit] as const;
+      })
+    );
+    for (const [threadId, audit] of startedAudits) {
+      audits.set(threadId, audit);
+      const normalizedTriggers =
+        input.audit?.normalizedTriggers ?? input.triggers ?? [];
+      const supersedeWasClearedBeforePipeline =
+        normalizedTriggers.some((trigger) => trigger.kind === "supersede") &&
+        !(input.triggers ?? []).some((trigger) => trigger.kind === "supersede");
+      if (supersedeWasClearedBeforePipeline) {
+        // Mixed supersede + synthesis jobs clear the previous read in the
+        // worker preflight, before this pipeline gets its RunState. Preserve
+        // that observable write in the same logical run's sequence.
+        audit.record(
+          "read.published",
+          { reason: "supersede", read: null, source: "worker_preflight" },
+          { phase: "supersede" }
+        );
+      }
+    }
+
     const context = new JobContext(pipelineJobId, input, options, runStates);
 
     const executionOrder = processorRegistry.resolveExecutionOrder();
@@ -353,6 +488,26 @@ export const executePipeline = async (
         turns: executionOrder,
       },
     });
+    for (const [threadId, audit] of audits) {
+      audit.record(
+        "pipeline.plan",
+        {
+          processorCount: totalProcessors,
+          turns: executionOrder,
+        },
+        { phase: "pipeline" }
+      );
+      audit.record(
+        "context.captured",
+        {
+          hints: runStates.get(threadId)?.hints() ?? {},
+          options,
+          thread: runStates.get(threadId)?.thread ?? null,
+          triggers: input.triggers ?? [],
+        },
+        { phase: "context" }
+      );
+    }
 
     const turns: TurnSummary[] = [];
     const turnLogSummaries: {
@@ -574,6 +729,14 @@ export const executePipeline = async (
       turns: [],
     };
   } finally {
+    await Promise.all(
+      [...audits.values()].map((audit) =>
+        audit.complete(status >= 500 ? "failed" : "completed", {
+          httpStatus: status,
+          pipelineJobId: jobId ?? null,
+        })
+      )
+    );
     requestLog.emit({ status });
   }
 };

--- a/apps/worker/src/pipeline/core/run-state.ts
+++ b/apps/worker/src/pipeline/core/run-state.ts
@@ -27,6 +27,11 @@ import { log } from "@workspace/utils/logging";
 import { fetchClient } from "../../lib/database/client";
 import { errorFields } from "../../lib/logging";
 import type { Thread } from "../../types";
+import type {
+  AgentRunAudit,
+  AgentRunEventMetadata,
+  AgentRunEventType,
+} from "./agent-run-audit";
 
 /** An organization label, as the label classifier consumes it. */
 export interface OrgLabel {
@@ -105,6 +110,7 @@ export class RunState {
   #autonomy?: Promise<Record<ActionKind, AutonomyLevel>>;
   #availability?: Promise<ActionAvailability>;
   #authors?: Promise<ResolvedMessageAuthors>;
+  #audit?: AgentRunAudit;
   #labels?: Promise<OrgLabel[]>;
   #lastAutonomousReply?: Promise<{ stateFingerprint: string } | null>;
 
@@ -113,6 +119,24 @@ export class RunState {
     this.threadId = thread.id;
     this.organizationId = thread.organizationId;
     this.#hints = { ...(thread.hints as Hints | null) };
+  }
+
+  /** Attach the forensic record after hydration has established its tenant. */
+  attachAudit(audit: AgentRunAudit): void {
+    this.#audit = audit;
+  }
+
+  /** Best-effort observation hook; it can never affect pipeline behavior. */
+  recordAudit(
+    type: AgentRunEventType,
+    payload: unknown,
+    metadata?: AgentRunEventMetadata
+  ): void {
+    this.#audit?.record(type, payload, metadata);
+  }
+
+  get audit(): AgentRunAudit | undefined {
+    return this.#audit;
   }
 
   /**
@@ -154,6 +178,12 @@ export class RunState {
     } as Parameters<typeof fetchClient.mutate.thread.writeHintSlot>[0]);
 
     this.#hints = { ...this.#hints, [kind]: slot };
+    this.recordAudit("hint.computed", {
+      evidence,
+      hash,
+      kind,
+      slot,
+    });
   }
 
   /**
@@ -166,6 +196,7 @@ export class RunState {
       organizationId: this.organizationId,
       threadId: this.threadId,
     });
+    this.recordAudit("read.published", { read });
   }
 
   /** Upserts an inline suggestion by id, server-side and transactional. */

--- a/apps/worker/src/pipeline/core/types.ts
+++ b/apps/worker/src/pipeline/core/types.ts
@@ -40,6 +40,16 @@ export interface PipelineJobOptions {
   scoreThreshold?: number;
 }
 
+export interface PipelineAuditInput {
+  attemptNumber?: number;
+  bullmqJobId?: string;
+  /** The normalized/coalesced causes before the pipeline removes supersede. */
+  normalizedTriggers?: ThreadReadTrigger[];
+  queueJobId?: string;
+  queueName?: string;
+  rawQueuePayload?: unknown;
+}
+
 export interface PipelineJobInput {
   threadIds: string[];
   /**
@@ -49,6 +59,8 @@ export interface PipelineJobInput {
    * because the worker enqueues one thread per job.
    */
   triggers?: ThreadReadTrigger[];
+  /** Queue identity used to link retries into one logical run record. */
+  audit?: PipelineAuditInput;
 }
 
 export interface ProcessorExecuteContext {

--- a/apps/worker/src/pipeline/core/types.ts
+++ b/apps/worker/src/pipeline/core/types.ts
@@ -45,6 +45,8 @@ export interface PipelineAuditInput {
   bullmqJobId?: string;
   /** The normalized/coalesced causes before the pipeline removes supersede. */
   normalizedTriggers?: ThreadReadTrigger[];
+  /** Queue generation: stable across BullMQ retries, new after a terminal requeue. */
+  queueGeneration?: number;
   queueJobId?: string;
   queueName?: string;
   rawQueuePayload?: unknown;

--- a/apps/worker/src/pipeline/core/types.ts
+++ b/apps/worker/src/pipeline/core/types.ts
@@ -47,7 +47,6 @@ export interface PipelineAuditInput {
   normalizedTriggers?: ThreadReadTrigger[];
   /** Queue generation: stable across BullMQ retries, new after a terminal requeue. */
   queueGeneration?: number;
-  queueJobId?: string;
   queueName?: string;
   rawQueuePayload?: unknown;
 }

--- a/apps/worker/src/pipeline/processors/embed-messages.ts
+++ b/apps/worker/src/pipeline/processors/embed-messages.ts
@@ -11,6 +11,7 @@ import type { WorkerLogger } from "../../lib/logging";
 import { messageIndex } from "../../lib/qdrant/messages";
 import type { MessagePayload } from "../../lib/qdrant/messages";
 import type { AgentRunAudit } from "../core/agent-run-audit";
+import { auditEmbedding } from "../core/model-audit";
 import type {
   ProcessorDefinition,
   ProcessorExecuteContext,
@@ -45,20 +46,11 @@ const generateMessageEmbedding = async (
     return null;
   }
 
-  const startedAt = performance.now();
-  const model = {
+  const span = auditEmbedding(audit, {
     modelId: EMBEDDING_MODEL,
-    provider: "google",
-  };
-  const modelMetadata = {
-    input: { chars: text.length, hash: computeSha256(text) },
-    kind: "embedding",
-    model,
-    providerOptions: { google: { taskType: "RETRIEVAL_DOCUMENT" } },
-  };
-  audit?.record("model.requested", modelMetadata, {
-    phase: "model",
     processor: "embed-messages",
+    taskType: "RETRIEVAL_DOCUMENT",
+    text,
   });
 
   try {
@@ -88,48 +80,15 @@ const generateMessageEmbedding = async (
           step: "normalize_embedding",
         }
       );
-      audit?.record(
-        "model.completed",
-        {
-          ...modelMetadata,
-          dimensions: embedding.length,
-          durationMs: performance.now() - startedAt,
-          embeddingHash: computeSha256(JSON.stringify(embedding)),
-          normalized: false,
-          status: "completed",
-          usage,
-        },
-        { phase: "model", processor: "embed-messages" }
-      );
+      span.completed(embedding, usage, { normalized: false });
       return embedding;
     }
 
-    const normalizedEmbedding = embedding.map((value) => value / norm);
-    audit?.record(
-      "model.completed",
-      {
-        ...modelMetadata,
-        dimensions: normalizedEmbedding.length,
-        durationMs: performance.now() - startedAt,
-        embeddingHash: computeSha256(JSON.stringify(normalizedEmbedding)),
-        normalized: true,
-        status: "completed",
-        usage,
-      },
-      { phase: "model", processor: "embed-messages" }
-    );
-    return normalizedEmbedding;
+    const normalized = embedding.map((value) => value / norm);
+    span.completed(normalized, usage, { normalized: true });
+    return normalized;
   } catch (error) {
-    audit?.record(
-      "model.failed",
-      {
-        ...modelMetadata,
-        durationMs: performance.now() - startedAt,
-        error,
-        status: "failed",
-      },
-      { phase: "model", processor: "embed-messages" }
-    );
+    span.failed(error);
     requestLog?.error(error instanceof Error ? error : String(error), {
       retryable: isRetryableError(error),
       step: "generate_message_embedding",

--- a/apps/worker/src/pipeline/processors/embed-messages.ts
+++ b/apps/worker/src/pipeline/processors/embed-messages.ts
@@ -4,11 +4,13 @@ import { google } from "@ai-sdk/google";
 import { createAILogger, createLogger } from "@workspace/utils/logging";
 import { jsonContentToPlainText, safeParseJSON } from "@workspace/utils/tiptap";
 import { embed } from "ai";
+
 import { AI_PRICING } from "../../lib/ai-pricing";
 import { isRetryableError } from "../../lib/logging";
 import type { WorkerLogger } from "../../lib/logging";
 import { messageIndex } from "../../lib/qdrant/messages";
 import type { MessagePayload } from "../../lib/qdrant/messages";
+import type { AgentRunAudit } from "../core/agent-run-audit";
 import type {
   ProcessorDefinition,
   ProcessorExecuteContext,
@@ -36,11 +38,28 @@ const computeSha256 = (data: string): string =>
 const generateMessageEmbedding = async (
   text: string,
   ai?: ReturnType<typeof createAILogger>,
-  requestLog?: WorkerLogger
+  requestLog?: WorkerLogger,
+  audit?: AgentRunAudit
 ): Promise<number[] | null> => {
   if (!text || text.trim().length === 0) {
     return null;
   }
+
+  const startedAt = performance.now();
+  const model = {
+    modelId: EMBEDDING_MODEL,
+    provider: "google",
+  };
+  const modelMetadata = {
+    input: { chars: text.length, hash: computeSha256(text) },
+    kind: "embedding",
+    model,
+    providerOptions: { google: { taskType: "RETRIEVAL_DOCUMENT" } },
+  };
+  audit?.record("model.requested", modelMetadata, {
+    phase: "model",
+    processor: "embed-messages",
+  });
 
   try {
     const { embedding, usage } = await embed({
@@ -69,11 +88,48 @@ const generateMessageEmbedding = async (
           step: "normalize_embedding",
         }
       );
+      audit?.record(
+        "model.completed",
+        {
+          ...modelMetadata,
+          dimensions: embedding.length,
+          durationMs: performance.now() - startedAt,
+          embeddingHash: computeSha256(JSON.stringify(embedding)),
+          normalized: false,
+          status: "completed",
+          usage,
+        },
+        { phase: "model", processor: "embed-messages" }
+      );
       return embedding;
     }
 
-    return embedding.map((value) => value / norm);
+    const normalizedEmbedding = embedding.map((value) => value / norm);
+    audit?.record(
+      "model.completed",
+      {
+        ...modelMetadata,
+        dimensions: normalizedEmbedding.length,
+        durationMs: performance.now() - startedAt,
+        embeddingHash: computeSha256(JSON.stringify(normalizedEmbedding)),
+        normalized: true,
+        status: "completed",
+        usage,
+      },
+      { phase: "model", processor: "embed-messages" }
+    );
+    return normalizedEmbedding;
   } catch (error) {
+    audit?.record(
+      "model.failed",
+      {
+        ...modelMetadata,
+        durationMs: performance.now() - startedAt,
+        error,
+        status: "failed",
+      },
+      { phase: "model", processor: "embed-messages" }
+    );
     requestLog?.error(error instanceof Error ? error : String(error), {
       retryable: isRetryableError(error),
       step: "generate_message_embedding",
@@ -190,7 +246,8 @@ export const embedMessagesProcessor: ProcessorDefinition<EmbedMessagesOutput> =
               const embedding = await generateMessageEmbedding(
                 plainText,
                 ai,
-                requestLog
+                requestLog,
+                context.run.audit
               );
               if (!embedding) return null;
               // Message ids are ULIDs and the index derives its point id from

--- a/apps/worker/src/pipeline/processors/embed.ts
+++ b/apps/worker/src/pipeline/processors/embed.ts
@@ -11,6 +11,7 @@ import { threadIndex } from "../../lib/qdrant/threads";
 import type { ThreadPayload } from "../../lib/qdrant/threads";
 import type { EmbedOutput, ParsedSummary, Thread } from "../../types";
 import type { AgentRunAudit } from "../core/agent-run-audit";
+import { auditEmbedding } from "../core/model-audit";
 import type {
   ProcessorDefinition,
   ProcessorExecuteContext,
@@ -50,20 +51,11 @@ const generateEmbedding = async (
     return null;
   }
 
-  const startedAt = performance.now();
-  const model = {
+  const span = auditEmbedding(audit, {
     modelId: EMBEDDING_MODEL,
-    provider: "google",
-  };
-  const modelMetadata = {
-    input: { chars: text.length, hash: computeSha256(text) },
-    kind: "embedding",
-    model,
-    providerOptions: { google: { taskType: "SEMANTIC_SIMILARITY" } },
-  };
-  audit?.record("model.requested", modelMetadata, {
-    phase: "model",
     processor: "embed",
+    taskType: "SEMANTIC_SIMILARITY",
+    text,
   });
 
   try {
@@ -94,48 +86,15 @@ const generateEmbedding = async (
           step: "normalize_embedding",
         }
       );
-      audit?.record(
-        "model.completed",
-        {
-          ...modelMetadata,
-          dimensions: embedding.length,
-          durationMs: performance.now() - startedAt,
-          embeddingHash: computeSha256(JSON.stringify(embedding)),
-          normalized: false,
-          status: "completed",
-          usage,
-        },
-        { phase: "model", processor: "embed" }
-      );
+      span.completed(embedding, usage, { normalized: false });
       return embedding;
     }
 
-    const normalizedEmbedding = embedding.map((value) => value / norm);
-    audit?.record(
-      "model.completed",
-      {
-        ...modelMetadata,
-        dimensions: normalizedEmbedding.length,
-        durationMs: performance.now() - startedAt,
-        embeddingHash: computeSha256(JSON.stringify(normalizedEmbedding)),
-        normalized: true,
-        status: "completed",
-        usage,
-      },
-      { phase: "model", processor: "embed" }
-    );
-    return normalizedEmbedding;
+    const normalized = embedding.map((value) => value / norm);
+    span.completed(normalized, usage, { normalized: true });
+    return normalized;
   } catch (error) {
-    audit?.record(
-      "model.failed",
-      {
-        ...modelMetadata,
-        durationMs: performance.now() - startedAt,
-        error,
-        status: "failed",
-      },
-      { phase: "model", processor: "embed" }
-    );
+    span.failed(error);
     requestLog?.error(error instanceof Error ? error : String(error), {
       retryable: isRetryableError(error),
       step: "generate_thread_embedding",

--- a/apps/worker/src/pipeline/processors/embed.ts
+++ b/apps/worker/src/pipeline/processors/embed.ts
@@ -10,6 +10,7 @@ import type { WorkerLogger } from "../../lib/logging";
 import { threadIndex } from "../../lib/qdrant/threads";
 import type { ThreadPayload } from "../../lib/qdrant/threads";
 import type { EmbedOutput, ParsedSummary, Thread } from "../../types";
+import type { AgentRunAudit } from "../core/agent-run-audit";
 import type {
   ProcessorDefinition,
   ProcessorExecuteContext,
@@ -42,11 +43,28 @@ const createSummaryText = (summary: ParsedSummary): string =>
 const generateEmbedding = async (
   text: string,
   ai?: ReturnType<typeof createAILogger>,
-  requestLog?: WorkerLogger
+  requestLog?: WorkerLogger,
+  audit?: AgentRunAudit
 ): Promise<number[] | null> => {
   if (!text || text.trim().length === 0) {
     return null;
   }
+
+  const startedAt = performance.now();
+  const model = {
+    modelId: EMBEDDING_MODEL,
+    provider: "google",
+  };
+  const modelMetadata = {
+    input: { chars: text.length, hash: computeSha256(text) },
+    kind: "embedding",
+    model,
+    providerOptions: { google: { taskType: "SEMANTIC_SIMILARITY" } },
+  };
+  audit?.record("model.requested", modelMetadata, {
+    phase: "model",
+    processor: "embed",
+  });
 
   try {
     const { embedding, usage } = await embed({
@@ -76,11 +94,48 @@ const generateEmbedding = async (
           step: "normalize_embedding",
         }
       );
+      audit?.record(
+        "model.completed",
+        {
+          ...modelMetadata,
+          dimensions: embedding.length,
+          durationMs: performance.now() - startedAt,
+          embeddingHash: computeSha256(JSON.stringify(embedding)),
+          normalized: false,
+          status: "completed",
+          usage,
+        },
+        { phase: "model", processor: "embed" }
+      );
       return embedding;
     }
 
-    return embedding.map((value) => value / norm);
+    const normalizedEmbedding = embedding.map((value) => value / norm);
+    audit?.record(
+      "model.completed",
+      {
+        ...modelMetadata,
+        dimensions: normalizedEmbedding.length,
+        durationMs: performance.now() - startedAt,
+        embeddingHash: computeSha256(JSON.stringify(normalizedEmbedding)),
+        normalized: true,
+        status: "completed",
+        usage,
+      },
+      { phase: "model", processor: "embed" }
+    );
+    return normalizedEmbedding;
   } catch (error) {
+    audit?.record(
+      "model.failed",
+      {
+        ...modelMetadata,
+        durationMs: performance.now() - startedAt,
+        error,
+        status: "failed",
+      },
+      { phase: "model", processor: "embed" }
+    );
     requestLog?.error(error instanceof Error ? error : String(error), {
       retryable: isRetryableError(error),
       step: "generate_thread_embedding",
@@ -204,7 +259,12 @@ export const embedProcessor: ProcessorDefinition<EmbedOutput> = {
 
       const summaryText = createSummaryText(summary);
 
-      const embedding = await generateEmbedding(summaryText, ai, requestLog);
+      const embedding = await generateEmbedding(
+        summaryText,
+        ai,
+        requestLog,
+        context.run.audit
+      );
 
       if (!embedding) {
         status = 500;

--- a/apps/worker/src/pipeline/processors/inline-track/label/classify.ts
+++ b/apps/worker/src/pipeline/processors/inline-track/label/classify.ts
@@ -91,17 +91,31 @@ Return the chosen label id (exactly as listed) or null. Confidence should reflec
   );
 
   const modelStartedAt = performance.now();
-  const result = await generateText({
-    model: ai ? ai.wrap(baseModel) : baseModel,
-    onStepFinish: (step) => {
-      audit?.record("model.step", serializeObservableModelStep(step), {
-        phase: "label_classifier",
-        stepIndex: step.stepNumber,
-      });
-    },
-    output: Output.object({ schema: responseSchema }),
-    prompt,
-  });
+  let result: Awaited<ReturnType<typeof generateText>>;
+  try {
+    result = await generateText({
+      model: ai ? ai.wrap(baseModel) : baseModel,
+      onStepFinish: (step) => {
+        audit?.record("model.step", serializeObservableModelStep(step), {
+          phase: "label_classifier",
+          stepIndex: step.stepNumber,
+        });
+      },
+      output: Output.object({ schema: responseSchema }),
+      prompt,
+    });
+  } catch (error) {
+    audit?.record(
+      "model.failed",
+      {
+        durationMs: performance.now() - modelStartedAt,
+        error,
+        status: "failed",
+      },
+      { phase: "label_classifier" }
+    );
+    throw error;
+  }
 
   audit?.record(
     "model.completed",

--- a/apps/worker/src/pipeline/processors/inline-track/label/classify.ts
+++ b/apps/worker/src/pipeline/processors/inline-track/label/classify.ts
@@ -3,6 +3,8 @@ import { generateText, Output } from "ai";
 import z from "zod";
 
 import { generationModel } from "../../../../lib/respan";
+import type { AgentRunAudit } from "../../../core/agent-run-audit";
+import { serializeObservableModelStep } from "../../../core/model-audit";
 import type { SummarizeOutput } from "../../summarize";
 
 export interface ClassifyLabelInput {
@@ -33,7 +35,8 @@ const responseSchema = z.object({
 
 export const classifyLabel = async (
   input: ClassifyLabelInput,
-  ai?: ReturnType<typeof createAILogger>
+  ai?: ReturnType<typeof createAILogger>,
+  audit?: AgentRunAudit
 ): Promise<ClassifyLabelResult> => {
   if (input.orgLabels.length === 0) {
     return { confidence: 0, labelId: null };
@@ -73,15 +76,47 @@ ${
 Return the chosen label id (exactly as listed) or null. Confidence should reflect how confident you are; use values below 0.5 when uncertain, above 0.85 only when the match is unambiguous.`;
 
   const baseModel = generationModel();
-  const { output } = await generateText({
+  audit?.record(
+    "model.requested",
+    {
+      input,
+      model: {
+        modelId: baseModel.modelId,
+        provider: baseModel.provider,
+      },
+      outputSchema: z.toJSONSchema(responseSchema),
+      prompt,
+    },
+    { phase: "label_classifier" }
+  );
+
+  const modelStartedAt = performance.now();
+  const result = await generateText({
     model: ai ? ai.wrap(baseModel) : baseModel,
+    onStepFinish: (step) => {
+      audit?.record("model.step", serializeObservableModelStep(step), {
+        phase: "label_classifier",
+        stepIndex: step.stepNumber,
+      });
+    },
     output: Output.object({ schema: responseSchema }),
     prompt,
   });
 
-  const valid = input.orgLabels.some((l) => l.id === output.labelId);
+  audit?.record(
+    "model.completed",
+    {
+      output: result.output,
+      text: result.text,
+      totalUsage: result.totalUsage,
+      durationMs: performance.now() - modelStartedAt,
+    },
+    { phase: "label_classifier" }
+  );
+
+  const valid = input.orgLabels.some((l) => l.id === result.output.labelId);
   return {
-    confidence: output.confidence,
-    labelId: valid ? output.labelId : null,
+    confidence: result.output.confidence,
+    labelId: valid ? result.output.labelId : null,
   };
 };

--- a/apps/worker/src/pipeline/processors/inline-track/label/processor.ts
+++ b/apps/worker/src/pipeline/processors/inline-track/label/processor.ts
@@ -129,7 +129,7 @@ export const labelClassifierProcessor: ProcessorDefinition<LabelClassifierOutput
         );
 
         if (!labelId || confidence < SUGGEST_THRESHOLD) {
-          const skipReason = labelId ? "below_threshold" : "no_label";
+          const skipReason = labelId ? "below_threshold" : "no_labels";
           run.recordAudit(
             "action.filtered",
             {
@@ -148,7 +148,7 @@ export const labelClassifierProcessor: ProcessorDefinition<LabelClassifierOutput
             data: {
               confidence,
               labelId: undefined,
-              skipped: labelId ? "below_threshold" : "no_labels",
+              skipped: skipReason,
             },
             success: true,
             threadId,

--- a/apps/worker/src/pipeline/processors/inline-track/label/processor.ts
+++ b/apps/worker/src/pipeline/processors/inline-track/label/processor.ts
@@ -25,6 +25,7 @@ export interface LabelClassifierOutput {
   skipped?:
     | "autonomy_off"
     | "no_labels"
+    | "no_label"
     | "below_threshold"
     | "already_applied";
   labelId?: string;
@@ -129,7 +130,7 @@ export const labelClassifierProcessor: ProcessorDefinition<LabelClassifierOutput
         );
 
         if (!labelId || confidence < SUGGEST_THRESHOLD) {
-          const skipReason = labelId ? "below_threshold" : "no_labels";
+          const skipReason = labelId ? "below_threshold" : "no_label";
           run.recordAudit(
             "action.filtered",
             {

--- a/apps/worker/src/pipeline/processors/inline-track/label/processor.ts
+++ b/apps/worker/src/pipeline/processors/inline-track/label/processor.ts
@@ -129,25 +129,26 @@ export const labelClassifierProcessor: ProcessorDefinition<LabelClassifierOutput
         );
 
         if (!labelId || confidence < SUGGEST_THRESHOLD) {
+          const skipReason = labelId ? "below_threshold" : "no_label";
           run.recordAudit(
             "action.filtered",
             {
               action: labelId ? { kind: "apply_label", labelId } : null,
               confidence,
-              reason: "below_threshold",
+              reason: skipReason,
               threshold: SUGGEST_THRESHOLD,
             },
             { phase: "label_classifier" }
           );
           requestLog.set({
             classification: { confidence, threshold: SUGGEST_THRESHOLD },
-            outcome: { status: "skipped", reason: "below_threshold" },
+            outcome: { status: "skipped", reason: skipReason },
           });
           return {
             data: {
               confidence,
               labelId: undefined,
-              skipped: "below_threshold",
+              skipped: labelId ? "below_threshold" : "no_labels",
             },
             success: true,
             threadId,

--- a/apps/worker/src/pipeline/processors/inline-track/label/processor.ts
+++ b/apps/worker/src/pipeline/processors/inline-track/label/processor.ts
@@ -66,6 +66,16 @@ export const labelClassifierProcessor: ProcessorDefinition<LabelClassifierOutput
 
       try {
         const autonomy = (await run.autonomy()).apply_label;
+        run.recordAudit(
+          "autonomy.policy",
+          {
+            actionKind: "apply_label",
+            autonomy,
+            suggestThreshold: SUGGEST_THRESHOLD,
+            autoThreshold: AUTO_THRESHOLD,
+          },
+          { phase: "label_classifier" }
+        );
         if (autonomy === "off") {
           requestLog.set({
             outcome: { status: "skipped", reason: "autonomy_off" },
@@ -114,10 +124,21 @@ export const labelClassifierProcessor: ProcessorDefinition<LabelClassifierOutput
             summary: summarizeOutput?.summary ?? null,
             threadName: thread.name ?? null,
           },
-          ai
+          ai,
+          run.audit
         );
 
         if (!labelId || confidence < SUGGEST_THRESHOLD) {
+          run.recordAudit(
+            "action.filtered",
+            {
+              action: labelId ? { kind: "apply_label", labelId } : null,
+              confidence,
+              reason: "below_threshold",
+              threshold: SUGGEST_THRESHOLD,
+            },
+            { phase: "label_classifier" }
+          );
           requestLog.set({
             classification: { confidence, threshold: SUGGEST_THRESHOLD },
             outcome: { status: "skipped", reason: "below_threshold" },
@@ -134,6 +155,15 @@ export const labelClassifierProcessor: ProcessorDefinition<LabelClassifierOutput
         }
 
         if (appliedLabelIds.has(labelId)) {
+          run.recordAudit(
+            "action.filtered",
+            {
+              action: { kind: "apply_label", labelId },
+              confidence,
+              reason: "already_applied",
+            },
+            { phase: "label_classifier" }
+          );
           requestLog.set({
             classification: {
               confidence,
@@ -167,6 +197,11 @@ export const labelClassifierProcessor: ProcessorDefinition<LabelClassifierOutput
                 ? result.failed.error
                 : new Error(String(result.failed.error));
             }
+            run.recordAudit(
+              "action.executed",
+              { action, result },
+              { phase: "label_classifier" }
+            );
             requestLog.set({
               classification: {
                 confidence,
@@ -181,6 +216,11 @@ export const labelClassifierProcessor: ProcessorDefinition<LabelClassifierOutput
               threadId,
             };
           } catch (error) {
+            run.recordAudit(
+              "action.failed",
+              { action, error },
+              { phase: "label_classifier" }
+            );
             // Same posture as the synthesis autonomy stage: a failed autonomous
             // execution falls back to the human rather than vanishing.
             requestLog.set({
@@ -203,6 +243,11 @@ export const labelClassifierProcessor: ProcessorDefinition<LabelClassifierOutput
           generator: "label_classifier",
           id: `label:${threadId}`,
         });
+        run.recordAudit(
+          "action.suggested",
+          { action, confidence, threshold: SUGGEST_THRESHOLD },
+          { phase: "label_classifier" }
+        );
 
         requestLog.set({
           classification: { confidence, labelId, threshold: SUGGEST_THRESHOLD },

--- a/apps/worker/src/pipeline/processors/summarize.ts
+++ b/apps/worker/src/pipeline/processors/summarize.ts
@@ -159,6 +159,7 @@ Think: "If another user has the exact same underlying problem with different wor
   let lastError: unknown;
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    let modelStartedAt: number | undefined;
     try {
       const baseModel = generationModel();
       audit?.record(
@@ -180,7 +181,7 @@ Think: "If another user has the exact same underlying problem with different wor
         { phase: "summarize", stepIndex: attempt }
       );
 
-      const modelStartedAt = performance.now();
+      modelStartedAt = performance.now();
       const result = await generateText({
         model: ai ? ai.wrap(baseModel) : baseModel,
         onStepFinish: (step) => {
@@ -221,6 +222,18 @@ Think: "If another user has the exact same underlying problem with different wor
       };
     } catch (error) {
       lastError = error;
+      if (modelStartedAt !== undefined) {
+        audit?.record(
+          "model.failed",
+          {
+            attempt: attempt + 1,
+            durationMs: performance.now() - modelStartedAt,
+            error,
+            status: "failed",
+          },
+          { phase: "summarize", stepIndex: attempt }
+        );
+      }
       const isLastAttempt = attempt === MAX_RETRIES - 1;
       const isRetryable = isRetryableError(error);
       const isRateLimit = isRateLimitError(error);

--- a/apps/worker/src/pipeline/processors/summarize.ts
+++ b/apps/worker/src/pipeline/processors/summarize.ts
@@ -11,6 +11,8 @@ import { isRetryableError } from "../../lib/logging";
 import type { WorkerLogger } from "../../lib/logging";
 import { generationModel } from "../../lib/respan";
 import type { ParsedSummary } from "../../types";
+import type { AgentRunAudit } from "../core/agent-run-audit";
+import { serializeObservableModelStep } from "../core/model-audit";
 import { hasSynthesisTrigger } from "../core/trigger-policy";
 import type {
   ProcessorDefinition,
@@ -84,7 +86,8 @@ export const summarizeThread = async (
     { messages: true; labels: { include: { label: true } } }
   >,
   ai?: ReturnType<typeof createAILogger>,
-  requestLog?: WorkerLogger
+  requestLog?: WorkerLogger,
+  audit?: AgentRunAudit
 ): Promise<ParsedSummary> => {
   requestLog?.set({
     input: {
@@ -158,25 +161,63 @@ Think: "If another user has the exact same underlying problem with different wor
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
       const baseModel = generationModel();
-      const { output } = await generateText({
+      audit?.record(
+        "model.requested",
+        {
+          attempt: attempt + 1,
+          input: {
+            appliedLabels: activeLabels || null,
+            firstMessage: firstMessage?.content ?? null,
+            threadName: thread.name ?? null,
+          },
+          model: {
+            modelId: baseModel.modelId,
+            provider: baseModel.provider,
+          },
+          outputSchema: z.toJSONSchema(summarySchema),
+          prompt,
+        },
+        { phase: "summarize", stepIndex: attempt }
+      );
+
+      const modelStartedAt = performance.now();
+      const result = await generateText({
         model: ai ? ai.wrap(baseModel) : baseModel,
+        onStepFinish: (step) => {
+          audit?.record("model.step", serializeObservableModelStep(step), {
+            phase: "summarize",
+            stepIndex: attempt,
+          });
+        },
         output: Output.object({ schema: summarySchema }),
         prompt,
       });
 
+      audit?.record(
+        "model.completed",
+        {
+          attempt: attempt + 1,
+          output: result.output,
+          text: result.text,
+          totalUsage: result.totalUsage,
+          durationMs: performance.now() - modelStartedAt,
+        },
+        { phase: "summarize", stepIndex: attempt }
+      );
+
       requestLog?.set({
         output: {
-          entityCount: output.entities.length,
-          keywordCount: output.keywords.length,
-          hasTitle: output.title.trim().length > 0,
+          entityCount: result.output.entities.length,
+          keywordCount: result.output.keywords.length,
+          hasTitle: result.output.title.trim().length > 0,
         },
       });
       return {
-        entities: output.entities,
-        expectedAction: output.expectedAction,
-        keywords: output.keywords,
-        shortDescription: output.shortDescription,
-        title: output.title,
+        entities: result.output.entities,
+        expectedAction: result.output.expectedAction,
+        keywords: result.output.keywords,
+        shortDescription: result.output.shortDescription,
+        title: result.output.title,
       };
     } catch (error) {
       lastError = error;
@@ -259,7 +300,12 @@ export const summarizeProcessor: ProcessorDefinition<SummarizeOutput> = {
     let status = 200;
 
     try {
-      const summary = await summarizeThread(thread, ai, requestLog);
+      const summary = await summarizeThread(
+        thread,
+        ai,
+        requestLog,
+        context.run.audit
+      );
 
       if (!summary || !summary.title || summary.title.trim().length === 0) {
         status = 500;

--- a/apps/worker/src/pipeline/processors/synthesis-track/define-retrieval-hint.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/define-retrieval-hint.ts
@@ -5,6 +5,7 @@ import { createLogger } from "@workspace/utils/logging";
 
 import { isRetryableError } from "../../../lib/logging";
 import type { EmbedOutput, ParsedSummary, Thread } from "../../../types";
+import type { AgentRunAudit } from "../../core/agent-run-audit";
 import type { SlotEvidenceMap } from "../../core/run-state";
 import type {
   ProcessorDefinition,
@@ -38,6 +39,7 @@ export interface RetrievalTuning {
 }
 
 export interface RetrievalInput {
+  audit?: AgentRunAudit;
   thread: Thread;
   organizationId: string;
   /** Thread embedding, or null when `embed` produced none. */
@@ -157,9 +159,7 @@ export const defineRetrievalHint = <K extends HintKind, THit>(
         }
 
         const summary = summaryOf(context);
-        const hash = computeSha256(
-          summary ? summaryHashInput(summary) : ""
-        );
+        const hash = computeSha256(summary ? summaryHashInput(summary) : "");
 
         const embedding =
           jobContext.getProcessorOutput<EmbedOutput>("embed", threadId)
@@ -177,6 +177,7 @@ export const defineRetrievalHint = <K extends HintKind, THit>(
         }
 
         const hits = await spec.retrieve({
+          audit: run.audit,
           embedding,
           organizationId: thread.organizationId,
           summary,
@@ -191,9 +192,7 @@ export const defineRetrievalHint = <K extends HintKind, THit>(
         requestLog.set({
           outcome: {
             status: "completed",
-            evidenceCount: evidence
-              ? (spec.count?.(evidence) ?? 1)
-              : 0,
+            evidenceCount: evidence ? (spec.count?.(evidence) ?? 1) : 0,
           },
           search: {
             candidateCount: hits.length,

--- a/apps/worker/src/pipeline/processors/synthesis-track/related_docs/processor.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/related_docs/processor.ts
@@ -36,14 +36,18 @@ export const relatedDocsHintSpec: RetrievalHintSpec<
 
   requiresEmbedding: false,
 
-  async retrieve({ organizationId, summary, tuning }) {
+  async retrieve({ audit, organizationId, summary, tuning }) {
     const query = summary ? buildSearchQuery(summary) : "";
     // An absent query legitimately means "no evidence" and clears the hint. A
     // query that fails to embed does not — throw, so the prior hint survives.
     if (query.length === 0) {
       return [];
     }
-    const vector = await generateDocumentationQueryEmbedding(query);
+    const vector = await generateDocumentationQueryEmbedding(
+      query,
+      audit,
+      "related_docs"
+    );
     if (!vector) {
       throw new Error("Failed to embed documentation search query");
     }

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/processor.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/processor.ts
@@ -60,25 +60,18 @@ export const synthesisProcessor: ProcessorDefinition<SynthesisProcessorOutput> =
         "summarize",
         threadId
       );
-      const duplicate = jobContext.getProcessorOutput<RetrievalHintOutput<"duplicate">>(
-        "duplicate",
-        threadId
-      );
-      const relatedDocs =
-        jobContext.getProcessorOutput<RetrievalHintOutput<"related_docs">>(
-          "related_docs",
-          threadId
-        );
-      const relatedPrs =
-        jobContext.getProcessorOutput<RetrievalHintOutput<"related_prs">>(
-          "related_prs",
-          threadId
-        );
-      const relatedIssues =
-        jobContext.getProcessorOutput<RetrievalHintOutput<"related_issues">>(
-          "related_issues",
-          threadId
-        );
+      const duplicate = jobContext.getProcessorOutput<
+        RetrievalHintOutput<"duplicate">
+      >("duplicate", threadId);
+      const relatedDocs = jobContext.getProcessorOutput<
+        RetrievalHintOutput<"related_docs">
+      >("related_docs", threadId);
+      const relatedPrs = jobContext.getProcessorOutput<
+        RetrievalHintOutput<"related_prs">
+      >("related_prs", threadId);
+      const relatedIssues = jobContext.getProcessorOutput<
+        RetrievalHintOutput<"related_issues">
+      >("related_issues", threadId);
 
       const hashInput = [
         thread.id,
@@ -186,6 +179,7 @@ export const synthesisProcessor: ProcessorDefinition<SynthesisProcessorOutput> =
         const availability = await run.availability();
 
         const tools = createSynthesisTools({
+          audit: run.audit,
           organizationId: thread.organizationId,
           currentThreadId: threadId,
           currentThread: thread,
@@ -215,7 +209,8 @@ export const synthesisProcessor: ProcessorDefinition<SynthesisProcessorOutput> =
           },
           tools,
           ai,
-          requestLog
+          requestLog,
+          run.audit
         );
 
         const rawActionSet = normalizeSynthesisRawActionSet({

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
@@ -20,6 +20,11 @@ import z from "zod";
 import type { WorkerLogger } from "../../../../lib/logging";
 import { generationModel } from "../../../../lib/respan";
 import type { ParsedSummary } from "../../../../types";
+import type {
+  AgentRunAudit,
+  AgentRunEventMetadata,
+} from "../../../core/agent-run-audit";
+import { serializeObservableModelStep } from "../../../core/model-audit";
 import {
   collectRetrievedDocUrls,
   verifyReplyGrounding,
@@ -42,6 +47,31 @@ const baseSynthesisActionSchemas = [
   linkIssueActionSchema,
   setStatusActionSchema,
 ] as const;
+
+const describeTool = (name: string, definition: unknown) => {
+  const candidate = definition as {
+    description?: unknown;
+    inputSchema?: unknown;
+  };
+  let inputSchema: unknown = candidate.inputSchema ?? null;
+
+  if (inputSchema && typeof inputSchema === "object") {
+    try {
+      inputSchema = z.toJSONSchema(inputSchema as z.ZodType);
+    } catch {
+      // A provider-native JSON schema is already useful as-is. If it is not
+      // serializable either, the tool name and description still explain what
+      // the model was allowed to call.
+    }
+  }
+
+  return {
+    description:
+      typeof candidate.description === "string" ? candidate.description : null,
+    inputSchema,
+    name,
+  };
+};
 
 /**
  * The parse schema is shaped by [action availability](../../../../CONTEXT.md):
@@ -144,7 +174,8 @@ export const synthesizeThreadRead = async (
   input: SynthesizeThreadReadInput,
   tools: ReturnType<typeof createSynthesisTools>,
   ai?: ReturnType<typeof createAILogger>,
-  requestLog?: WorkerLogger
+  requestLog?: WorkerLogger,
+  audit?: AgentRunAudit
 ): Promise<SynthesisRawActionSet> => {
   // One JSON object per line, content included as a JSON string value rather
   // than interpolated next to the metadata. `customer_confirmed` is a claim
@@ -435,14 +466,95 @@ Return a single valid JSON object with exactly this shape:
 `;
 
   const baseModel = generationModel();
+  const toolDefinitions = Object.entries(tools).map(([name, definition]) =>
+    describeTool(name, definition)
+  );
+  const auditStepMetadata = (stepIndex?: number): AgentRunEventMetadata => ({
+    phase: "synthesis",
+    ...(stepIndex === undefined ? {} : { stepIndex }),
+  });
+
+  audit?.record(
+    "model.requested",
+    {
+      input,
+      model: {
+        modelId: baseModel.modelId,
+        provider: baseModel.provider,
+      },
+      prompt,
+      stopWhen: "stepCountIs(8)",
+      tools: toolDefinitions,
+    },
+    auditStepMetadata()
+  );
+
+  const modelStartedAt = performance.now();
   const { text, steps } = await generateText({
+    onToolExecutionEnd: (event) => {
+      audit?.record(
+        "tool.completed",
+        {
+          callId: event.callId,
+          durationMs: event.toolExecutionMs,
+          error:
+            event.toolOutput.type === "tool-error"
+              ? event.toolOutput.error
+              : null,
+          output:
+            event.toolOutput.type === "tool-result"
+              ? event.toolOutput.output
+              : null,
+          success: event.toolOutput.type === "tool-result",
+          toolCall: event.toolCall,
+        },
+        {
+          ...auditStepMetadata(),
+          toolCallId: event.toolCall.toolCallId,
+        }
+      );
+    },
+    onToolExecutionStart: (event) => {
+      audit?.record(
+        "tool.called",
+        {
+          callId: event.callId,
+          toolCall: event.toolCall,
+        },
+        {
+          ...auditStepMetadata(),
+          toolCallId: event.toolCall.toolCallId,
+        }
+      );
+    },
     model: ai ? ai.wrap(baseModel) : baseModel,
+    onStepFinish: (step) => {
+      audit?.record(
+        "model.step",
+        serializeObservableModelStep(step),
+        auditStepMetadata(step.stepNumber)
+      );
+    },
     prompt,
     stopWhen: stepCountIs(8),
     tools,
   });
 
+  const lastStep = steps.at(-1);
+  audit?.record(
+    "model.completed",
+    {
+      step: lastStep ? serializeObservableModelStep(lastStep) : null,
+      steps: steps.map(serializeObservableModelStep),
+      text,
+      totalUsage: steps.map((step) => step.usage),
+      durationMs: performance.now() - modelStartedAt,
+    },
+    auditStepMetadata()
+  );
+
   const raw = parseRawActionSetFromText(text, input.availability, requestLog);
+  audit?.record("output.parsed", { raw, text }, auditStepMetadata());
   // Trust boundary: only allow link_pr URLs returned by a successful read_pr.
   // Prompt instructions alone cannot authorize an external PR link. If primary
   // loses a link_pr, discard the set so recommendation stays consistent.

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
@@ -490,55 +490,72 @@ Return a single valid JSON object with exactly this shape:
   );
 
   const modelStartedAt = performance.now();
-  const { text, steps } = await generateText({
-    onToolExecutionEnd: (event) => {
-      audit?.record(
-        "tool.completed",
-        {
-          callId: event.callId,
-          durationMs: event.toolExecutionMs,
-          error:
-            event.toolOutput.type === "tool-error"
-              ? event.toolOutput.error
-              : null,
-          output:
-            event.toolOutput.type === "tool-result"
-              ? event.toolOutput.output
-              : null,
-          success: event.toolOutput.type === "tool-result",
-          toolCall: event.toolCall,
+  const generationResult = await (async () => {
+    try {
+      return await generateText({
+        onToolExecutionEnd: (event) => {
+          audit?.record(
+            "tool.completed",
+            {
+              callId: event.callId,
+              durationMs: event.toolExecutionMs,
+              error:
+                event.toolOutput.type === "tool-error"
+                  ? event.toolOutput.error
+                  : null,
+              output:
+                event.toolOutput.type === "tool-result"
+                  ? event.toolOutput.output
+                  : null,
+              success: event.toolOutput.type === "tool-result",
+              toolCall: event.toolCall,
+            },
+            {
+              ...auditStepMetadata(),
+              toolCallId: event.toolCall.toolCallId,
+            }
+          );
         },
-        {
-          ...auditStepMetadata(),
-          toolCallId: event.toolCall.toolCallId,
-        }
-      );
-    },
-    onToolExecutionStart: (event) => {
-      audit?.record(
-        "tool.called",
-        {
-          callId: event.callId,
-          toolCall: event.toolCall,
+        onToolExecutionStart: (event) => {
+          audit?.record(
+            "tool.called",
+            {
+              callId: event.callId,
+              toolCall: event.toolCall,
+            },
+            {
+              ...auditStepMetadata(),
+              toolCallId: event.toolCall.toolCallId,
+            }
+          );
         },
-        {
-          ...auditStepMetadata(),
-          toolCallId: event.toolCall.toolCallId,
-        }
-      );
-    },
-    model: ai ? ai.wrap(baseModel) : baseModel,
-    onStepFinish: (step) => {
+        model: ai ? ai.wrap(baseModel) : baseModel,
+        onStepFinish: (step) => {
+          audit?.record(
+            "model.step",
+            serializeObservableModelStep(step),
+            auditStepMetadata(step.stepNumber)
+          );
+        },
+        prompt,
+        stopWhen: stepCountIs(8),
+        tools,
+      });
+    } catch (error) {
       audit?.record(
-        "model.step",
-        serializeObservableModelStep(step),
-        auditStepMetadata(step.stepNumber)
+        "model.failed",
+        {
+          durationMs: performance.now() - modelStartedAt,
+          error,
+          status: "failed",
+        },
+        auditStepMetadata()
       );
-    },
-    prompt,
-    stopWhen: stepCountIs(8),
-    tools,
-  });
+      throw error;
+    }
+  })();
+
+  const { text, steps, totalUsage } = generationResult;
 
   const lastStep = steps.at(-1);
   audit?.record(
@@ -547,7 +564,7 @@ Return a single valid JSON object with exactly this shape:
       step: lastStep ? serializeObservableModelStep(lastStep) : null,
       steps: steps.map(serializeObservableModelStep),
       text,
-      totalUsage: steps.map((step) => step.usage),
+      totalUsage,
       durationMs: performance.now() - modelStartedAt,
     },
     auditStepMetadata()

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
@@ -20,10 +20,7 @@ import z from "zod";
 import type { WorkerLogger } from "../../../../lib/logging";
 import { generationModel } from "../../../../lib/respan";
 import type { ParsedSummary } from "../../../../types";
-import type {
-  AgentRunAudit,
-  AgentRunEventMetadata,
-} from "../../../core/agent-run-audit";
+import type { AgentRunAudit } from "../../../core/agent-run-audit";
 import { serializeObservableModelStep } from "../../../core/model-audit";
 import {
   collectRetrievedDocUrls,
@@ -469,10 +466,7 @@ Return a single valid JSON object with exactly this shape:
   const toolDefinitions = Object.entries(tools).map(([name, definition]) =>
     describeTool(name, definition)
   );
-  const auditStepMetadata = (stepIndex?: number): AgentRunEventMetadata => ({
-    phase: "synthesis",
-    ...(stepIndex === undefined ? {} : { stepIndex }),
-  });
+  const inSynthesis = { phase: "synthesis" } as const;
 
   audit?.record(
     "model.requested",
@@ -486,92 +480,79 @@ Return a single valid JSON object with exactly this shape:
       stopWhen: "stepCountIs(8)",
       tools: toolDefinitions,
     },
-    auditStepMetadata()
+    inSynthesis
   );
 
   const modelStartedAt = performance.now();
-  const generationResult = await (async () => {
-    try {
-      return await generateText({
-        onToolExecutionEnd: (event) => {
-          audit?.record(
-            "tool.completed",
-            {
-              callId: event.callId,
-              durationMs: event.toolExecutionMs,
-              error:
-                event.toolOutput.type === "tool-error"
-                  ? event.toolOutput.error
-                  : null,
-              output:
-                event.toolOutput.type === "tool-result"
-                  ? event.toolOutput.output
-                  : null,
-              success: event.toolOutput.type === "tool-result",
-              toolCall: event.toolCall,
-            },
-            {
-              ...auditStepMetadata(),
-              toolCallId: event.toolCall.toolCallId,
-            }
-          );
-        },
-        onToolExecutionStart: (event) => {
-          audit?.record(
-            "tool.called",
-            {
-              callId: event.callId,
-              toolCall: event.toolCall,
-            },
-            {
-              ...auditStepMetadata(),
-              toolCallId: event.toolCall.toolCallId,
-            }
-          );
-        },
-        model: ai ? ai.wrap(baseModel) : baseModel,
-        onStepFinish: (step) => {
-          audit?.record(
-            "model.step",
-            serializeObservableModelStep(step),
-            auditStepMetadata(step.stepNumber)
-          );
-        },
-        prompt,
-        stopWhen: stepCountIs(8),
-        tools,
-      });
-    } catch (error) {
-      audit?.record(
-        "model.failed",
-        {
-          durationMs: performance.now() - modelStartedAt,
-          error,
-          status: "failed",
-        },
-        auditStepMetadata()
-      );
-      throw error;
-    }
-  })();
+  let text: string;
+  let steps: Awaited<ReturnType<typeof generateText>>["steps"];
+  let totalUsage: Awaited<ReturnType<typeof generateText>>["totalUsage"];
+  try {
+    ({ text, steps, totalUsage } = await generateText({
+      onToolExecutionEnd: (event) => {
+        audit?.record(
+          "tool.completed",
+          {
+            callId: event.callId,
+            durationMs: event.toolExecutionMs,
+            error:
+              event.toolOutput.type === "tool-error"
+                ? event.toolOutput.error
+                : null,
+            output:
+              event.toolOutput.type === "tool-result"
+                ? event.toolOutput.output
+                : null,
+            success: event.toolOutput.type === "tool-result",
+            toolCall: event.toolCall,
+          },
+          { ...inSynthesis, toolCallId: event.toolCall.toolCallId }
+        );
+      },
+      onToolExecutionStart: (event) => {
+        audit?.record(
+          "tool.called",
+          { callId: event.callId, toolCall: event.toolCall },
+          { ...inSynthesis, toolCallId: event.toolCall.toolCallId }
+        );
+      },
+      model: ai ? ai.wrap(baseModel) : baseModel,
+      onStepFinish: (step) => {
+        audit?.record("model.step", serializeObservableModelStep(step), {
+          ...inSynthesis,
+          stepIndex: step.stepNumber,
+        });
+      },
+      prompt,
+      stopWhen: stepCountIs(8),
+      tools,
+    }));
+  } catch (error) {
+    audit?.record(
+      "model.failed",
+      {
+        durationMs: performance.now() - modelStartedAt,
+        error,
+        status: "failed",
+      },
+      inSynthesis
+    );
+    throw error;
+  }
 
-  const { text, steps, totalUsage } = generationResult;
-
-  const lastStep = steps.at(-1);
   audit?.record(
     "model.completed",
     {
-      step: lastStep ? serializeObservableModelStep(lastStep) : null,
       steps: steps.map(serializeObservableModelStep),
       text,
       totalUsage,
       durationMs: performance.now() - modelStartedAt,
     },
-    auditStepMetadata()
+    inSynthesis
   );
 
   const raw = parseRawActionSetFromText(text, input.availability, requestLog);
-  audit?.record("output.parsed", { raw, text }, auditStepMetadata());
+  audit?.record("output.parsed", { raw, text }, inSynthesis);
   // Trust boundary: only allow link_pr URLs returned by a successful read_pr.
   // Prompt instructions alone cannot authorize an external PR link. If primary
   // loses a link_pr, discard the set so recommendation stays consistent.

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/tools.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/tools.ts
@@ -14,6 +14,7 @@ import {
   issueIndex,
 } from "../../../../lib/qdrant/issues";
 import type { Thread } from "../../../../types";
+import type { AgentRunAudit } from "../../../core/agent-run-audit";
 
 /**
  * What `search_documentation` hands the synthesis agent. Flat and id-free by
@@ -38,6 +39,7 @@ export interface DocumentationPageChunkResult {
 }
 
 interface CreateSynthesisToolsOptions {
+  audit?: AgentRunAudit;
   organizationId: string;
   currentThreadId: string;
   currentThread: Thread;
@@ -54,7 +56,7 @@ const toOrderedMessages = (thread: Thread) =>
     }));
 
 export const createSynthesisTools = (options: CreateSynthesisToolsOptions) => {
-  const { organizationId, currentThreadId, currentThread } = options;
+  const { audit, organizationId, currentThreadId, currentThread } = options;
 
   return {
     read_documentation_page: tool({
@@ -230,7 +232,11 @@ export const createSynthesisTools = (options: CreateSynthesisToolsOptions) => {
         // and failing it would abort the whole synthesis run.
         let results: Awaited<ReturnType<typeof issueIndex.search>>;
         try {
-          const vector = await generateSimilarityEmbedding(query);
+          const vector = await generateSimilarityEmbedding(
+            query,
+            undefined,
+            audit
+          );
           if (!vector) {
             return { hits: [] };
           }
@@ -267,7 +273,10 @@ export const createSynthesisTools = (options: CreateSynthesisToolsOptions) => {
         // Same reasoning as `search_issues`: degrade to no hits rather than
         // aborting the synthesis run on a backend failure.
         try {
-          const vector = await generateDocumentationQueryEmbedding(query);
+          const vector = await generateDocumentationQueryEmbedding(
+            query,
+            audit
+          );
           if (!vector) {
             return { hits: [] };
           }

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -35,6 +35,8 @@ import { issueIndex } from "./lib/qdrant/issues";
 import { messageIndex } from "./lib/qdrant/messages";
 import { prIndex } from "./lib/qdrant/pull-requests";
 import { threadIndex } from "./lib/qdrant/threads";
+import { createAgentRunAudit } from "./pipeline/core/agent-run-audit";
+import type { AgentRunAudit } from "./pipeline/core/agent-run-audit";
 import { executePipeline } from "./pipeline/core/orchestrator";
 import { hydrateRunStates } from "./pipeline/core/run-state";
 import { registerDefaultProcessors } from "./pipeline/processors/registration";
@@ -116,6 +118,7 @@ const handleThreadReadJob = async (job: Job<ThreadReadJobData>) => {
     }
   );
   let status = 200;
+  let supersedeAudit: AgentRunAudit | undefined;
 
   try {
     if (!threadId) {
@@ -135,6 +138,38 @@ const handleThreadReadJob = async (job: Job<ThreadReadJobData>) => {
     const supersedeCleared = hasSupersede
       ? await (async () => {
           const run = (await hydrateRunStates([threadId])).get(threadId);
+          if (run && synthesisTriggers.length === 0) {
+            supersedeAudit = await createAgentRunAudit({
+              attemptNumber: job.attemptsMade + 1,
+              bullmqJobId: job.id === undefined ? undefined : String(job.id),
+              input: {
+                audit: { normalizedTriggers: triggers },
+                threadIds: [threadId],
+                triggers,
+              },
+              options: {},
+              organizationId: run.organizationId,
+              queueJobId: job.id === undefined ? undefined : String(job.id),
+              queueName: THREAD_PIPELINE_QUEUE,
+              rawQueuePayload: job.data,
+              threadId,
+            });
+            run.attachAudit(supersedeAudit);
+            supersedeAudit.record(
+              "run.started",
+              { reason: "supersede", threadId, triggers },
+              { phase: "run" }
+            );
+            supersedeAudit.record(
+              "trigger.received",
+              {
+                effectiveTriggers: [],
+                normalizedTriggers: triggers,
+                rawQueuePayload: job.data,
+              },
+              { phase: "trigger" }
+            );
+          }
           await run?.publishRead(null);
           return Boolean(run);
         })()
@@ -155,6 +190,14 @@ const handleThreadReadJob = async (job: Job<ThreadReadJobData>) => {
     }
 
     const result = await executePipeline({
+      audit: {
+        attemptNumber: job.attemptsMade + 1,
+        bullmqJobId: job.id === undefined ? undefined : String(job.id),
+        normalizedTriggers: triggers,
+        queueJobId: job.id === undefined ? undefined : String(job.id),
+        queueName: THREAD_PIPELINE_QUEUE,
+        rawQueuePayload: job.data,
+      },
       threadIds: [threadId],
       triggers: synthesisTriggers,
     });
@@ -212,6 +255,10 @@ const handleThreadReadJob = async (job: Job<ThreadReadJobData>) => {
     });
     throw error;
   } finally {
+    await supersedeAudit?.complete(status >= 500 ? "failed" : "completed", {
+      reason: "supersede",
+      status,
+    });
     requestLog.emit({ status });
   }
 };

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -95,7 +95,11 @@ configureThreadReadQueue({ connection });
  * current read first and bypass synthesis when no other cause was coalesced.
  */
 const handleThreadReadJob = async (job: Job<ThreadReadJobData>) => {
-  const { threadId, triggers } = normalizeThreadReadJobData(job.data);
+  const {
+    generation: queueGeneration,
+    threadId,
+    triggers,
+  } = normalizeThreadReadJobData(job.data);
   const loggedThreadId = threadId || "missing";
 
   const requestLog = createWorkerJobLogger(
@@ -149,6 +153,7 @@ const handleThreadReadJob = async (job: Job<ThreadReadJobData>) => {
               },
               options: {},
               organizationId: run.organizationId,
+              queueGeneration,
               queueJobId: job.id === undefined ? undefined : String(job.id),
               queueName: THREAD_PIPELINE_QUEUE,
               rawQueuePayload: job.data,
@@ -194,6 +199,7 @@ const handleThreadReadJob = async (job: Job<ThreadReadJobData>) => {
         attemptNumber: job.attemptsMade + 1,
         bullmqJobId: job.id === undefined ? undefined : String(job.id),
         normalizedTriggers: triggers,
+        queueGeneration,
         queueJobId: job.id === undefined ? undefined : String(job.id),
         queueName: THREAD_PIPELINE_QUEUE,
         rawQueuePayload: job.data,

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -10,6 +10,7 @@ import type {
   PrIndexJobData,
   PrMatchJobData,
   ThreadReadJobData,
+  ThreadReadTrigger,
 } from "@workspace/schemas/signals";
 import { normalizeThreadReadJobData } from "@workspace/schemas/signals";
 import {
@@ -39,6 +40,7 @@ import { createAgentRunAudit } from "./pipeline/core/agent-run-audit";
 import type { AgentRunAudit } from "./pipeline/core/agent-run-audit";
 import { executePipeline } from "./pipeline/core/orchestrator";
 import { hydrateRunStates } from "./pipeline/core/run-state";
+import type { RunState } from "./pipeline/core/run-state";
 import { registerDefaultProcessors } from "./pipeline/processors/registration";
 
 const THREAD_PIPELINE_QUEUE = "thread-pipeline";
@@ -90,6 +92,56 @@ if (!connection) {
 configureThreadReadQueue({ connection });
 
 /**
+ * A supersede that coalesced with no other cause never reaches the pipeline, so
+ * it opens its own run record here — otherwise the read it clears would leave
+ * no trace in the ledger at all.
+ */
+const startSupersedeAudit = async (
+  run: RunState,
+  job: Job<ThreadReadJobData>,
+  identity: {
+    bullmqJobId?: string;
+    queueGeneration?: number;
+    threadId: string;
+    triggers: ThreadReadTrigger[];
+  }
+): Promise<AgentRunAudit> => {
+  const { threadId, triggers } = identity;
+  const audit = await createAgentRunAudit({
+    attemptNumber: job.attemptsMade + 1,
+    bullmqJobId: identity.bullmqJobId,
+    input: {
+      audit: { normalizedTriggers: triggers },
+      threadIds: [threadId],
+      triggers,
+    },
+    options: {},
+    organizationId: run.organizationId,
+    queueGeneration: identity.queueGeneration,
+    queueName: THREAD_PIPELINE_QUEUE,
+    rawQueuePayload: job.data,
+    threadId,
+  });
+
+  run.attachAudit(audit);
+  audit.record(
+    "run.started",
+    { reason: "supersede", threadId, triggers },
+    { phase: "run" }
+  );
+  audit.record(
+    "trigger.received",
+    {
+      effectiveTriggers: [],
+      normalizedTriggers: triggers,
+      rawQueuePayload: job.data,
+    },
+    { phase: "trigger" }
+  );
+  return audit;
+};
+
+/**
  * Handler for thread-pipeline jobs
  * Runs the full thread pipeline for a single thread. Supersede causes clear the
  * current read first and bypass synthesis when no other cause was coalesced.
@@ -101,6 +153,7 @@ const handleThreadReadJob = async (job: Job<ThreadReadJobData>) => {
     triggers,
   } = normalizeThreadReadJobData(job.data);
   const loggedThreadId = threadId || "missing";
+  const bullmqJobId = job.id === undefined ? undefined : String(job.id);
 
   const requestLog = createWorkerJobLogger(
     THREAD_PIPELINE_QUEUE,
@@ -143,37 +196,12 @@ const handleThreadReadJob = async (job: Job<ThreadReadJobData>) => {
       ? await (async () => {
           const run = (await hydrateRunStates([threadId])).get(threadId);
           if (run && synthesisTriggers.length === 0) {
-            supersedeAudit = await createAgentRunAudit({
-              attemptNumber: job.attemptsMade + 1,
-              bullmqJobId: job.id === undefined ? undefined : String(job.id),
-              input: {
-                audit: { normalizedTriggers: triggers },
-                threadIds: [threadId],
-                triggers,
-              },
-              options: {},
-              organizationId: run.organizationId,
+            supersedeAudit = await startSupersedeAudit(run, job, {
+              bullmqJobId,
               queueGeneration,
-              queueJobId: job.id === undefined ? undefined : String(job.id),
-              queueName: THREAD_PIPELINE_QUEUE,
-              rawQueuePayload: job.data,
               threadId,
+              triggers,
             });
-            run.attachAudit(supersedeAudit);
-            supersedeAudit.record(
-              "run.started",
-              { reason: "supersede", threadId, triggers },
-              { phase: "run" }
-            );
-            supersedeAudit.record(
-              "trigger.received",
-              {
-                effectiveTriggers: [],
-                normalizedTriggers: triggers,
-                rawQueuePayload: job.data,
-              },
-              { phase: "trigger" }
-            );
           }
           await run?.publishRead(null);
           return Boolean(run);
@@ -197,10 +225,9 @@ const handleThreadReadJob = async (job: Job<ThreadReadJobData>) => {
     const result = await executePipeline({
       audit: {
         attemptNumber: job.attemptsMade + 1,
-        bullmqJobId: job.id === undefined ? undefined : String(job.id),
+        bullmqJobId,
         normalizedTriggers: triggers,
         queueGeneration,
-        queueJobId: job.id === undefined ? undefined : String(job.id),
         queueName: THREAD_PIPELINE_QUEUE,
         rawQueuePayload: job.data,
       },

--- a/docs/adr/0018-run-record-audit-ledger.md
+++ b/docs/adr/0018-run-record-audit-ledger.md
@@ -1,0 +1,29 @@
+# 0018 — Persist forensic run records for Agent behavior
+
+**Status:** Accepted  **Date:** 2026-08-18  **References:** [ADR 0005](./0005-synthesis-candidate-persistence.md), [ADR 0006](./0006-trigger-context-channel.md), [ADR 0017](./0017-inbound-only-trigger-causality.md)
+
+## Context
+
+The final `thread.agentRead`, autonomous receipts, activity rows, and worker logs explain the current result only partially. They do not preserve the exact triggers and hints supplied to synthesis, the model/tool exchange, the policy snapshot, gate decisions, or the actions that were filtered before the final read. After a behavior change, the team therefore has to infer why the Agent took a position from state that may already have changed.
+
+The goal is behavioral debugging and improvement: reconstruct what the Agent could see, what it produced, which deterministic policies narrowed it, and what the system executed. This is not a customer-facing activity history or a compliance-grade non-repudiation ledger.
+
+## Decision
+
+Persist a server-owned forensic [run record](../../CONTEXT.md#run-record) for background worker pipeline executions.
+
+- A logical run covers one thread and has one [run attempt](../../CONTEXT.md#run-attempt) per actual worker execution. Queue retries link to the same logical run and create a new attempt.
+- Each attempt appends ordered [run events](../../CONTEXT.md#run-event). Events include raw and coalesced triggers, processor and hint results, Agent-visible context snapshots, model requests and responses, tool calls and results, parsed action sets, autonomy policy, filters, gates, execution outcomes, side-effect identifiers when available, and the final read.
+- The model boundary is materialized as observed input and output. Hidden chain-of-thought is not required or treated as an audit artifact.
+- The database is the durable source of truth. Run, attempt, and event rows are organization-scoped; event payloads are immutable and stored in full when behaviorally useful. Raw embeddings and redundant infrastructure details may be represented by model/version, counts, hashes, and timing.
+- Records are stored indefinitely. There is no expiry field or automatic cleanup path in this version. Payloads use stable event types and JSON without per-event schema-version machinery.
+- Internal pipeline persistence is best effort and batched. A persistence failure marks the record incomplete when possible and emits operational telemetry; it must never change Agent prompts, processor order, tool calls, action execution, or pipeline success.
+- The only v1 read surface is a narrow, read-only developer query used by the existing UI developer tools. “Copy latest agent run data” reads the latest logical run for the current thread, including all attempts and partial evidence, and copies the complete JSON record. The worker has an internal persistence sink to write the ledger, but no developer-facing or customer-facing write operation, client sync, replay, or mutation surface is added.
+
+## Consequences
+
+- Investigators can follow one causal path from queue cause to Agent-visible evidence, model/tool behavior, deterministic policy, and system consequence without relying on log retention or mutable thread state.
+- The ledger intentionally contains customer and organization content that was visible to the Agent. It is server-only and organization-scoped; server-only credentials and unrelated storage are outside the Agent-visible context boundary.
+- Indefinite full-payload storage creates unbounded data volume and operational cost. This is accepted for v1; any future deletion, archival, encryption, or compliance policy is a separate decision.
+- Audit writes can be incomplete during API/database failures or worker crashes. The attempt status and operational metrics make that gap visible, while the pipeline remains behaviorally independent.
+- Interactive Agent chat is not included in this first integration. It can adopt the same run/event vocabulary later.

--- a/docs/adr/0018-run-record-audit-ledger.md
+++ b/docs/adr/0018-run-record-audit-ledger.md
@@ -1,6 +1,6 @@
 # 0018 — Persist forensic run records for Agent behavior
 
-**Status:** Accepted  **Date:** 2026-08-18  **References:** [ADR 0005](./0005-synthesis-candidate-persistence.md), [ADR 0006](./0006-trigger-context-channel.md), [ADR 0017](./0017-inbound-only-trigger-causality.md)
+**Status:** Accepted  **Date:** 2026-08-18  **References:** [ADR 0005](./0005-hints-as-evidence-agentic-synthesis.md), [ADR 0006](./0006-trigger-context-channel.md), [ADR 0017](./0017-inbound-only-trigger-causality.md)
 
 ## Context
 

--- a/packages/queue/src/thread-read.test.ts
+++ b/packages/queue/src/thread-read.test.ts
@@ -293,11 +293,10 @@ describe(ThreadReadQueueManager, () => {
     });
 
     const job = queue.jobs.get("thread:t1:read");
-    expect(job?.data.triggers).toStrictEqual([
-      prTrigger("pr-1"),
-      { kind: "message" },
-      prTrigger("pr-2"),
-    ]);
+    expect(job?.data).toMatchObject({
+      generation: 1,
+      triggers: [prTrigger("pr-1"), { kind: "message" }, prTrigger("pr-2")],
+    });
     expect(job?.opts.priority).toBe(1);
   });
 

--- a/packages/queue/src/thread-read.test.ts
+++ b/packages/queue/src/thread-read.test.ts
@@ -318,6 +318,7 @@ describe(ThreadReadQueueManager, () => {
     await manager.enqueue("t1", [prTrigger("pr-1")]);
     const active = queue.jobs.get("thread:t1:read");
     if (!active) throw new Error("missing test job");
+    expect(active.data.generation).toBe(1);
     active.state = "active";
 
     await expect(
@@ -335,6 +336,7 @@ describe(ThreadReadQueueManager, () => {
     expect(queue.jobs.get("thread:t1:read")?.data.triggers).toStrictEqual([
       { kind: "message" },
     ]);
+    expect(queue.jobs.get("thread:t1:read")?.data.generation).toBe(2);
   });
 
   it("buffers when a waiting job becomes active during payload mutation", async () => {

--- a/packages/queue/src/thread-read.ts
+++ b/packages/queue/src/thread-read.ts
@@ -497,7 +497,7 @@ export class ThreadReadQueueManager {
 
           if (changed) {
             await existing.updateData({
-              generation: claim.pending.generation,
+              generation: existingData.generation ?? claim.pending.generation,
               threadId,
               triggers: mergedTriggers,
             });

--- a/packages/queue/src/thread-read.ts
+++ b/packages/queue/src/thread-read.ts
@@ -445,6 +445,8 @@ export class ThreadReadQueueManager {
     const priority = job.opts.priority ?? THREAD_READ_PRIORITY_VALUES.normal;
     return (
       data.threadId === threadId &&
+      (data.generation === undefined ||
+        data.generation <= pending.generation) &&
       priority <= pending.priority &&
       containsTriggers(data.triggers, pending.triggers)
     );
@@ -494,7 +496,11 @@ export class ThreadReadQueueManager {
             mergedPriority !== existingPriority;
 
           if (changed) {
-            await existing.updateData({ threadId, triggers: mergedTriggers });
+            await existing.updateData({
+              generation: claim.pending.generation,
+              threadId,
+              triggers: mergedTriggers,
+            });
             if (mergedPriority !== existingPriority) {
               await existing.changePriority({ priority: mergedPriority });
             }
@@ -537,7 +543,11 @@ export class ThreadReadQueueManager {
 
       const added = await this.queue.add(
         THREAD_READ_JOB_NAME,
-        { threadId, triggers: claim.pending.triggers },
+        {
+          generation: claim.pending.generation,
+          threadId,
+          triggers: claim.pending.triggers,
+        },
         {
           delay: delayMs,
           jobId,

--- a/packages/schemas/src/signals.test.ts
+++ b/packages/schemas/src/signals.test.ts
@@ -30,6 +30,20 @@ describe("thread-read trigger contracts", () => {
     });
   });
 
+  it("preserves queue generation for legacy payloads", () => {
+    expect(
+      normalizeThreadReadJobData({
+        generation: 4,
+        kind: "message",
+        threadId: "thread-1",
+      })
+    ).toStrictEqual({
+      generation: 4,
+      threadId: "thread-1",
+      triggers: [{ kind: "message" }],
+    });
+  });
+
   it("normalizes legacy coalesced payloads without losing either cause", () => {
     expect(
       normalizeThreadReadJobData({

--- a/packages/schemas/src/signals.test.ts
+++ b/packages/schemas/src/signals.test.ts
@@ -108,7 +108,7 @@ describe("thread-read trigger contracts", () => {
   });
 });
 
-describe("fingerprint stability", () => {
+describe(fingerprintAgentRead, () => {
   it("is stable when nested action keys are reshuffled (jsonb vs insertion order)", () => {
     const insertionOrder: ThreadRead = {
       alternatives: [{ draftMarkdown: "hi", kind: "reply" }],

--- a/packages/schemas/src/signals.test.ts
+++ b/packages/schemas/src/signals.test.ts
@@ -16,6 +16,20 @@ const candidate = (prId: string, score: number, title = prId) => ({
 });
 
 describe("thread-read trigger contracts", () => {
+  it("preserves queue generation for audit identity", () => {
+    expect(
+      normalizeThreadReadJobData({
+        generation: 4,
+        threadId: "thread-1",
+        triggers: [{ kind: "message" }],
+      })
+    ).toStrictEqual({
+      generation: 4,
+      threadId: "thread-1",
+      triggers: [{ kind: "message" }],
+    });
+  });
+
   it("normalizes legacy coalesced payloads without losing either cause", () => {
     expect(
       normalizeThreadReadJobData({
@@ -80,7 +94,7 @@ describe("thread-read trigger contracts", () => {
   });
 });
 
-describe("fingerprintAgentRead", () => {
+describe("fingerprint stability", () => {
   it("is stable when nested action keys are reshuffled (jsonb vs insertion order)", () => {
     const insertionOrder: ThreadRead = {
       alternatives: [{ draftMarkdown: "hi", kind: "reply" }],

--- a/packages/schemas/src/signals.ts
+++ b/packages/schemas/src/signals.ts
@@ -210,13 +210,15 @@ export const statusWitnessSchema = z.object({
 export type StatusWitness = z.infer<typeof statusWitnessSchema>;
 
 /** Which witness class may finish a thread into which status. */
-export const WITNESS_JUSTIFIES: Record<StatusWitnessClass, ReadonlySet<number>> =
-  {
-    abandoned: new Set([STATUS_CLOSED]),
-    customer_confirmed: new Set([STATUS_RESOLVED]),
-    entity_settled: new Set([STATUS_RESOLVED]),
-    inferred: new Set<number>(),
-  };
+export const WITNESS_JUSTIFIES: Record<
+  StatusWitnessClass,
+  ReadonlySet<number>
+> = {
+  abandoned: new Set([STATUS_CLOSED]),
+  customer_confirmed: new Set([STATUS_RESOLVED]),
+  entity_settled: new Set([STATUS_RESOLVED]),
+  inferred: new Set<number>(),
+};
 
 // Emitted directly by the label classifier, the sole writer of
 // `thread.inlineSuggestions` (ADR 0014).
@@ -801,6 +803,7 @@ export const threadReadTriggerSchema = z.object({
 export type ThreadReadTrigger = z.infer<typeof threadReadTriggerSchema>;
 
 const canonicalThreadReadJobDataSchema = z.object({
+  generation: z.number().int().positive().optional(),
   threadId: z.string(),
   triggers: z.array(threadReadTriggerSchema).min(1),
 });
@@ -813,6 +816,7 @@ const canonicalThreadReadJobDataSchema = z.object({
 export const legacyThreadReadJobDataSchema = z.object({
   kind: threadReadKindSchema,
   prMatched: prMatchCandidateSchema.optional(),
+  generation: z.number().int().positive().optional(),
   threadId: z.string(),
 });
 export type LegacyThreadReadJobData = z.infer<
@@ -870,10 +874,13 @@ export const sortThreadReadTriggers = (
 
 export const normalizeThreadReadJobData = (
   input: unknown
-): { threadId: string; triggers: ThreadReadTrigger[] } => {
+): { generation?: number; threadId: string; triggers: ThreadReadTrigger[] } => {
   const canonical = canonicalThreadReadJobDataSchema.safeParse(input);
   if (canonical.success) {
     return {
+      ...(canonical.data.generation === undefined
+        ? {}
+        : { generation: canonical.data.generation }),
       threadId: canonical.data.threadId,
       triggers: mergeThreadReadTriggers(canonical.data.triggers),
     };
@@ -889,6 +896,9 @@ export const normalizeThreadReadJobData = (
         ]
     : [{ kind: legacy.kind }];
   return {
+    ...(legacy.generation === undefined
+      ? {}
+      : { generation: legacy.generation }),
     threadId: legacy.threadId,
     triggers: mergeThreadReadTriggers(triggers),
   };


### PR DESCRIPTION
## Summary

- Add a server-owned logical run, attempt, and append-only event ledger for background Agent pipeline executions.
- Capture triggers, Agent-visible context, hints, model/tool boundaries, observable outputs, autonomy policy and gates, actions, outcomes, and retries while excluding hidden reasoning and raw embedding vectors.
- Add scoped internal persistence, a read-only developer query, and the Copy latest agent run data devtool command.
- Document the domain model and add API/worker coverage for IDs, ordering, deduplication, serialization, model evidence, and readback.

## Verification

- Worker test suite: 51 passed.
- API test suite: 52 passed.
- Worker, API, and web typechecks passed.
- Targeted Ultracite checks on changed files passed.
- git diff --check passed.

Repo-wide lint still reports unrelated pre-existing findings outside this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a server-owned forensic audit ledger for background Agent pipeline runs to enable post‑hoc debugging. Previously we relied on mutable thread state and logs; now we persist logical runs, link `bullmq` retries into attempts via queue generation, and append ordered events without changing pipeline execution. The label classifier now distinguishes the skip reasons no_label (no confident single label) vs no_labels (no labels configured).

- Creates `agentRun`, `agentRunAttempt`, and `agentRunEvent` tables; events are append‑only, ordered by occurredAt/sequence, and deduplicated by id.
- Adds `agentRun` procedures: `start`, `appendEvents`, `complete` (internal key required), and `latestForThread` (developer‑scoped read) with authorization.
- Instruments the worker to record triggers, pipeline plan, processor lifecycle, model/tool calls with observable steps only (no chain‑of‑thought or provider metadata), parsed outputs, embedding input hashes/dimensions (no vectors), autonomy policy, gates, action filtering/executions, and published reads.
- Groups `bullmq` retries into one run using preserved queue generation; increments attempt numbers per execution with a stable run id and prevents outdated coalesced jobs from superseding newer work.
- Handles transport failures: batches up to 100 events with a 500ms timeout, caps 500 events per append, sets `auditIncomplete` on errors/timeouts, and never blocks execution.
- Adds a devtool command “Copy latest agent run data” that reads normalized JSON via `agentRun.latestForThread`.
- Quality pass: centralizes embedding audit via `auditEmbedding`, unifies `bullmqJobId` naming, upserts the start row, and prefetches event rows for dedupe.

**Review and rollout**
- Run schema migrations; deploy API and worker together. No client migration beyond the new devtool.
- Writes require an internal API key; the read requires a developer permission. Ledger is server‑only and organization‑scoped.
- If you inspect label classifier `skipped` reasons, handle both no_labels and no_label.
- Retention and privacy: indefinite retention; contents include Agent‑visible org/customer data only (no server‑only secrets, chain‑of‑thought, or embedding vectors).
- Monitor worker audit warnings and the `auditIncomplete` flag to spot transport issues.

<sup>Written for commit 64b72144bd93bf20d845d8230a01e9c119031fd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable records for Agent runs, retries, events, model activity, policies, gates, and outcomes.
  * Added developer-only controls to retrieve and copy the latest run details for a thread.
  * Added activity tracking across embedding, synthesis, classification, and pipeline execution.
* **Bug Fixes**
  * Improved thread-read generation tracking to prevent outdated work from being processed.
* **Documentation**
  * Documented run records, attempts, events, and Agent-visible synthesis context.
* **Tests**
  * Added coverage for persistence, event handling, serialization, retries, failures, and completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->