### PR TITLE
perf(worker): cut Qdrant memory usage

### DIFF
--- a/apps/api/src/evals/agent-chat.eval.ts
+++ b/apps/api/src/evals/agent-chat.eval.ts
@@ -6,15 +6,13 @@ import { evalite } from "evalite";
 import { reportTrace } from "evalite/traces";
 import { OpenAI } from "openai";
 
-import {
-  agentModel,
-  RESPAN_OPENAI_BASE_URL,
-} from "../lib/ai/respan";
+import { agentModel, RESPAN_OPENAI_BASE_URL } from "../lib/ai/respan";
 import {
   buildAgentChatTools,
   buildSystemPrompt,
   formatThreadMetadata,
 } from "../live-state/router/agent-chat-core";
+import type { AgentChatTools } from "../live-state/router/agent-chat-core";
 import {
   toolSelectionDataset,
   proactiveToolDataset,
@@ -92,6 +90,7 @@ function buildPromptFromThread(
     labels: string[];
     messages: { author: string; content: string }[];
   },
+  tools: AgentChatTools,
   suggestionsContext = ""
 ) {
   const threadMetadata = formatThreadMetadata({
@@ -108,14 +107,13 @@ function buildPromptFromThread(
     .map((m) => `[${m.author}]: ${m.content}`)
     .join("\n");
 
-  return buildSystemPrompt({
-    suggestionsContext,
-    threadContext,
-    threadMetadata,
-    // The fixtures always supply a `searchThreads` implementation, so the
-    // evals keep exercising the full tool surface.
-    threadSearchEnabled: true,
-  });
+  // The prompt describes whatever `tools` actually holds; the fixtures supply a
+  // `searchThreads` implementation, so the evals keep exercising the full
+  // tool surface.
+  return buildSystemPrompt(
+    { suggestionsContext, threadContext, threadMetadata },
+    tools
+  );
 }
 
 function extractToolNames(
@@ -140,10 +138,10 @@ evalite("Agent Chat — Tool Selection", {
   data: () => toolSelectionDataset,
   scorers: [toolSelectionAccuracy],
   task: async (input) => {
-    const systemPrompt = buildPromptFromThread(input.thread);
     const tools = buildAgentChatTools(
       createMockToolImplementations(input.toolOverrides)
     );
+    const systemPrompt = buildPromptFromThread(input.thread, tools);
 
     const start = Date.now();
     const result = await generateText({
@@ -165,12 +163,13 @@ evalite("Agent Chat — Proactive Tool Usage", {
   data: () => proactiveToolDataset,
   scorers: [proactiveToolUsage],
   task: async (input) => {
-    const systemPrompt = buildPromptFromThread(
-      input.thread,
-      input.suggestionsContext
-    );
     const tools = buildAgentChatTools(
       createMockToolImplementations(input.toolOverrides)
+    );
+    const systemPrompt = buildPromptFromThread(
+      input.thread,
+      tools,
+      input.suggestionsContext
     );
 
     const start = Date.now();
@@ -195,7 +194,6 @@ evalite("Agent Chat — Draft Quality", {
   task: async (input) => {
     let capturedDraft = "";
 
-    const systemPrompt = buildPromptFromThread(input.thread);
     const tools = buildAgentChatTools(
       createMockToolImplementations({
         ...input.toolOverrides,
@@ -205,6 +203,7 @@ evalite("Agent Chat — Draft Quality", {
         },
       })
     );
+    const systemPrompt = buildPromptFromThread(input.thread, tools);
 
     const start = Date.now();
     const result = await generateText({
@@ -226,10 +225,10 @@ evalite("Agent Chat — Thread References", {
   data: () => threadReferenceDataset,
   scorers: [threadReferenceFormat],
   task: async (input) => {
-    const systemPrompt = buildPromptFromThread(input.thread);
     const tools = buildAgentChatTools(
       createMockToolImplementations(input.toolOverrides)
     );
+    const systemPrompt = buildPromptFromThread(input.thread, tools);
 
     const start = Date.now();
     const result = await generateText({

--- a/apps/api/src/evals/agent-chat.eval.ts
+++ b/apps/api/src/evals/agent-chat.eval.ts
@@ -112,6 +112,9 @@ function buildPromptFromThread(
     suggestionsContext,
     threadContext,
     threadMetadata,
+    // The fixtures always supply a `searchThreads` implementation, so the
+    // evals keep exercising the full tool surface.
+    threadSearchEnabled: true,
   });
 }
 

--- a/apps/api/src/lib/search/qdrant.ts
+++ b/apps/api/src/lib/search/qdrant.ts
@@ -5,7 +5,8 @@ import { generateEmbedding } from "../ai/embeddings";
 const QDRANT_URL = process.env.QDRANT_URL ?? "http://localhost:6333";
 const { QDRANT_API_KEY } = process.env;
 
-const MESSAGES_COLLECTION = "messages-v1";
+// Retired (FRO-224); kept for the commented searchMessages below.
+// const MESSAGES_COLLECTION = "messages-v1";
 const DOCUMENTATION_COLLECTION = "documentation-v1";
 
 const qdrantClient = new QdrantClient({
@@ -13,61 +14,79 @@ const qdrantClient = new QdrantClient({
   url: QDRANT_URL,
 });
 
-export async function searchMessages(options: {
+/**
+ * Stubbed: the `messages-v1` collection it queried is retired (FRO-224). A
+ * per-message vector index was the largest thing in Qdrant, and both callers —
+ * the flag-gated search page and the Agent's `searchThreads` tool — consumed it
+ * at thread granularity anyway.
+ *
+ * Returning empty rather than throwing keeps both callers on their existing
+ * "no results" path. The implementation below is kept, commented, so the
+ * rewrite starts from the hybrid query that was actually running.
+ */
+export async function searchMessages(_options: {
   query: string;
   organizationId: string;
   limit?: number;
 }): Promise<{ messageId: string; threadId: string; score: number }[]> {
-  const { query, organizationId, limit = 20 } = options;
-
-  const denseQueryEmbedding = await generateEmbedding(query, "RETRIEVAL_QUERY");
-
-  if (!denseQueryEmbedding) {
-    console.error("Failed to generate query embedding for search");
-    return [];
-  }
-
-  try {
-    const results = await qdrantClient.query(MESSAGES_COLLECTION, {
-      filter: {
-        must: [{ key: "organizationId", match: { value: organizationId } }],
-      },
-      limit,
-      prefetch: [
-        {
-          query: denseQueryEmbedding,
-          using: "dense",
-          limit,
-        },
-        {
-          query: {
-            text: query,
-            model: "qdrant/bm25",
-          } as unknown as number[],
-          using: "bm25",
-          limit,
-        },
-      ],
-      query: { fusion: "rrf" },
-      with_payload: true,
-    });
-
-    return results.points.map((point) => {
-      const payload = point.payload as unknown as {
-        messageId: string;
-        threadId: string;
-      };
-      return {
-        messageId: payload.messageId,
-        score: point.score,
-        threadId: payload.threadId,
-      };
-    });
-  } catch (error) {
-    console.error("Failed to search messages in Qdrant:", error);
-    return [];
-  }
+  return [];
 }
+
+// export async function searchMessages(options: {
+//   query: string;
+//   organizationId: string;
+//   limit?: number;
+// }): Promise<{ messageId: string; threadId: string; score: number }[]> {
+//   const { query, organizationId, limit = 20 } = options;
+//
+//   const denseQueryEmbedding = await generateEmbedding(query, "RETRIEVAL_QUERY");
+//
+//   if (!denseQueryEmbedding) {
+//     console.error("Failed to generate query embedding for search");
+//     return [];
+//   }
+//
+//   try {
+//     const results = await qdrantClient.query(MESSAGES_COLLECTION, {
+//       filter: {
+//         must: [{ key: "organizationId", match: { value: organizationId } }],
+//       },
+//       limit,
+//       prefetch: [
+//         {
+//           query: denseQueryEmbedding,
+//           using: "dense",
+//           limit,
+//         },
+//         {
+//           query: {
+//             text: query,
+//             model: "qdrant/bm25",
+//           } as unknown as number[],
+//           using: "bm25",
+//           limit,
+//         },
+//       ],
+//       query: { fusion: "rrf" },
+//       with_payload: true,
+//     });
+//
+//     return results.points.map((point) => {
+//       const payload = point.payload as unknown as {
+//         messageId: string;
+//         threadId: string;
+//       };
+//       return {
+//         messageId: payload.messageId,
+//         score: point.score,
+//         threadId: payload.threadId,
+//       };
+//     });
+//   } catch (error) {
+//     console.error("Failed to search messages in Qdrant:", error);
+//     return [];
+//   }
+// }
 
 export async function searchDocumentation(options: {
   query: string;

--- a/apps/api/src/live-state/router/agent-chat-core.ts
+++ b/apps/api/src/live-state/router/agent-chat-core.ts
@@ -9,19 +9,22 @@ export interface AgentChatContext {
   suggestionsContext: string;
   customInstructions?: string | null;
   currentUserName?: string | null;
-  /**
-   * Whether the `searchThreads` tool is available, i.e. whether a
-   * `searchThreads` implementation was handed to
-   * {@link buildAgentChatTools}. Required rather than defaulted: a default
-   * would let the prompt advertise a tool the model was never given. The
-   * production route sets it to false while thread search is retired
-   * (FRO-224).
-   */
-  threadSearchEnabled: boolean;
 }
 
-export function buildSystemPrompt(ctx: AgentChatContext): string {
-  const threadSearch = ctx.threadSearchEnabled;
+/**
+ * Builds the system prompt for a given tool map.
+ *
+ * `tools` is not decoration: the prompt describes the tools the model has, so
+ * it reads which ones exist off the very map that is handed to the model. A
+ * separate capability flag was tried and rejected — two independent inputs can
+ * disagree, and a prompt that advertises an undeclared tool makes the model
+ * call something that is not there.
+ */
+export function buildSystemPrompt(
+  ctx: AgentChatContext,
+  tools: AgentChatTools
+): string {
+  const threadSearch = "searchThreads" in tools;
   const searchTools = threadSearch
     ? "searchDocumentation and/or searchThreads"
     : "searchDocumentation";
@@ -230,11 +233,29 @@ export interface AgentChatToolImplementations {
   }) => Promise<ListThreadsResult[]>;
 }
 
+/**
+ * Built only when there is something to execute, so the tool is never declared
+ * to the model without a working implementation behind it.
+ */
+function buildSearchThreadsTool(
+  execute: NonNullable<AgentChatToolImplementations["searchThreads"]>
+) {
+  return tool({
+    description:
+      "Search across all support threads in the organization using a text query. Use this to find related issues, check if a problem has been reported before, or find context from past conversations. Results include an _id field. When presenting results to the user, ALWAYS format thread references as [Thread Name](thread:<threadId>) markdown links, substituting each result's _id value.",
+    inputSchema: z.object({
+      query: z
+        .string()
+        .describe("The search query to find relevant support threads"),
+    }),
+    execute,
+  });
+}
+
 export function buildAgentChatTools(
   implementations: AgentChatToolImplementations
 ) {
-  const searchThreadsImpl = implementations.searchThreads;
-  const tools = {
+  const base = {
     getDraft: tool({
       description:
         "Read the current draft reply. Use this when you need to see the support agent's current draft before making changes.",
@@ -280,16 +301,6 @@ export function buildAgentChatTools(
       }),
       execute: implementations.searchDocumentation,
     }),
-    searchThreads: tool({
-      description:
-        "Search across all support threads in the organization using a text query. Use this to find related issues, check if a problem has been reported before, or find context from past conversations. Results include an _id field. When presenting results to the user, ALWAYS format thread references as [Thread Name](thread:<threadId>) markdown links, substituting each result's _id value.",
-      inputSchema: z.object({
-        query: z
-          .string()
-          .describe("The search query to find relevant support threads"),
-      }),
-      execute: searchThreadsImpl ?? (async () => []),
-    }),
     setDraft: tool({
       description:
         "Draft a reply message for the support agent to send to the customer. This replaces the current draft if one exists. The draft will be shown to the agent for review and editing before sending. Use markdown formatting. You MUST call this tool when the user asks to draft, write, reply, or respond. Do not stop after searching without calling this tool.",
@@ -302,16 +313,28 @@ export function buildAgentChatTools(
     }),
   };
 
-  // Declared above, then removed when there is no implementation — an
-  // undeclared tool is the only way to stop the model from calling something
-  // that cannot work. The return type deliberately keeps the key required:
-  // marking it optional widens the AI SDK's `TypedToolCall` with `undefined`
-  // and breaks tool-call typing for every caller. `threadSearchEnabled` on
-  // `AgentChatContext` is required for the same reason — it is the one switch
-  // callers must set, and it cannot silently disagree with this map.
+  type Tools = typeof base & {
+    searchThreads: ReturnType<typeof buildSearchThreadsTool>;
+  };
+
+  const searchThreadsImpl = implementations.searchThreads;
+
   if (!searchThreadsImpl) {
-    delete (tools as Partial<typeof tools>).searchThreads;
+    // Leaving the tool out is the only way to stop the model from calling
+    // something that cannot work; `buildSystemPrompt` reads this map, so the
+    // prompt drops it too.
+    //
+    // The cast is deliberate. Typing the key as optional widens the AI SDK's
+    // `TypedToolCall` with `undefined`, which breaks tool-call typing for every
+    // caller, so the type stays whole and the runtime map — the one that
+    // actually reaches the model — is what varies.
+    return base as Tools;
   }
 
-  return tools;
+  return {
+    ...base,
+    searchThreads: buildSearchThreadsTool(searchThreadsImpl),
+  } as Tools;
 }
+
+export type AgentChatTools = ReturnType<typeof buildAgentChatTools>;

--- a/apps/api/src/live-state/router/agent-chat-core.ts
+++ b/apps/api/src/live-state/router/agent-chat-core.ts
@@ -10,15 +10,18 @@ export interface AgentChatContext {
   customInstructions?: string | null;
   currentUserName?: string | null;
   /**
-   * Whether the `searchThreads` tool is available. Defaults to true; the
-   * production route turns it off while thread search is retired (FRO-224) so
-   * the prompt never advertises a tool the model cannot actually use.
+   * Whether the `searchThreads` tool is available, i.e. whether a
+   * `searchThreads` implementation was handed to
+   * {@link buildAgentChatTools}. Required rather than defaulted: a default
+   * would let the prompt advertise a tool the model was never given. The
+   * production route sets it to false while thread search is retired
+   * (FRO-224).
    */
-  threadSearchEnabled?: boolean;
+  threadSearchEnabled: boolean;
 }
 
 export function buildSystemPrompt(ctx: AgentChatContext): string {
-  const threadSearch = ctx.threadSearchEnabled ?? true;
+  const threadSearch = ctx.threadSearchEnabled;
   const searchTools = threadSearch
     ? "searchDocumentation and/or searchThreads"
     : "searchDocumentation";
@@ -299,9 +302,13 @@ export function buildAgentChatTools(
     }),
   };
 
-  // Declared above so the object keeps a concrete type for callers, then
-  // removed when there is no implementation — an undeclared tool is the only
-  // way to stop the model from calling something that cannot work.
+  // Declared above, then removed when there is no implementation — an
+  // undeclared tool is the only way to stop the model from calling something
+  // that cannot work. The return type deliberately keeps the key required:
+  // marking it optional widens the AI SDK's `TypedToolCall` with `undefined`
+  // and breaks tool-call typing for every caller. `threadSearchEnabled` on
+  // `AgentChatContext` is required for the same reason — it is the one switch
+  // callers must set, and it cannot silently disagree with this map.
   if (!searchThreadsImpl) {
     delete (tools as Partial<typeof tools>).searchThreads;
   }

--- a/apps/api/src/live-state/router/agent-chat-core.ts
+++ b/apps/api/src/live-state/router/agent-chat-core.ts
@@ -9,9 +9,22 @@ export interface AgentChatContext {
   suggestionsContext: string;
   customInstructions?: string | null;
   currentUserName?: string | null;
+  /**
+   * Whether the `searchThreads` tool is available. Defaults to true; the
+   * production route turns it off while thread search is retired (FRO-224) so
+   * the prompt never advertises a tool the model cannot actually use.
+   */
+  threadSearchEnabled?: boolean;
 }
 
 export function buildSystemPrompt(ctx: AgentChatContext): string {
+  const threadSearch = ctx.threadSearchEnabled ?? true;
+  const searchTools = threadSearch
+    ? "searchDocumentation and/or searchThreads"
+    : "searchDocumentation";
+  const lookupTools = threadSearch
+    ? "searchThreads, searchDocumentation, or listThreads"
+    : "searchDocumentation or listThreads";
   return `You are a helpful AI assistant for a customer support team. You have access to the following support thread for context.
 
 ${ctx.currentUserName ? `You are chatting with ${ctx.currentUserName}, a support agent on this team. Address them by name when appropriate.\n\n` : ""}## Thread Details
@@ -27,8 +40,7 @@ You also have a tool called "setDraft" that lets you draft a reply message for t
 You also have a tool called "getDraft" that lets you read the current draft reply. Use it when the user asks about or references their current draft, or when you need to see the draft before making modifications. The support agent may have edited the draft manually, so always use getDraft to read the latest version before updating it with setDraft.
 
 You also have tools to explore other support threads in the organization:
-- "searchThreads": Search across all support threads using a text query. Use it to find related issues, check if a problem has been reported before, or find context from past conversations.
-- "getThread": Read the full details and messages of a specific thread by its ID. Use it after finding a thread via search to get the complete conversation.
+${threadSearch ? `- "searchThreads": Search across all support threads using a text query. Use it to find related issues, check if a problem has been reported before, or find context from past conversations.\n` : ""}- "getThread": Read the full details and messages of a specific thread by its ID. Use it after finding a thread via search to get the complete conversation.
 - "listThreads": Browse recent support threads, optionally filtered by status or priority. Use it to get an overview of current issues or find threads with a specific status.
 ${ctx.customInstructions ? `\n## Custom Instructions\n${ctx.customInstructions}\n` : ""}
 Use the thread context to help answer questions about this support thread. Be concise and helpful.
@@ -39,8 +51,8 @@ IMPORTANT: When mentioning threads in your responses, ALWAYS use markdown link s
 Follow these rules to decide which tools to use:
 
 1. **If the user asks to UPDATE or EDIT an existing draft** → call getDraft, then setDraft. Do NOT search.
-2. **If the user asks to draft, write, reply, compose, or respond** → search for context using searchDocumentation and/or searchThreads (you may retry once with a different query if the first returns no results), then MUST call setDraft. Do not search more than twice per tool. Always draft based on whatever context you have — even if all searches return empty, use the thread messages to write the draft.
-3. **If the user asks to search, look up, find, or list** → use ONLY the requested tool (searchThreads, searchDocumentation, or listThreads). Do NOT call setDraft. Present results and stop.
+2. **If the user asks to draft, write, reply, compose, or respond** → search for context using ${searchTools} (you may retry once with a different query if the first returns no results), then MUST call setDraft. Do not search more than twice per tool. Always draft based on whatever context you have — even if all searches return empty, use the thread messages to write the draft.
+3. **If the user asks to search, look up, find, or list** → use ONLY the requested tool (${lookupTools}). Do NOT call setDraft. Present results and stop.
 4. **If the user asks a question about this thread** → answer from context. No tools needed unless the answer requires external information.
 
 IMPORTANT: In rules 1-3, use ONLY the tools listed. Do not add extra tools like listThreads or getThread unless the user specifically asks for them or suggestions mention a related thread to read. Only retry a tool when explicitly allowed above (e.g., rule 2); otherwise use one call per tool.
@@ -200,7 +212,11 @@ export interface AgentChatToolImplementations {
     content: string | null;
   }>;
   setDraft: (args: { content: string }) => Promise<{ success: boolean }>;
-  searchThreads: (args: { query: string }) => Promise<SearchThreadsResult[]>;
+  /**
+   * Optional: when omitted the `searchThreads` tool is not declared to the
+   * model at all. Pair with `threadSearchEnabled: false` on the system prompt.
+   */
+  searchThreads?: (args: { query: string }) => Promise<SearchThreadsResult[]>;
   getThread: (args: {
     threadId: string;
   }) => Promise<GetThreadResult | { error: string }>;
@@ -214,7 +230,8 @@ export interface AgentChatToolImplementations {
 export function buildAgentChatTools(
   implementations: AgentChatToolImplementations
 ) {
-  return {
+  const searchThreadsImpl = implementations.searchThreads;
+  const tools = {
     getDraft: tool({
       description:
         "Read the current draft reply. Use this when you need to see the support agent's current draft before making changes.",
@@ -268,7 +285,7 @@ export function buildAgentChatTools(
           .string()
           .describe("The search query to find relevant support threads"),
       }),
-      execute: implementations.searchThreads,
+      execute: searchThreadsImpl ?? (async () => []),
     }),
     setDraft: tool({
       description:
@@ -281,4 +298,13 @@ export function buildAgentChatTools(
       execute: implementations.setDraft,
     }),
   };
+
+  // Declared above so the object keeps a concrete type for callers, then
+  // removed when there is no implementation — an undeclared tool is the only
+  // way to stop the model from calling something that cannot work.
+  if (!searchThreadsImpl) {
+    delete (tools as Partial<typeof tools>).searchThreads;
+  }
+
+  return tools;
 }

--- a/apps/api/src/live-state/router/agent-chat.ts
+++ b/apps/api/src/live-state/router/agent-chat.ts
@@ -312,16 +312,6 @@ export const agentChatRoute = privateRoute.withProcedures(({ mutation }) => ({
     // Fetch current user name for personalization
     const currentUser = await db.findOne(schema.user, actor.userId);
 
-    const systemPrompt = buildSystemPrompt({
-      threadMetadata,
-      threadContext,
-      suggestionsContext,
-      customInstructions: org?.customInstructions,
-      currentUserName: currentUser?.name ?? null,
-      // Thread search is retired with the `messages-v1` index (FRO-224).
-      threadSearchEnabled: false,
-    });
-
     // Stream in background — don't await, let the mutation return immediately
     // so the client sees the user message + empty assistant message right away.
     (async () => {
@@ -567,11 +557,25 @@ export const agentChatRoute = privateRoute.withProcedures(({ mutation }) => ({
           },
         };
 
+        // `toolImplementations` omits `searchThreads` while thread search is
+        // retired (FRO-224), so the prompt built from this map drops it too.
+        const tools = buildAgentChatTools(toolImplementations);
+        const systemPrompt = buildSystemPrompt(
+          {
+            threadMetadata,
+            threadContext,
+            suggestionsContext,
+            customInstructions: org?.customInstructions,
+            currentUserName: currentUser?.name ?? null,
+          },
+          tools
+        );
+
         const result = streamText({
           model: agentModel(),
           system: systemPrompt,
           messages: conversationHistory,
-          tools: buildAgentChatTools(toolImplementations),
+          tools,
           stopWhen: stepCountIs(12),
         });
 

--- a/apps/api/src/live-state/router/agent-chat.ts
+++ b/apps/api/src/live-state/router/agent-chat.ts
@@ -10,7 +10,9 @@ import {
   authorizeOwnedAgentChat,
   authorizeWorkspaceOrgMember,
 } from "../../lib/authorize";
-import { searchDocumentation, searchMessages } from "../../lib/search/qdrant";
+// `searchMessages` is retired with `messages-v1` (FRO-224); see the commented
+// searchThreads implementation below.
+import { searchDocumentation } from "../../lib/search/qdrant";
 import { privateRoute } from "../factories";
 import { schema } from "../schema";
 import {
@@ -378,89 +380,96 @@ export const agentChatRoute = privateRoute.withProcedures(({ mutation }) => ({
             });
             return { success: true };
           },
-          searchThreads: async ({ query }) => {
-            console.log(
-              `[agent-chat] Tool call: searchThreads query="${query}"`
-            );
-            const results = await searchMessages({
-              query,
-              organizationId,
-              limit: 15,
-            });
+          // Stubbed with the `messages-v1` index it searched (FRO-224). The
+          // tool stays declared to the model so the prompt and evals keep their
+          // shape; it just finds nothing until search is rebuilt on a substrate
+          // that does not need a per-message vector index.
+          searchThreads: async () => [],
 
-            // Deduplicate by threadId, keeping highest score per thread
-            const threadMap = new Map<
-              string,
-              { messageId: string; threadId: string; score: number }
-            >();
-            for (const r of results) {
-              if (r.threadId === agentChat.threadId) continue;
-              const existing = threadMap.get(r.threadId);
-              if (!existing || r.score > existing.score) {
-                threadMap.set(r.threadId, r);
-              }
-            }
+          // searchThreads: async ({ query }) => {
+          //   console.log(
+          //     `[agent-chat] Tool call: searchThreads query="${query}"`
+          //   );
+          //   const results = await searchMessages({
+          //     query,
+          //     organizationId,
+          //     limit: 15,
+          //   });
+          //
+          //   // Deduplicate by threadId, keeping highest score per thread
+          //   const threadMap = new Map<
+          //     string,
+          //     { messageId: string; threadId: string; score: number }
+          //   >();
+          //   for (const r of results) {
+          //     if (r.threadId === agentChat.threadId) continue;
+          //     const existing = threadMap.get(r.threadId);
+          //     if (!existing || r.score > existing.score) {
+          //       threadMap.set(r.threadId, r);
+          //     }
+          //   }
+          //
+          //   const uniqueResults = [...threadMap.values()]
+          //     .toSorted((a, b) => b.score - a.score)
+          //     .slice(0, 8);
+          //
+          //   const enriched = await Promise.all(
+          //     uniqueResults.map(async (r) => {
+          //       const [foundThread, message] = await Promise.all([
+          //         db
+          //           .find(schema.thread, {
+          //             where: {
+          //               id: r.threadId,
+          //               organizationId,
+          //               deletedAt: null,
+          //             },
+          //           })
+          //           .then((res) => Object.values(res)[0] ?? null),
+          //         db.findOne(schema.message, r.messageId),
+          //       ]);
+          //
+          //       if (!foundThread) {
+          //         return null;
+          //       }
+          //
+          //       const author = foundThread.authorId
+          //         ? await db.findOne(schema.author, foundThread.authorId)
+          //         : null;
+          //
+          //       let snippet = "";
+          //       if (message) {
+          //         snippet = jsonContentToPlainText(
+          //           safeParseJSON(message.content)
+          //         );
+          //         if (snippet.length > 300) {
+          //           snippet = `${snippet.slice(0, 300)}...`;
+          //         }
+          //       }
+          //
+          //       return {
+          //         _id: r.threadId,
+          //         name: foundThread.name,
+          //         status: statusLabels[foundThread.status ?? 0] ?? "Unknown",
+          //         priority: priorityLabels[foundThread.priority ?? 0] ?? "None",
+          //         author: author?.name ?? "Unknown",
+          //         createdAt: foundThread.createdAt
+          //           ? new Date(foundThread.createdAt).toISOString()
+          //           : "Unknown",
+          //         matchingMessageSnippet: snippet,
+          //         score: r.score,
+          //       };
+          //     })
+          //   );
+          //
+          //   const filtered = enriched.filter(
+          //     (item): item is NonNullable<typeof item> => item !== null
+          //   );
+          //   console.log(
+          //     `[agent-chat] searchThreads returned ${filtered.length} threads`
+          //   );
+          //   return filtered;
+          // },
 
-            const uniqueResults = [...threadMap.values()]
-              .toSorted((a, b) => b.score - a.score)
-              .slice(0, 8);
-
-            const enriched = await Promise.all(
-              uniqueResults.map(async (r) => {
-                const [foundThread, message] = await Promise.all([
-                  db
-                    .find(schema.thread, {
-                      where: {
-                        id: r.threadId,
-                        organizationId,
-                        deletedAt: null,
-                      },
-                    })
-                    .then((res) => Object.values(res)[0] ?? null),
-                  db.findOne(schema.message, r.messageId),
-                ]);
-
-                if (!foundThread) {
-                  return null;
-                }
-
-                const author = foundThread.authorId
-                  ? await db.findOne(schema.author, foundThread.authorId)
-                  : null;
-
-                let snippet = "";
-                if (message) {
-                  snippet = jsonContentToPlainText(
-                    safeParseJSON(message.content)
-                  );
-                  if (snippet.length > 300) {
-                    snippet = `${snippet.slice(0, 300)}...`;
-                  }
-                }
-
-                return {
-                  _id: r.threadId,
-                  name: foundThread.name,
-                  status: statusLabels[foundThread.status ?? 0] ?? "Unknown",
-                  priority: priorityLabels[foundThread.priority ?? 0] ?? "None",
-                  author: author?.name ?? "Unknown",
-                  createdAt: foundThread.createdAt
-                    ? new Date(foundThread.createdAt).toISOString()
-                    : "Unknown",
-                  matchingMessageSnippet: snippet,
-                  score: r.score,
-                };
-              })
-            );
-
-            const filtered = enriched.filter(
-              (item): item is NonNullable<typeof item> => item !== null
-            );
-            console.log(
-              `[agent-chat] searchThreads returned ${filtered.length} threads`
-            );
-            return filtered;
-          },
           getThread: async ({ threadId }) => {
             console.log(
               `[agent-chat] Tool call: getThread threadId="${threadId}"`

--- a/apps/api/src/live-state/router/agent-chat.ts
+++ b/apps/api/src/live-state/router/agent-chat.ts
@@ -10,8 +10,8 @@ import {
   authorizeOwnedAgentChat,
   authorizeWorkspaceOrgMember,
 } from "../../lib/authorize";
-// `searchMessages` is retired with `messages-v1` (FRO-224); see the commented
-// searchThreads implementation below.
+// Thread search is retired along with the `messages-v1` index (FRO-224); the
+// `searchThreads` tool is not declared to the model until it is rebuilt.
 import { searchDocumentation } from "../../lib/search/qdrant";
 import { privateRoute } from "../factories";
 import { schema } from "../schema";
@@ -318,6 +318,8 @@ export const agentChatRoute = privateRoute.withProcedures(({ mutation }) => ({
       suggestionsContext,
       customInstructions: org?.customInstructions,
       currentUserName: currentUser?.name ?? null,
+      // Thread search is retired with the `messages-v1` index (FRO-224).
+      threadSearchEnabled: false,
     });
 
     // Stream in background — don't await, let the mutation return immediately
@@ -380,96 +382,6 @@ export const agentChatRoute = privateRoute.withProcedures(({ mutation }) => ({
             });
             return { success: true };
           },
-          // Stubbed with the `messages-v1` index it searched (FRO-224). The
-          // tool stays declared to the model so the prompt and evals keep their
-          // shape; it just finds nothing until search is rebuilt on a substrate
-          // that does not need a per-message vector index.
-          searchThreads: async () => [],
-
-          // searchThreads: async ({ query }) => {
-          //   console.log(
-          //     `[agent-chat] Tool call: searchThreads query="${query}"`
-          //   );
-          //   const results = await searchMessages({
-          //     query,
-          //     organizationId,
-          //     limit: 15,
-          //   });
-          //
-          //   // Deduplicate by threadId, keeping highest score per thread
-          //   const threadMap = new Map<
-          //     string,
-          //     { messageId: string; threadId: string; score: number }
-          //   >();
-          //   for (const r of results) {
-          //     if (r.threadId === agentChat.threadId) continue;
-          //     const existing = threadMap.get(r.threadId);
-          //     if (!existing || r.score > existing.score) {
-          //       threadMap.set(r.threadId, r);
-          //     }
-          //   }
-          //
-          //   const uniqueResults = [...threadMap.values()]
-          //     .toSorted((a, b) => b.score - a.score)
-          //     .slice(0, 8);
-          //
-          //   const enriched = await Promise.all(
-          //     uniqueResults.map(async (r) => {
-          //       const [foundThread, message] = await Promise.all([
-          //         db
-          //           .find(schema.thread, {
-          //             where: {
-          //               id: r.threadId,
-          //               organizationId,
-          //               deletedAt: null,
-          //             },
-          //           })
-          //           .then((res) => Object.values(res)[0] ?? null),
-          //         db.findOne(schema.message, r.messageId),
-          //       ]);
-          //
-          //       if (!foundThread) {
-          //         return null;
-          //       }
-          //
-          //       const author = foundThread.authorId
-          //         ? await db.findOne(schema.author, foundThread.authorId)
-          //         : null;
-          //
-          //       let snippet = "";
-          //       if (message) {
-          //         snippet = jsonContentToPlainText(
-          //           safeParseJSON(message.content)
-          //         );
-          //         if (snippet.length > 300) {
-          //           snippet = `${snippet.slice(0, 300)}...`;
-          //         }
-          //       }
-          //
-          //       return {
-          //         _id: r.threadId,
-          //         name: foundThread.name,
-          //         status: statusLabels[foundThread.status ?? 0] ?? "Unknown",
-          //         priority: priorityLabels[foundThread.priority ?? 0] ?? "None",
-          //         author: author?.name ?? "Unknown",
-          //         createdAt: foundThread.createdAt
-          //           ? new Date(foundThread.createdAt).toISOString()
-          //           : "Unknown",
-          //         matchingMessageSnippet: snippet,
-          //         score: r.score,
-          //       };
-          //     })
-          //   );
-          //
-          //   const filtered = enriched.filter(
-          //     (item): item is NonNullable<typeof item> => item !== null
-          //   );
-          //   console.log(
-          //     `[agent-chat] searchThreads returned ${filtered.length} threads`
-          //   );
-          //   return filtered;
-          // },
-
           getThread: async ({ threadId }) => {
             console.log(
               `[agent-chat] Tool call: getThread threadId="${threadId}"`

--- a/apps/api/src/live-state/router/message.ts
+++ b/apps/api/src/live-state/router/message.ts
@@ -10,7 +10,8 @@ import {
   requireInternalApiKey,
   resolveHumanAuthor,
 } from "../../lib/authorize";
-import { searchMessages } from "../../lib/search/qdrant";
+// Retired with `messages-v1` (FRO-224); see the commented search handler below.
+// import { searchMessages } from "../../lib/search/qdrant";
 import { serializeMessageContent } from "../../lib/tiptap-content";
 import { publicRoute } from "../factories";
 import { schema } from "../schema";
@@ -228,23 +229,36 @@ export default publicRoute.withProcedures(({ mutation, query }) => ({
 
     return updatedMessage ?? { ...message, markedAsAnswer: true };
   }),
+  /**
+   * Stubbed with the `messages-v1` index behind it (FRO-224). Kept as a
+   * procedure so the search page keeps rendering its empty state instead of
+   * erroring; the page is gated behind the `in-app-search` flag, which is off
+   * everywhere.
+   */
   search: mutation(
     z.object({
       organizationId: z.string(),
       query: z.string(),
     })
-  ).handler(async ({ req }) => {
-    const results = await searchMessages({
-      organizationId: req.input.organizationId,
-      query: req.input.query,
-    });
+  ).handler(async () => ({ hits: [] as { document: { id: string } }[] })),
 
-    return {
-      hits: results.map((r) => ({
-        document: { id: r.messageId },
-      })),
-    };
-  }),
+  // search: mutation(
+  //   z.object({
+  //     organizationId: z.string(),
+  //     query: z.string(),
+  //   })
+  // ).handler(async ({ req }) => {
+  //   const results = await searchMessages({
+  //     organizationId: req.input.organizationId,
+  //     query: req.input.query,
+  //   });
+  //
+  //   return {
+  //     hits: results.map((r) => ({
+  //       document: { id: r.messageId },
+  //     })),
+  //   };
+  // }),
   setExternalMessageId: mutation(setExternalMessageIdInputSchema).handler(
     async ({ req, db }) => {
       requireInternalApiKey(req.context);

--- a/apps/worker/src/lib/qdrant/define-index.ts
+++ b/apps/worker/src/lib/qdrant/define-index.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 import { log } from "@workspace/utils/logging";
+import { z } from "zod";
 
 import { errorFields } from "../logging";
 import { qdrantClient } from "./client";
@@ -21,6 +22,24 @@ import { qdrantClient } from "./client";
  *
  * **Organization scoping** is applied by this module, not by callers.
  */
+
+/**
+ * The slice of Qdrant's live `quantization_config` that
+ * {@link VectorIndex.ensure}'s reconcile compares against. Parsed rather than
+ * asserted because it is an external response: anything else — a different
+ * quantization mode, a shape a future Qdrant returns — falls through as "does
+ * not match" instead of reading fields off an unchecked value.
+ */
+const scalarQuantizationSchema = z.object({
+  scalar: z
+    .object({
+      always_ram: z.boolean().nullish(),
+      memory: z.string().nullish(),
+      quantile: z.number().nullish(),
+      type: z.string().nullish(),
+    })
+    .optional(),
+});
 
 /** A value a payload field can be matched on. */
 type MatchValue = string | number | boolean;
@@ -336,21 +355,15 @@ export const defineIndex = <
    * otherwise read as a permanent mismatch and re-PATCH on every boot.
    */
   const quantizationMatches = (current: unknown): boolean => {
-    const scalar = (
-      current as {
-        scalar?: {
-          type?: string;
-          quantile?: number | null;
-          always_ram?: boolean | null;
-          memory?: string | null;
-        };
-      } | null
-    )?.scalar;
+    const parsed = scalarQuantizationSchema.safeParse(current);
 
-    if (!scalar) {
-      // Absent, or a different mode (product/binary) that has no `scalar` key.
+    if (!parsed.success || !parsed.data.scalar) {
+      // Absent, malformed, or a different mode (product/binary) that has no
+      // `scalar` key.
       return false;
     }
+
+    const { scalar } = parsed.data;
 
     const pinned = scalar.always_ram === true || scalar.memory === "pinned";
 

--- a/apps/worker/src/lib/qdrant/define-index.ts
+++ b/apps/worker/src/lib/qdrant/define-index.ts
@@ -295,6 +295,70 @@ export const defineIndex = <
     return collections.collections.some((c) => c.name === name);
   };
 
+  /**
+   * Keeps the RAM-resident copy of a 3072-dimension vector to a quarter of its
+   * float32 size: an int8 quantized copy is pinned in memory and the originals
+   * are served from mmap, read back only to rescore the shortlist.
+   *
+   * `indexing_threshold` must stay above zero. Quantized vectors are produced by
+   * the same optimizer pass that builds the HNSW graph, so a collection that
+   * never indexes never quantizes either, and the config below would be inert.
+   * It also keeps search off a full scan, which with on-disk originals would
+   * pull the entire collection through the page cache on every query.
+   */
+  const INDEXING_THRESHOLD = 20_000;
+
+  const quantizationConfig = {
+    scalar: {
+      always_ram: true,
+      // Clip the top and bottom percentile so a single outlier dimension does
+      // not stretch the int8 range for every other one.
+      quantile: 0.99,
+      type: "int8" as const,
+    },
+  };
+
+  /** The `VectorsConfigDiff` key for this collection's dense vector. */
+  const denseVectorKey = sparse ? "dense" : "";
+
+  /**
+   * Bring an existing collection up to the memory config above. No-op once it
+   * already matches, so this is safe to call on every boot.
+   */
+  const reconcileMemoryConfig = async (): Promise<void> => {
+    const info = await client.getCollection(name);
+    const { config } = info;
+
+    const vectorParams = sparse
+      ? (config.params.vectors as Record<string, { on_disk?: boolean | null }>)
+          ?.dense
+      : (config.params.vectors as { on_disk?: boolean | null } | undefined);
+
+    const alreadyApplied =
+      Boolean(config.quantization_config) &&
+      vectorParams?.on_disk === true &&
+      config.optimizer_config.indexing_threshold !== 0;
+
+    if (alreadyApplied) {
+      return;
+    }
+
+    await client.updateCollection(name, {
+      optimizers_config: { indexing_threshold: INDEXING_THRESHOLD },
+      quantization_config: quantizationConfig,
+      vectors: { [denseVectorKey]: { on_disk: true } },
+    });
+
+    log.info({
+      action: "worker.qdrant",
+      operation: "collection.reconcile_memory_config",
+      collection: name,
+      indexingThreshold: INDEXING_THRESHOLD,
+      quantization: "int8",
+      vectorsOnDisk: true,
+    });
+  };
+
   const toVector = (point: UpsertPoint<TPayload, TSparse>) => {
     const dense = point.vector;
     if (!sparse) {
@@ -313,15 +377,26 @@ export const defineIndex = <
         if (!(await collectionExists())) {
           try {
             await client.createCollection(name, {
-              optimizers_config: { indexing_threshold: 0 },
+              optimizers_config: { indexing_threshold: INDEXING_THRESHOLD },
+              quantization_config: quantizationConfig,
               ...(sparse
                 ? {
                     sparse_vectors: { bm25: { modifier: "idf" as const } },
                     vectors: {
-                      dense: { distance: "Cosine" as const, size: dimensions },
+                      dense: {
+                        distance: "Cosine" as const,
+                        on_disk: true,
+                        size: dimensions,
+                      },
                     },
                   }
-                : { vectors: { distance: "Cosine" as const, size: dimensions } }),
+                : {
+                    vectors: {
+                      distance: "Cosine" as const,
+                      on_disk: true,
+                      size: dimensions,
+                    },
+                  }),
             });
 
             log.info({
@@ -339,6 +414,14 @@ export const defineIndex = <
             }
           }
         }
+
+        // Collections created before quantization was introduced still hold
+        // full float32 vectors in RAM, and a create-time config reaches only new
+        // ones. Patch them in place instead — Qdrant re-quantizes on the next
+        // optimizer pass, with no re-upload from our side. Guarded on the
+        // current config because an unconditional PATCH on every worker boot
+        // would restart that pass each time.
+        await reconcileMemoryConfig();
 
         // Reconciled on every boot, not only on creation: a descriptor can gain
         // a payload index, and a create that died mid-loop leaves the rest

--- a/apps/worker/src/lib/qdrant/define-index.ts
+++ b/apps/worker/src/lib/qdrant/define-index.ts
@@ -308,18 +308,60 @@ export const defineIndex = <
    */
   const INDEXING_THRESHOLD = 20_000;
 
+  /**
+   * Clips the top and bottom percentile so a single outlier dimension does not
+   * stretch the int8 range for every other one.
+   */
+  const QUANTIZATION_QUANTILE = 0.99;
+
   const quantizationConfig = {
     scalar: {
       always_ram: true,
-      // Clip the top and bottom percentile so a single outlier dimension does
-      // not stretch the int8 range for every other one.
-      quantile: 0.99,
+      quantile: QUANTIZATION_QUANTILE,
       type: "int8" as const,
     },
   };
 
   /** The `VectorsConfigDiff` key for this collection's dense vector. */
   const denseVectorKey = sparse ? "dense" : "";
+
+  /**
+   * Whether a collection's live quantization matches {@link quantizationConfig}
+   * field by field. A looser "is anything configured at all" test would let the
+   * constants above be retuned without existing collections ever picking the new
+   * values up, which is the one thing a reconcile is for.
+   *
+   * `always_ram` is the legacy spelling of `memory: "pinned"`. Qdrant 1.16
+   * round-trips it unchanged, but a later version that normalizes it would
+   * otherwise read as a permanent mismatch and re-PATCH on every boot.
+   */
+  const quantizationMatches = (current: unknown): boolean => {
+    const scalar = (
+      current as {
+        scalar?: {
+          type?: string;
+          quantile?: number | null;
+          always_ram?: boolean | null;
+          memory?: string | null;
+        };
+      } | null
+    )?.scalar;
+
+    if (!scalar) {
+      // Absent, or a different mode (product/binary) that has no `scalar` key.
+      return false;
+    }
+
+    const pinned = scalar.always_ram === true || scalar.memory === "pinned";
+
+    // Qdrant stores the quantile as an f32, so a round-trip can land a hair off
+    // the literal above. Comparing exactly would re-PATCH forever.
+    const quantileMatches =
+      typeof scalar.quantile === "number" &&
+      Math.abs(scalar.quantile - QUANTIZATION_QUANTILE) < 1e-6;
+
+    return scalar.type === "int8" && quantileMatches && pinned;
+  };
 
   /**
    * Bring an existing collection up to the memory config above. No-op once it
@@ -335,9 +377,9 @@ export const defineIndex = <
       : (config.params.vectors as { on_disk?: boolean | null } | undefined);
 
     const alreadyApplied =
-      Boolean(config.quantization_config) &&
+      quantizationMatches(config.quantization_config) &&
       vectorParams?.on_disk === true &&
-      config.optimizer_config.indexing_threshold !== 0;
+      config.optimizer_config.indexing_threshold === INDEXING_THRESHOLD;
 
     if (alreadyApplied) {
       return;

--- a/apps/worker/src/pipeline/processors/registration.ts
+++ b/apps/worker/src/pipeline/processors/registration.ts
@@ -1,5 +1,4 @@
 import { embedProcessor } from "./embed";
-import { embedMessagesProcessor } from "./embed-messages";
 import { labelClassifierProcessor } from "./inline-track/label/processor";
 import { processorRegistry } from "./registry";
 import { summarizeProcessor } from "./summarize";
@@ -12,7 +11,11 @@ import { synthesisProcessor } from "./synthesis-track/synthesis/processor";
 export const registerDefaultProcessors = (): string[] => {
   processorRegistry.register(summarizeProcessor);
   processorRegistry.register(embedProcessor);
-  processorRegistry.register(embedMessagesProcessor);
+  // TODO(FRO-224): `messages-v1` is retired — per-message embedding produced the
+  // largest collection in Qdrant to serve a flag-gated search page and one Agent
+  // tool, neither of which used message-level granularity. `embedMessagesProcessor`
+  // is left in the tree, unregistered, so the search rewrite can reuse or delete it
+  // deliberately rather than reconstruct it from history.
 
   // --- Inline suggestions --------------------------------------------------
   // One producer, one kind (ADR 0014): synthesis owns status, since it already

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -33,7 +33,6 @@ import {
 } from "./lib/logging";
 import { documentationIndex } from "./lib/qdrant/documentation";
 import { issueIndex } from "./lib/qdrant/issues";
-import { messageIndex } from "./lib/qdrant/messages";
 import { prIndex } from "./lib/qdrant/pull-requests";
 import { threadIndex } from "./lib/qdrant/threads";
 import { createAgentRunAudit } from "./pipeline/core/agent-run-audit";
@@ -517,13 +516,9 @@ const initialize = async () => {
     });
 
     // Ensure Qdrant collections exist
-    const indexes = [
-      threadIndex,
-      messageIndex,
-      documentationIndex,
-      prIndex,
-      issueIndex,
-    ];
+    // `messageIndex` is absent: nothing writes to `messages-v1` any more, and
+    // ensuring it would recreate the collection after it is dropped in Qdrant.
+    const indexes = [threadIndex, documentationIndex, prIndex, issueIndex];
     const readiness = await Promise.all(
       indexes.map(async (index) => [index.name, await index.ensure()] as const)
     );


### PR DESCRIPTION
Reduces production Qdrant memory on two fronts: quantizing what stays, and dropping the collection that was never worth its size.

Closes nothing on its own — see the ops steps below, without which the memory is not actually reclaimed.

## 1. int8 quantization + on-disk originals

Every collection was created with unquantized float32 vectors held in RAM. At 3072 dimensions that is ~12KB per point before payload and index overhead. Now an int8 quantized copy is pinned in RAM and the originals are served from mmap, read back only to rescore a shortlist — roughly a 4× cut on the RAM-resident copy, with no re-embedding.

`reconcileMemoryConfig()` patches collections created before this landed, so `threads-v2`, `documentation-v1`, `prs-v2` and `issues-v1` are re-quantized in place by the next optimizer pass. It is guarded on the current config, because an unconditional PATCH on every worker boot would restart that pass each time.

**`indexing_threshold` moves off zero as part of this, not as an aside.** Quantized vectors are built by the same optimizer pass that builds the HNSW graph, so a collection that never indexes never quantizes either. Verified against Qdrant v1.16.3:

| `indexing_threshold` | quantized files written |
|---|---|
| `0` | **none** |
| non-zero | `quantized.data`, `quantized.meta.json`, `quantized.config.json` |

With the threshold left at zero the quantization config is completely inert. 20000 is Qdrant's own default and is denominated in KB of vector data per segment, not vector count — at 3072 dims, ~1,700 vectors per segment. Dropping the full scan also matters once originals are on disk, since a scan would pull the whole collection through the page cache on every query.

## 2. `messages-v1` retired

It embedded **every message** individually at 3072 dims, with a bm25 sparse vector alongside and the full message text in the payload — by far the largest collection in Qdrant.

Nothing in the ingestion pipeline read it back: `summarize` reads messages straight from Postgres, and the synthesis track reads only the doc/issue/PR/thread indexes. Its two readers both consumed it at thread granularity:

- **In-app search** — gated behind `in-app-search`, off for every organization. The handler discarded the relevance score and returned a bare list of message ids.
- **The Agent's `searchThreads`** — deduplicated message hits up to one per thread. It wanted thread-level retrieval and used the message index as a proxy.

Both readers are stubbed and the writer unregistered, all commented out in place rather than deleted, so the rewrite starts from the queries that were actually running. `messageIndex` leaves the boot `ensure` list so the collection is not recreated after it is dropped.

Rewrite tracked in [FRO-224](https://linear.app/front-desk/issue/FRO-224/rebuild-search-after-retiring-the-messages-v1-index).

## Not included

`threads-v1` is deliberately left in place — [FRO-221](https://linear.app/front-desk/issue/FRO-221/index-only-backfill-for-vector-collections) has not run, so it is still the only cheap source for dormant threads' vectors.

## Testing

- `bun run typecheck` passes; no new lint errors in the touched files.
- Quantization behaviour probed against a local Qdrant v1.16.3: the PATCH returns 200 on a collection created in the old shape, search still works after it, and the threshold/quantization relationship is the table above.
- Agent evals unaffected — `agent-chat.eval.ts` builds tools from `createMockToolImplementations`, which supplies its own `searchThreads` and never reaches the router implementation.

## Ops steps after merge

Neither is in code, and both touch production:

1. **Delete `messages-v1` from production Qdrant.** Nothing reclaims it automatically; this PR only stops the writes. That deletion is the actual memory win.
2. **Watch the first optimizer pass after deploy.** Re-quantizing rewrites segments for four collections at once and is CPU- and disk-heavy while it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uh4EihwAtCaanxocphx9PX

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts Qdrant RAM by pinning an int8‑quantized copy of each vector in memory and serving float32 originals from disk. Retires the per‑message `messages‑v1` index; the Agent no longer declares `searchThreads`, and both `searchMessages` and the message search route return empty results, so behavior shifts from hybrid message‑level search to no thread search by default.

New collections set `on_disk: true` for dense vectors and enable scalar int8 quantization with `quantile: 0.99` and `indexing_threshold: 20000`. Existing collections are reconciled at boot via a Zod‑validated, field‑by‑field compare (tolerant quantile check; `always_ram` vs `memory: "pinned"`), so future retunes apply without loops or misses. The writer is unregistered and the worker no longer ensures `messages‑v1`; `threads‑v1` remains (FRO‑221). The system prompt now derives tool availability from the actual tool map, preventing drift; evals continue to pass their own `searchThreads` implementation and are unaffected. The first optimizer pass after deploy will re‑quantize and rewrite segments; expect CPU/disk load.

Rollout
- Delete `messages‑v1` from production Qdrant to reclaim memory.
- Monitor the first optimizer pass post‑deploy until re‑quantization completes.

<sup>Written for commit 2a0944637ee6ace9093b19c7ff93623f79edf1ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Retired message search; related searches now return no results.
  * Removed automatic creation and indexing of the retired message search collection.
  * Added optimized vector storage and indexing settings for newly created memory collections.
  * Existing collections are updated when configuration changes.
  * Stopped registering message embedding as a default background process.
  * Agent conversations now show search guidance and tools only when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->