### PR TITLE
feat(slack): add outbound reply observability

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -297,8 +297,10 @@
         "zod": "catalog:",
       },
       "devDependencies": {
+        "@types/node": "^22.15.2",
         "bun-types": "latest",
         "tsdown": "^0.10.2",
+        "vitest": "^4.0.0",
       },
     },
     "packages/emails": {

--- a/connectors/framework/src/runtime/outbound.ts
+++ b/connectors/framework/src/runtime/outbound.ts
@@ -43,10 +43,7 @@ export interface OutboundReplicationOptions {
    * Matches the thread's origin and namespaces the replicated marker.
    */
   provider: string;
-  /**
-   * Extra constraints merged into the `thread` sub-filter of both queries (e.g.
-   * slack also requires `externalMetadataStr: { $not: null }`).
-   */
+  /** Extra constraints merged into the `thread` sub-filter of both queries. */
   threadFilter?: Record<string, unknown>;
   deliverMessage: Deliver<OutboundMessage>;
   deliverUpdate: Deliver<OutboundUpdate>;
@@ -72,11 +69,11 @@ export const startOutboundReplication = async ({
   deliverMessage,
   deliverUpdate,
 }: OutboundReplicationOptions) => {
-  // Provider invariants are spread last so a caller-supplied `threadFilter`
-  // cannot override `externalOrigin`/`externalId` and pull another provider's rows.
+  // The provider invariant is spread last so a caller-supplied `threadFilter`
+  // cannot pull another provider's rows. Provider resolvers intentionally see
+  // rows with missing target metadata so they can emit a precise blocked reason.
   const threadWhere = {
     ...threadFilter,
-    externalId: { $not: null },
     externalOrigin: provider,
   };
 
@@ -95,7 +92,7 @@ export const startOutboundReplication = async ({
       try {
         const externalMessageId = await deliverMessage(message);
         if (externalMessageId) {
-          store.mutate.message.setExternalMessageId({
+          await store.mutate.message.setExternalMessageId({
             externalMessageId,
             messageId: message.id,
           });

--- a/connectors/slack/package.json
+++ b/connectors/slack/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "module": "src/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
     "build": "tsdown",
     "start": "node dist/index.mjs",
     "dev": "bun run --watch src/index.ts"
@@ -24,7 +25,9 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@types/node": "^22.15.2",
     "bun-types": "latest",
-    "tsdown": "^0.10.2"
+    "tsdown": "^0.10.2",
+    "vitest": "^4.0.0"
   }
 }

--- a/connectors/slack/src/index.ts
+++ b/connectors/slack/src/index.ts
@@ -16,14 +16,20 @@ import type {
 import { App } from "@slack/bolt";
 import { WebClient } from "@slack/web-api";
 import type { MessageElement } from "@slack/web-api/dist/types/response/ConversationsHistoryResponse";
+import {
+  createLogger,
+  flushSharedLogger,
+  initSharedLogger,
+} from "@workspace/utils/logging";
 import { parse } from "@workspace/utils/md-tiptap";
 import { stringify } from "@workspace/utils/tiptap-md";
-import { z } from "zod";
 
 import { closeDigestWorker, initializeDigestWorker } from "./lib/digest-queue";
 import { reflagClient } from "./lib/feature-flag";
 import { installationStore } from "./lib/installation-store";
 import { fetchClient, store } from "./lib/live-state";
+import { resolveSlackTargetPrerequisites } from "./lib/outbound-target";
+import type { SlackTargetPrerequisiteFailureReason } from "./lib/outbound-target";
 import type { BackfillChannelResult } from "./lib/queue";
 import {
   addChannelBackfillJob,
@@ -39,8 +45,7 @@ import {
   withBackfillLock,
 } from "./lib/utils";
 
-/** Thread `externalMetadataStr` shape — a non-empty Slack channel id. */
-const externalMetadataSchema = z.object({ channelId: z.string().min(1) });
+initSharedLogger({ service: "slack-connector" });
 
 const app = new App({
   authorize: async ({ teamId, enterpriseId }): Promise<AuthorizeResult> => {
@@ -231,7 +236,17 @@ const buildPortalBotBlocks = ({
   },
 ];
 
-const getClientForTeam = async (teamId: string): Promise<WebClient | null> => {
+type SlackClientResolution =
+  | { client: WebClient; ok: true }
+  | {
+      error?: unknown;
+      ok: false;
+      reason: "bot_token_missing" | "installation_lookup_failed";
+    };
+
+const resolveClientForTeam = async (
+  teamId: string
+): Promise<SlackClientResolution> => {
   try {
     const installation = await installationStore.fetchInstallation({
       enterpriseId: undefined,
@@ -250,17 +265,31 @@ const getClientForTeam = async (teamId: string): Promise<WebClient | null> => {
       installationData.bot?.token ?? installationData.access_token ?? null;
 
     if (!botToken) {
-      console.error(
-        `Bot token not found in installation for teamId: ${teamId}`
-      );
-      return null;
+      return { ok: false, reason: "bot_token_missing" };
     }
 
-    return new WebClient(botToken);
+    return { client: new WebClient(botToken), ok: true };
   } catch (error) {
-    console.error(`Failed to get client for teamId: ${teamId}`, error);
-    return null;
+    return { error, ok: false, reason: "installation_lookup_failed" };
   }
+};
+
+const getClientForTeam = async (teamId: string): Promise<WebClient | null> => {
+  const resolution = await resolveClientForTeam(teamId);
+  if (resolution.ok) {
+    return resolution.client;
+  }
+
+  if (resolution.reason === "bot_token_missing") {
+    console.error(`Bot token not found in installation for teamId: ${teamId}`);
+  } else {
+    console.error(
+      `Failed to get client for teamId: ${teamId}`,
+      resolution.error
+    );
+  }
+
+  return null;
 };
 
 /** Integration `type` / `support-entry-point` provider key for this connector. */
@@ -900,54 +929,71 @@ app.message(
  * channel id lives in the thread's `externalMetadataStr`; the thread ts on
  * `externalId`.
  */
+type SlackTargetFailureReason =
+  | "bot_token_missing"
+  | "installation_lookup_failed"
+  | SlackTargetPrerequisiteFailureReason;
+
+type SlackTargetResolution =
+  | {
+      ok: true;
+      target: {
+        channelId: string;
+        client: WebClient;
+        integrationId: string;
+        teamId: string;
+        threadTs: string;
+      };
+    }
+  | {
+      context?: Record<string, unknown>;
+      error?: unknown;
+      ok: false;
+      reason: SlackTargetFailureReason;
+    };
+
+const toLogError = (error: unknown, fallback: string): Error =>
+  new Error(error instanceof Error ? error.message : fallback);
+
 const resolveSlackTarget = async (thread: {
   organizationId?: string;
   externalId?: string | null;
   externalMetadataStr?: string | null;
-}): Promise<{
-  client: WebClient;
-  channelId: string;
-  threadTs: string;
-} | null> => {
+}): Promise<SlackTargetResolution> => {
   const integration = store.query.integration
     .first({ organizationId: thread?.organizationId, type: "slack" })
     .get();
-  if (!integration || !integration.configStr) {
-    return null;
+  const prerequisiteResolution = resolveSlackTargetPrerequisites({
+    integration,
+    parseIntegrationConfig: safeParseIntegrationSettings,
+    thread,
+  });
+  if (!prerequisiteResolution.ok) {
+    return prerequisiteResolution;
+  }
+  const { channelId, integrationId, teamId, threadTs } =
+    prerequisiteResolution.target;
+
+  const clientResolution = await resolveClientForTeam(teamId);
+  if (!clientResolution.ok) {
+    return {
+      context: { channelId, integrationId, teamId },
+      error: clientResolution.error,
+      ok: false,
+      reason: clientResolution.reason,
+    };
   }
 
-  const parsedConfig = safeParseIntegrationSettings(integration.configStr);
-  const teamId = parsedConfig?.teamId;
-  if (!teamId) {
-    return null;
-  }
-
-  const threadTs = thread.externalId;
-  if (!threadTs) {
-    return null;
-  }
-
-  let channelId: string | null = null;
-  if (thread.externalMetadataStr) {
-    try {
-      const metadata = externalMetadataSchema.parse(
-        JSON.parse(thread.externalMetadataStr)
-      );
-      channelId = metadata.channelId;
-    } catch (error) {
-      console.error("Error parsing externalMetadataStr:", error);
-    }
-  }
-  if (!channelId) {
-    return null;
-  }
-
-  const client = await getClientForTeam(teamId);
-  if (!client) {
-    return null;
-  }
-
-  return { channelId, client, threadTs };
+  return {
+    ok: true,
+    target: {
+      channelId,
+      client: clientResolution.client,
+      integrationId,
+      teamId,
+      threadTs,
+    },
+  };
 };
 
 /**
@@ -957,12 +1003,54 @@ const resolveSlackTarget = async (thread: {
 const deliverSlackMessage = async (
   message: OutboundMessage
 ): Promise<string | null> => {
-  const target = await resolveSlackTarget(message.thread);
-  if (!target) {
-    return null;
-  }
+  const requestLog = createLogger({
+    action: "connector.outbound_reply",
+    message: {
+      id: message.id,
+      origin: message.origin,
+    },
+    operation: "slack.reply.sync",
+    provider: "slack",
+    thread: {
+      externalOrigin: message.thread.externalOrigin,
+      hasExternalId: Boolean(message.thread.externalId),
+      hasExternalMetadata: Boolean(message.thread.externalMetadataStr),
+      id: message.thread.id,
+      organizationId: message.thread.organizationId,
+    },
+  });
+  let status = 500;
 
   try {
+    const resolution = await resolveSlackTarget(message.thread);
+    if (!resolution.ok) {
+      requestLog.set({
+        delivery: {
+          outcome: "blocked",
+          reason: resolution.reason,
+        },
+        slack: resolution.context,
+      });
+      if (resolution.error !== undefined) {
+        requestLog.error(
+          toLogError(resolution.error, "Slack target resolution failed"),
+          { step: "resolve_target" }
+        );
+      }
+      status = 424;
+      return null;
+    }
+
+    const { target } = resolution;
+    requestLog.set({
+      slack: {
+        channelId: target.channelId,
+        integrationId: target.integrationId,
+        teamId: target.teamId,
+        threadTs: target.threadTs,
+      },
+    });
+
     const result = await target.client.chat.postMessage({
       channel: target.channelId,
       icon_url: message.author?.user?.image ?? undefined,
@@ -974,10 +1062,52 @@ const deliverSlackMessage = async (
       username: message.author.name,
     });
 
-    return result.ok && result.ts ? result.ts : null;
+    if (!result.ok) {
+      const slackError =
+        "error" in result && typeof result.error === "string"
+          ? result.error
+          : undefined;
+      requestLog.set({
+        delivery: {
+          outcome: "rejected",
+          reason: "slack_api_not_ok",
+          ...(slackError ? { slackError } : {}),
+        },
+      });
+      status = 502;
+      return null;
+    }
+
+    if (!result.ts) {
+      requestLog.set({
+        delivery: {
+          outcome: "rejected",
+          reason: "slack_response_missing_ts",
+        },
+      });
+      status = 502;
+      return null;
+    }
+
+    requestLog.set({
+      delivery: {
+        externalMessageId: result.ts,
+        outcome: "delivered",
+      },
+    });
+    status = 200;
+    return result.ts;
   } catch (error) {
-    console.error("Error sending Slack message:", error);
+    requestLog.set({
+      delivery: { outcome: "failed", reason: "slack_api_exception" },
+    });
+    requestLog.error(toLogError(error, "Slack API call failed"), {
+      step: "slack_api",
+    });
+    status = 502;
     return null;
+  } finally {
+    requestLog.emit({ status });
   }
 };
 
@@ -1022,10 +1152,11 @@ const formatUpdateMessage = (update: OutboundUpdate): string => {
 const deliverSlackUpdate = async (
   update: OutboundUpdate
 ): Promise<string | null> => {
-  const target = await resolveSlackTarget(update.thread);
-  if (!target) {
+  const resolution = await resolveSlackTarget(update.thread);
+  if (!resolution.ok) {
     return null;
   }
+  const { target } = resolution;
 
   const result = await target.client.chat.postMessage({
     channel: target.channelId,
@@ -1093,14 +1224,14 @@ const deliverSlackUpdate = async (
   setTimeout(async () => {
     // Watch un-replicated outbound messages/updates for Slack threads and
     // deliver them; the framework owns the round-trip of external message ids.
-    // Slack additionally requires the parent channel id in externalMetadataStr.
+    // Do not pre-filter missing Slack target metadata here: the resolver emits
+    // a reason-coded event for malformed legacy rows instead of hiding them.
     await startOutboundReplication({
       deliverMessage: deliverSlackMessage,
       deliverUpdate: deliverSlackUpdate,
       fetchClient,
       provider: "slack",
       store,
-      threadFilter: { externalMetadataStr: { $not: null } },
     });
 
     // Subscribe to Slack integrations to trigger backfill when channels are added
@@ -1116,6 +1247,7 @@ const shutdown = async () => {
   await reflagClient.flush();
   await closeBackfillQueue();
   await closeDigestWorker();
+  await flushSharedLogger();
   process.exit(0);
 };
 

--- a/connectors/slack/src/index.ts
+++ b/connectors/slack/src/index.ts
@@ -953,7 +953,7 @@ type SlackTargetResolution =
     };
 
 const toLogError = (error: unknown, fallback: string): Error =>
-  new Error(error instanceof Error ? error.message : fallback);
+  error instanceof Error ? error : new Error(fallback);
 
 const resolveSlackTarget = async (thread: {
   organizationId?: string;
@@ -1247,7 +1247,11 @@ const shutdown = async () => {
   await reflagClient.flush();
   await closeBackfillQueue();
   await closeDigestWorker();
-  await flushSharedLogger();
+  try {
+    await flushSharedLogger();
+  } catch (error) {
+    console.error("[Slack] Failed to flush shared logger:", error);
+  }
   process.exit(0);
 };
 

--- a/connectors/slack/src/lib/outbound-target.test.ts
+++ b/connectors/slack/src/lib/outbound-target.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSlackTargetPrerequisites } from "./outbound-target";
+
+const validIntegration = {
+  configStr: JSON.stringify({ teamId: "T123" }),
+  id: "integration-1",
+};
+const validThread = {
+  externalId: "1712345678.000100",
+  externalMetadataStr: JSON.stringify({ channelId: "C123" }),
+};
+const parseIntegrationConfig = (raw: string) => {
+  try {
+    return JSON.parse(raw) as { teamId?: string };
+  } catch {
+    return undefined;
+  }
+};
+
+describe("Slack target prerequisites", () => {
+  it.each([
+    {
+      expected: "integration_not_found",
+      integration: null,
+      thread: validThread,
+    },
+    {
+      expected: "integration_config_missing",
+      integration: { configStr: null, id: "integration-1" },
+      thread: validThread,
+    },
+    {
+      expected: "integration_config_invalid",
+      integration: { configStr: "not-json", id: "integration-1" },
+      thread: validThread,
+    },
+    {
+      expected: "team_id_missing",
+      integration: { configStr: "{}", id: "integration-1" },
+      thread: validThread,
+    },
+    {
+      expected: "thread_ts_missing",
+      integration: validIntegration,
+      thread: { ...validThread, externalId: null },
+    },
+    {
+      expected: "thread_metadata_missing",
+      integration: validIntegration,
+      thread: { ...validThread, externalMetadataStr: null },
+    },
+    {
+      expected: "thread_metadata_invalid",
+      integration: validIntegration,
+      thread: { ...validThread, externalMetadataStr: "not-json" },
+    },
+    {
+      expected: "channel_id_missing",
+      integration: validIntegration,
+      thread: { ...validThread, externalMetadataStr: "{}" },
+    },
+  ])("returns $expected", ({ expected, integration, thread }) => {
+    const result = resolveSlackTargetPrerequisites({
+      integration,
+      parseIntegrationConfig,
+      thread,
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: expected });
+  });
+
+  it("returns the safe Slack target identifiers", () => {
+    const result = resolveSlackTargetPrerequisites({
+      integration: validIntegration,
+      parseIntegrationConfig,
+      thread: validThread,
+    });
+
+    expect(result).toStrictEqual({
+      ok: true,
+      target: {
+        channelId: "C123",
+        integrationId: "integration-1",
+        teamId: "T123",
+        threadTs: "1712345678.000100",
+      },
+    });
+  });
+});

--- a/connectors/slack/src/lib/outbound-target.ts
+++ b/connectors/slack/src/lib/outbound-target.ts
@@ -1,0 +1,118 @@
+import { z } from "zod";
+
+const externalMetadataSchema = z.object({ channelId: z.string().optional() });
+
+export type SlackTargetPrerequisiteFailureReason =
+  | "channel_id_missing"
+  | "integration_config_invalid"
+  | "integration_config_missing"
+  | "integration_not_found"
+  | "team_id_missing"
+  | "thread_metadata_invalid"
+  | "thread_metadata_missing"
+  | "thread_ts_missing";
+
+export type SlackTargetPrerequisiteResolution =
+  | {
+      ok: true;
+      target: {
+        channelId: string;
+        integrationId: string;
+        teamId: string;
+        threadTs: string;
+      };
+    }
+  | {
+      context?: Record<string, unknown>;
+      ok: false;
+      reason: SlackTargetPrerequisiteFailureReason;
+    };
+
+export const resolveSlackTargetPrerequisites = (options: {
+  integration:
+    | {
+        configStr?: string | null;
+        id: string;
+      }
+    | null
+    | undefined;
+  parseIntegrationConfig: (
+    raw: string
+  ) => { teamId?: string | null } | undefined;
+  thread: {
+    externalId?: string | null;
+    externalMetadataStr?: string | null;
+  };
+}): SlackTargetPrerequisiteResolution => {
+  const { integration, parseIntegrationConfig, thread } = options;
+  if (!integration) {
+    return { ok: false, reason: "integration_not_found" };
+  }
+  if (!integration.configStr) {
+    return {
+      context: { integrationId: integration.id },
+      ok: false,
+      reason: "integration_config_missing",
+    };
+  }
+
+  const parsedConfig = parseIntegrationConfig(integration.configStr);
+  if (!parsedConfig) {
+    return {
+      context: { integrationId: integration.id },
+      ok: false,
+      reason: "integration_config_invalid",
+    };
+  }
+  const teamId = parsedConfig.teamId;
+  if (!teamId) {
+    return {
+      context: { integrationId: integration.id },
+      ok: false,
+      reason: "team_id_missing",
+    };
+  }
+
+  const threadTs = thread.externalId;
+  if (!threadTs) {
+    return {
+      context: { integrationId: integration.id, teamId },
+      ok: false,
+      reason: "thread_ts_missing",
+    };
+  }
+
+  if (!thread.externalMetadataStr) {
+    return {
+      context: { integrationId: integration.id, teamId },
+      ok: false,
+      reason: "thread_metadata_missing",
+    };
+  }
+
+  let channelId: string | undefined;
+  try {
+    channelId = externalMetadataSchema.parse(
+      JSON.parse(thread.externalMetadataStr)
+    ).channelId;
+  } catch {
+    return {
+      context: { integrationId: integration.id, teamId },
+      ok: false,
+      reason: "thread_metadata_invalid",
+    };
+  }
+
+  if (!channelId) {
+    return {
+      context: { integrationId: integration.id, teamId },
+      ok: false,
+      reason: "channel_id_missing",
+    };
+  }
+
+  return {
+    ok: true,
+    target: { channelId, integrationId: integration.id, teamId, threadTs },
+  };
+};

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build": "turbo build",
     "lint": "bunx --bun ultracite check",
     "lint:fix": "bunx --bun ultracite fix",
-    "test": "bun run --filter github --filter api --filter worker --filter @workspace/queue --filter @workspace/schemas test",
+    "test": "bun run --filter github --filter slack --filter api --filter worker --filter @workspace/queue --filter @workspace/schemas test",
     "format": "bunx --bun ultracite fix",
     "typecheck": "turbo typecheck",
     "dev": "turbo dev"


### PR DESCRIPTION
## Summary

- initialize the shared structured logger in the Slack connector and flush it during shutdown
- emit one redacted `connector.outbound_reply` event per delivery attempt with stable outcomes and failure reasons
- let malformed Slack-origin rows reach target resolution instead of silently filtering them out
- await external-message-id replication and add focused coverage for every Slack target precondition

## Observability

Events include message/thread/org/integration/team/channel identifiers, presence flags, `delivery.outcome`, and `delivery.reason`. They intentionally exclude message content, integration config blobs, installation payloads, and tokens.

Failure reasons cover missing or invalid integration configuration, missing thread/channel metadata, installation lookup and token failures, Slack API rejection, missing Slack timestamps, and Slack API exceptions.

## Verification

- `bun run --filter slack test` (9 tests)
- `bun run --filter slack typecheck`
- `bun run --filter slack build`
- `bun run --filter @connectors/framework typecheck`
- oxlint and oxfmt checks on changed files
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured outbound reply observability to the Slack connector and stops silently dropping malformed Slack thread rows. Each reply attempt now emits a redacted `connector.outbound_reply` event with stable outcomes/reasons, and replication awaits external message id writes.

- Initializes shared structured logging in `connectors/slack` via `@workspace/utils/logging` and flushes on shutdown; emits one `connector.outbound_reply` per reply attempt with delivery outcome (delivered | blocked | rejected | failed) and reason. Events include message/thread/org/integration/team/channel identifiers and exclude content, config blobs, and tokens.
- Resolves Slack targets with explicit prerequisite checks (`resolveSlackTargetPrerequisites`) and reason-coded failures: `integration_not_found`, `integration_config_missing`/`invalid`, `team_id_missing`, `thread_ts_missing`, `thread_metadata_missing`/`invalid`, `channel_id_missing`; client resolution adds `bot_token_missing` and `installation_lookup_failed`. Slack API issues surface as `slack_api_not_ok`, `slack_response_missing_ts`, or `slack_api_exception`.
- Lets malformed Slack-origin rows reach target resolution (no pre-filter on thread metadata or ts): framework no longer requires `externalId` in the outbound query, and Slack does not filter on `externalMetadataStr`. Provider scoping remains enforced.
- Awaits `store.mutate.message.setExternalMessageId(...)` to ensure replication state is written before proceeding.
- Adds focused tests for target prerequisites with `vitest`; updates `connectors/slack/package.json` dev deps (`vitest`, `@types/node`) and includes `slack` in the root `test` script.

<sup>Written for commit 1ffbd88254aecc7e0da3707e1b5ffc481e61c41e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved Slack message and thread delivery reliability.
  - Items missing optional target metadata can now be processed and receive clearer failure reporting when delivery prerequisites are unavailable.
  - Delivery outcomes are recorded more consistently, including successful, API-related, and target-resolution failures.
  - Message replication now waits for external message identifiers to be saved before completing.

- **Testing**
  - Expanded automated coverage for Slack target validation and included Slack in the standard test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->