### PR TITLE
fix(worker): improve synthesis reply continuity

### DIFF
--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/agent-dataset.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/eval/agent-dataset.ts
@@ -975,7 +975,7 @@ const synthesisAgentDatasetCases: (Omit<SynthesisAgentEvalCase, "input"> & {
       minToolCalls: { read_pr: 1 },
       mustIncludePrimaryKinds: ["link_pr", "reply"],
       replyMustContainAll: ["engineering", "working on", "let you know"],
-      replyMustStartWith: "Hi Alex Rivera,",
+      replyMustStartWith: "Hi Alex,",
       requiresReplyDraft: true,
       forbiddenReplyPhrases: [
         "we've identified a fix",
@@ -1728,7 +1728,7 @@ const synthesisAgentDatasetCases: (Omit<SynthesisAgentEvalCase, "input"> & {
       mustExcludePrimaryKinds: ["link_issue"],
       mustIncludePrimaryKinds: ["create_issue", "reply"],
       replyMustOmitIssueReference: true,
-      replyMustStartWith: "Hi Marta Silva,",
+      replyMustStartWith: "Hi Marta,",
       requiresReplyDraft: true,
     },
     input: {

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.test.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.test.ts
@@ -99,6 +99,42 @@ describe("synthesis action contract", () => {
     expect(enabledSynthesisActionKinds(inputFor(autonomy)).size).toBe(0);
   });
 
+  it("instructs replies to advance the conversation without recapping the customer problem", () => {
+    const prompt = buildSynthesisPrompt(inputFor());
+
+    expect(prompt).toContain("Every reply must move the conversation forward");
+    expect(prompt).toContain(
+      "Do not repeat or paraphrase their problem, symptoms, error message, request, or troubleshooting steps"
+    );
+    expect(prompt).toContain(
+      "contributing something new: the answer, the current status, the next step, or a focused request"
+    );
+  });
+
+  it("forbids greetings when the team has already replied", () => {
+    const prompt = buildSynthesisPrompt(inputFor());
+
+    expect(prompt).toContain("This is an ongoing conversation");
+    expect(prompt).toContain("NEVER begin with a greeting or salutation");
+    expect(prompt).not.toContain("Customer display name (use only in this");
+  });
+
+  it("requires a greeting when the team has not replied", () => {
+    const input = inputFor();
+    input.customerName = "Alex Rivera";
+    input.hasTeamReply = false;
+
+    const prompt = buildSynthesisPrompt(input);
+
+    expect(prompt).toContain("First-reply tone:");
+    expect(prompt).toContain("Begin with `Hi <first name>,`");
+    expect(prompt).toContain('"John Nolan" becomes "Hi John,"');
+    expect(prompt).toContain(
+      'derive the first name only for this first-reply greeting): "Alex Rivera"'
+    );
+    expect(prompt).not.toContain("NEVER begin with a greeting or salutation");
+  });
+
   it("keeps enabled non-reply actions on an unreplied thread when reply is off", () => {
     const output = parseRawActionSetFromText(
       rawActionSet({ kind: "set_status", status: 1, witness: null }),

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.test.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.test.ts
@@ -116,7 +116,10 @@ describe("synthesis action contract", () => {
 
     expect(prompt).toContain("This is an ongoing conversation");
     expect(prompt).toContain("NEVER begin with a greeting or salutation");
-    expect(prompt).not.toContain("Customer display name (use only in this");
+    expect(prompt).not.toContain("First-reply tone:");
+    expect(prompt).not.toContain(
+      "Customer display name (derive the first name only for this first-reply greeting):"
+    );
   });
 
   it("requires a greeting when the team has not replied", () => {
@@ -133,6 +136,26 @@ describe("synthesis action contract", () => {
       'derive the first name only for this first-reply greeting): "Alex Rivera"'
     );
     expect(prompt).not.toContain("NEVER begin with a greeting or salutation");
+  });
+
+  it("scopes future-update promises to available engineering actions", () => {
+    const engineeringPromptInput = inputFor();
+    engineeringPromptInput.hasTeamReply = false;
+    const engineeringPrompt = buildSynthesisPrompt(engineeringPromptInput);
+
+    expect(engineeringPrompt).toContain("When primary includes link_pr");
+    expect(engineeringPrompt).toContain("When primary includes create_issue");
+
+    const autonomy = allSuggest();
+    autonomy.create_issue = "off";
+    autonomy.link_pr = "off";
+    const input = inputFor(autonomy);
+    input.hasTeamReply = false;
+
+    const prompt = buildSynthesisPrompt(input);
+
+    expect(prompt).not.toContain("promise to update the customer");
+    expect(prompt).not.toContain("promise to follow up with the customer");
   });
 
   it("keeps enabled non-reply actions on an unreplied thread when reply is off", () => {

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
@@ -432,8 +432,7 @@ ${
     : `First-reply tone:
 - Begin with \`Hi ${customerName ? "<first name>" : "there"},\`.
 - When a customer display name is supplied, primarily use only the customer's first name, not their full display name: "John Nolan" becomes "Hi John,". Keep a single-name display name as-is. If the display name looks like a company, handle, email address, or you cannot confidently identify a first name, use \`Hi there,\` rather than guessing.
-${hasAction("link_pr") ? "- When primary includes link_pr, lead with the important customer-facing status: the engineering team is working on a fix for the reported issue.\n" : ""}- Then promise to update the customer when the fix is available or complete. Do not invent an ETA.
-- Thank or acknowledge the report briefly after the status and follow-up promise, without paraphrasing the problem back to the customer.
+${hasAction("link_pr") ? "- When primary includes link_pr, lead with the important customer-facing status: the engineering team is working on a fix for the reported issue, and promise to update the customer when the fix is available or complete. Do not invent an ETA.\n" : ""}${hasAction("create_issue") ? "- When primary includes create_issue, say that engineering will investigate and promise to follow up with the customer. Do not invent an ETA.\n" : ""}- Thank or acknowledge the report briefly, without paraphrasing the problem back to the customer.
 ${hasAction("link_pr") ? "- Do not say the pull request was linked. The PR link is an internal thread action, not a customer-facing claim.\n" : ""}
 Customer display name (derive the first name only for this first-reply greeting): ${JSON.stringify(customerName)}`
 }

--- a/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
+++ b/apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.ts
@@ -424,12 +424,19 @@ ${
 - **Reply-only primary** is fine when that is the best move (no bundling required).
 - **Empty primary** is still allowed when no substantive move is justified.
 
-First-reply tone:
-- Every first reply must begin with \`Hi ${customerName ? "<customer name>" : "there"},\` — use the supplied customer display name when present, otherwise use \`Hi there,\`.
+${
+  input.hasTeamReply
+    ? `Follow-up reply tone:
+- This is an ongoing conversation. NEVER begin with a greeting or salutation: no "Hi", "Hello", "Hey", customer name, or equivalent. Start directly with the substantive response.
+- Do not use the customer display name elsewhere as a substitute for a greeting.`
+    : `First-reply tone:
+- Begin with \`Hi ${customerName ? "<first name>" : "there"},\`.
+- When a customer display name is supplied, primarily use only the customer's first name, not their full display name: "John Nolan" becomes "Hi John,". Keep a single-name display name as-is. If the display name looks like a company, handle, email address, or you cannot confidently identify a first name, use \`Hi there,\` rather than guessing.
 ${hasAction("link_pr") ? "- When primary includes link_pr, lead with the important customer-facing status: the engineering team is working on a fix for the reported issue.\n" : ""}- Then promise to update the customer when the fix is available or complete. Do not invent an ETA.
-- Thank or acknowledge the report after the status and follow-up promise.
+- Thank or acknowledge the report briefly after the status and follow-up promise, without paraphrasing the problem back to the customer.
 ${hasAction("link_pr") ? "- Do not say the pull request was linked. The PR link is an internal thread action, not a customer-facing claim.\n" : ""}
-Customer display name (use only in the greeting): ${JSON.stringify(customerName)}
+Customer display name (derive the first name only for this first-reply greeting): ${JSON.stringify(customerName)}`
+}
 
 When hasTeamReply is true, alternatives may be any allowed action kind.`
     : "";
@@ -505,6 +512,15 @@ ${replyCitationRule}
 ${
   hasAction("reply")
     ? `
+## Every reply must move the conversation forward (critical)
+
+The customer already knows what they wrote. Do not repeat or paraphrase their problem, symptoms, error message, request, or troubleshooting steps merely to show that you understood them or to establish context.
+
+- Start the substantive response by contributing something new: the answer, the current status, the next step, or a focused request for missing information.
+- Keep acknowledgement short, such as "Thanks for confirming" or "Sorry this is still happening," then move forward.
+- Do not open with a recap such as "It sounds like ...", "You're experiencing ...", or "An <error> after <action> suggests ..." when those details came from the customer.
+- Restate a detail only when it is necessary to disambiguate what the customer means, confirm a high-stakes fact, or contrast a detail that changes the answer. Use the shortest fragment needed.
+
 ## Every reply must declare its grounding (critical)
 
 Each \`reply\` action carries a \`grounding\` object saying what backs the draft. Be honest here — this is not a confidence score to talk yourself into, it is a claim about evidence, and it is checked.


### PR DESCRIPTION
## Summary

- prevent synthesis replies from repeating the customer problem back to them
- omit greetings once a teammate has already replied in the thread
- prefer first names in first-response greetings, with a safe `Hi there` fallback
- update synthesis prompt coverage and agent eval expectations

## Testing

- `bunx vitest run apps/worker/src/pipeline/processors/synthesis-track/synthesis/synthesize.test.ts`
- `bun run typecheck` (apps/worker)
- `bunx --bun ultracite check` on changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops synthesis replies from repeating the customer's problem back to them, drops greetings once a teammate has already replied, and requires replies to move the conversation forward.

- First responses greet with just the customer's first name, falling back to `Hi there` when a safe first name can't be derived.
- Updated the synthesis prompt, eval dataset expectations, and tests to cover the new behavior, including scoping future-update promises to engineering actions when enabled.

<sup>Written for commit d3c25f6ff06d29f0fe4a707709bc6224affa4620. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved generated replies with personalized greetings for first responses.
  * Follow-up replies now avoid unnecessary greetings and repeated problem summaries.
  * Responses are guided to provide new information, status updates, next steps, or focused questions.

* **Tests**
  * Added coverage for greeting behavior, concise acknowledgments, and forward-moving replies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->