### PR TITLE
fix(worker): await Reflag initialization

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -17,7 +17,7 @@ import {
 } from "./lib/api-credential";
 import { auth } from "./lib/auth";
 import { parsePortalOrganizationSlug } from "./lib/authorize";
-import { reflagClient } from "./lib/feature-flag";
+import { initializeFeatureFlags, reflagClient } from "./lib/feature-flag";
 import { portalAuth } from "./lib/portal-auth";
 import { liveStateHooks } from "./live-state/hooks";
 import { runMigrations } from "./live-state/migrations";
@@ -340,9 +340,8 @@ expressAdapter(app as unknown as Express, lsServer, {
   basePath: "/api/ls",
 });
 
-reflagClient.initialize().then(() => {
-  console.log("Reflag client initialized");
-});
+await initializeFeatureFlags();
+console.log("Reflag client initialized");
 
 await runMigrations(storage);
 

--- a/apps/api/src/lib/feature-flag.test.ts
+++ b/apps/api/src/lib/feature-flag.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+const reflag = vi.hoisted(() => ({
+  initialize: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock(import("@reflag/node-sdk"), () => ({
+  ReflagClient: class {
+    initialize = reflag.initialize;
+  },
+}));
+
+import { initializeFeatureFlags } from "./feature-flag";
+
+describe(initializeFeatureFlags, () => {
+  it("waits for the Reflag client to finish initializing", async () => {
+    let finishInitialization: (() => void) | undefined;
+    reflag.initialize.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishInitialization = resolve;
+        })
+    );
+
+    let ready = false;
+    const startup = initializeFeatureFlags().then(() => {
+      ready = true;
+    });
+
+    await Promise.resolve();
+    expect(reflag.initialize).toHaveBeenCalledOnce();
+    expect(ready).toBeFalsy();
+
+    finishInitialization?.();
+    await startup;
+
+    expect(ready).toBeTruthy();
+  });
+});

--- a/apps/api/src/lib/feature-flag.ts
+++ b/apps/api/src/lib/feature-flag.ts
@@ -5,6 +5,15 @@ export const reflagClient = new ReflagClient({
   secretKey: process.env.REFLAG_SECRET_KEY,
 });
 
+/**
+ * Load flag definitions before either service accepts work. Reflag returns no
+ * flags when queried before initialization, which otherwise looks identical to
+ * an intentionally disabled feature.
+ */
+export const initializeFeatureFlags = async (): Promise<void> => {
+  await reflagClient.initialize();
+};
+
 export const isOrganizationFeatureEnabled = (
   organizationId: string,
   flag: string

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -19,9 +19,10 @@ import {
   initSharedLogger,
   log,
 } from "@workspace/utils/logging";
+import { areWorkerJobsEnabled, initializeFeatureFlags } from "api/feature-flag";
 import { Worker } from "bullmq";
 import type { Job } from "bullmq";
-import { areWorkerJobsEnabled } from "api/feature-flag";
+
 import { handleCrawlDocumentation } from "./handlers/crawl-documentation";
 import { handleIndexIssue } from "./handlers/index-issue";
 import { handleIndexPr } from "./handlers/index-pr";
@@ -522,6 +523,9 @@ const initialize = async () => {
   let status = 200;
 
   try {
+    await initializeFeatureFlags();
+    requestLog.set({ featureFlags: { initialized: true } });
+
     const processorNames = registerDefaultProcessors();
     requestLog.set({
       processors: {


### PR DESCRIPTION
## Summary

- add a shared awaited Reflag initialization boundary
- initialize Reflag before the API accepts traffic and before queue workers start
- add a regression test proving startup remains blocked until Reflag is ready

## Root cause

The worker evaluated `support-intelligence-pipeline` before the Reflag SDK loaded flag definitions. The SDK returned no flags, which the application interpreted as an intentionally disabled pipeline.

## Testing

- `bun run --filter api test`
- `bun run --filter worker test`
- `bun run --filter api typecheck`
- `bun run --filter worker typecheck`
- targeted `oxfmt` and `oxlint` checks for changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Await Reflag initialization before the API accepts traffic and before the worker starts processing, preventing flags from appearing “disabled” during startup.

- Introduces `initializeFeatureFlags()` that awaits `reflagClient.initialize()` from `@reflag/node-sdk`, and uses it in API boot and worker init (removes fire-and-forget init in the API).
- Adds a regression test that mocks Reflag and asserts startup blocks until initialization completes.
- Side effect: startup may be delayed by Reflag availability; no config or migration changes.

<sup>Written for commit 935113e731f1371860a40a634e1fbcf7d392b968. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application and background worker startup by ensuring feature flags are fully initialized before services and job processing begin.
  * Prevented feature flag evaluations from occurring before initialization completes.

* **Tests**
  * Added coverage verifying that startup waits for feature flag initialization to finish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->