### PR TITLE
chore(deps): upgrade TypeScript to 7.0.2

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["oxc.oxc-vscode"]
+  "recommendations": ["oxc.oxc-vscode", "TypeScriptTeam.native-preview"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,13 +4,15 @@
       "mode": "auto"
     }
   ],
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.tsdk": "node_modules/typescript",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "js/ts.experimental.useTsgo": true,
+  "js/ts.tsdk.path": "node_modules/typescript",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "tailwindCSS.experimental.configFile": "packages/ui/src/styles/globals.css",
   "editor.formatOnPaste": true,
   "editor.formatOnSave": true,
   "emmet.showExpandedAbbreviation": "never",
-  "js/ts.tsdk.path": "node_modules/typescript/lib",
-  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "[astro]": {
     "editor.defaultFormatter": "astro-build.astro-vscode"
   },

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -13,8 +13,7 @@
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
     "skipLibCheck": true,
-    "jsx": "react-jsx",
-    "baseUrl": "."
+    "jsx": "react-jsx"
   },
   "include": ["src"]
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -32,7 +32,7 @@
     "@types/react-dom": "^19.2.2",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.2.4",
-    "typescript": "catalog:",
+    "typescript": "^5.9.3",
     "wrangler": "^4.45.3"
   }
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -32,7 +32,7 @@
     "@types/react-dom": "^19.2.2",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.2.4",
-    "typescript": "^5.9.3",
+    "typescript": "catalog:",
     "wrangler": "^4.45.3"
   }
 }

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "target": "ESNext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
@@ -17,7 +16,7 @@
     "incremental": true,
     "paths": {
       "@/*": ["./src/*"],
-      "@/.source": [".source"],
+      "@/.source": ["./.source"],
       "@workspace/ui/*": ["../../packages/ui/src/*"]
     },
     "plugins": [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -77,7 +77,7 @@
     "postcss": "^8.5.1",
     "react-scan": "^0.4.3",
     "tailwindcss": "^4.2.4",
-    "typescript": "^5.7.2",
+    "typescript": "catalog:",
     "vite": "^7.1.10",
     "vite-tsconfig-paths": "^5.1.4",
     "wrangler": "^4.45.3"

--- a/apps/web/src/fontsource.d.ts
+++ b/apps/web/src/fontsource.d.ts
@@ -1,0 +1,2 @@
+declare module "@fontsource-variable/intel-one-mono";
+declare module "@fontsource-variable/inter";

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -13,12 +13,11 @@
     "target": "ES2022",
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
     "paths": {
       "~/*": ["./src/*"],
       "@workspace/ui/*": ["../../packages/ui/src/*"],
       "@workspace/utils/*": ["../../packages/utils/src/lib/*"],
-      "fumadocs-mdx:collections/*": [".source/*"]
+      "fumadocs-mdx:collections/*": ["./.source/*"]
     },
     "noEmit": true,
     "types": ["vite/client", "react"]

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -39,6 +39,6 @@
     "vitest": "^4.0.0"
   },
   "peerDependencies": {
-    "typescript": "^5"
+    "typescript": "catalog:"
   }
 }

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -13,6 +13,7 @@
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,
+    "types": ["bun"],
 
     // Best practices
     "strict": true,

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "openai": "^6.32.0",
         "oxfmt": "^0.60.0",
         "oxlint": "^1.75.0",
-        "typescript": "^5.9.2",
+        "typescript": "catalog:",
         "ultracite": "7.9.4",
         "vitest": "^4.0.0",
       },
@@ -106,7 +106,7 @@
         "@types/react-dom": "^19.2.2",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.2.4",
-        "typescript": "^5.9.3",
+        "typescript": "catalog:",
         "wrangler": "^4.45.3",
       },
     },
@@ -176,7 +176,7 @@
         "postcss": "^8.5.1",
         "react-scan": "^0.4.3",
         "tailwindcss": "^4.2.4",
-        "typescript": "^5.7.2",
+        "typescript": "catalog:",
         "vite": "^7.1.10",
         "vite-tsconfig-paths": "^5.1.4",
         "wrangler": "^4.45.3",
@@ -206,7 +206,7 @@
         "vitest": "^4.0.0",
       },
       "peerDependencies": {
-        "typescript": "^5",
+        "typescript": "catalog:",
       },
     },
     "connectors/discord": {
@@ -243,7 +243,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.15.2",
-        "typescript": "^5.7.0",
+        "typescript": "catalog:",
       },
       "peerDependencies": {
         "api": "workspace:*",
@@ -438,7 +438,7 @@
         "@vitejs/plugin-react": "^5.0.4",
         "colorjs.io": "^0.6.1",
         "jsdom": "^27.0.0",
-        "typescript": "^5.9.3",
+        "typescript": "catalog:",
         "vite": "^7.1.7",
         "vitest": "^3.0.5",
         "web-vitals": "^5.1.0",
@@ -460,7 +460,7 @@
       },
       "devDependencies": {
         "@types/mdast": "^4.0.4",
-        "typescript": "^5.9.3",
+        "typescript": "catalog:",
       },
     },
   },
@@ -476,6 +476,7 @@
     "better-auth": "^1.4.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "typescript": "^7.0.2",
     "zod": "4.1.9",
   },
   "packages": {
@@ -2068,6 +2069,46 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.65.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.65.0", "@typescript-eslint/types": "8.65.0", "@typescript-eslint/typescript-estree": "8.65.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.65.0", "", { "dependencies": { "@typescript-eslint/types": "8.65.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
@@ -3951,7 +3992,7 @@
 
     "typebox": ["typebox@1.0.75", "", {}, "sha512-5u1pkRdAfQiIprkuS59RrrV+5ydXQh2OzR7Lqb/bhgS8sBZznMVcNYZMrZdsmL7xEV+Qhu7wiAKLr9gE1INBPQ=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
@@ -5228,6 +5269,8 @@
     "web/lucide-react": ["lucide-react@0.475.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-NJzvVu1HwFVeZ+Gwq2q00KygM1aBhy/ZrhY9FsAgJtpB+E4R7uxRk9M2iKvHa6/vNxZydIB59htha4c2vvwvVg=="],
 
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "worker/@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "wrangler/esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -106,7 +106,7 @@
         "@types/react-dom": "^19.2.2",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.2.4",
-        "typescript": "catalog:",
+        "typescript": "^5.9.3",
         "wrangler": "^4.45.3",
       },
     },
@@ -5065,6 +5065,8 @@
     "docs/@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
 
     "docs/lucide-react": ["lucide-react@0.552.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-g9WCjmfwqbexSnZE+2cl21PCfXOcqnGeWeMTNAOGEfpPbm/ZF4YIq77Z8qWrxbu660EKuLB4nSLggoKnCb+isw=="],
+
+    "docs/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 

--- a/connectors/discord/tsconfig.json
+++ b/connectors/discord/tsconfig.json
@@ -14,7 +14,6 @@
     "verbatimModuleSyntax": true,
     "skipLibCheck": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "paths": {
       "~/*": ["./src/*"],
       "@workspace/utils/*": ["../../packages/utils/src/*"]

--- a/connectors/framework/package.json
+++ b/connectors/framework/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.15.2",
-    "typescript": "^5.7.0"
+    "typescript": "catalog:"
   },
   "peerDependencies": {
     "api": "workspace:*"

--- a/connectors/framework/tsconfig.json
+++ b/connectors/framework/tsconfig.json
@@ -14,8 +14,7 @@
     "strict": true,
     "target": "ES2022",
     "types": ["node"],
-    "verbatimModuleSyntax": true,
-    "baseUrl": "."
+    "verbatimModuleSyntax": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/connectors/github/tsconfig.json
+++ b/connectors/github/tsconfig.json
@@ -14,7 +14,6 @@
     "verbatimModuleSyntax": true,
     "skipLibCheck": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "paths": {
       "~/*": ["./src/*"],
       "@workspace/ui/*": ["../../packages/ui/src/*"]

--- a/connectors/slack/tsconfig.json
+++ b/connectors/slack/tsconfig.json
@@ -14,7 +14,6 @@
     "verbatimModuleSyntax": true,
     "skipLibCheck": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "paths": {
       "~/*": ["./src/*"],
       "@workspace/utils/*": ["../../packages/utils/src/*"]

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
       "better-auth": "^1.4.0",
       "react": "19.2.3",
       "react-dom": "19.2.3",
+      "typescript": "^7.0.2",
       "zod": "4.1.9"
     }
   },
@@ -43,7 +44,7 @@
     "openai": "^6.32.0",
     "oxfmt": "^0.60.0",
     "oxlint": "^1.75.0",
-    "typescript": "^5.9.2",
+    "typescript": "catalog:",
     "ultracite": "7.9.4",
     "vitest": "^4.0.0"
   },

--- a/packages/emails/tsconfig.json
+++ b/packages/emails/tsconfig.json
@@ -15,7 +15,6 @@
     "strict": true,
     "target": "ES2022",
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "paths": {
       "@workspace/emails/*": ["./src/*"]
     }

--- a/packages/schemas/tsconfig.json
+++ b/packages/schemas/tsconfig.json
@@ -14,7 +14,6 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "ES2022",
-    "baseUrl": ".",
     "paths": {
       "@workspace/schemas/*": ["./src/*"]
     }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -102,7 +102,7 @@
     "@vitejs/plugin-react": "^5.0.4",
     "colorjs.io": "^0.6.1",
     "jsdom": "^27.0.0",
-    "typescript": "^5.9.3",
+    "typescript": "catalog:",
     "vite": "^7.1.7",
     "vitest": "^3.0.5",
     "web-vitals": "^5.1.0"

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -20,7 +20,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@workspace/ui/*": ["./src/*"],

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -28,6 +28,6 @@
   },
   "devDependencies": {
     "@types/mdast": "^4.0.4",
-    "typescript": "^5.9.3"
+    "typescript": "catalog:"
   }
 }

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -19,7 +19,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary
- Pin TypeScript 7.0.2 in the workspace catalog and drop `baseUrl` / other TS 7 hard errors so `tsc --noEmit` still passes.
- Point the workspace editor at the project TypeScript 7 language server (`js/ts.experimental.useTsgo`) and recommend the native TypeScript 7 VS Code extension.

## Test plan
- [ ] Run `bun install` and confirm `bunx tsc --version` reports 7.0.2
- [ ] Run `bun run typecheck`
- [ ] Install `TypeScriptTeam.native-preview`, reload the window, and confirm the editor is using the workspace TypeScript 7 server


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades the workspace to TypeScript 7.0.2 via the workspace catalog, keeping `apps/docs` on TypeScript 5.9 because Next.js 16.0.10 still requires `typescript/lib/typescript.js`.

**Migration**
- Removed `baseUrl` from tsconfigs since TypeScript 7 dropped it; path mappings now use relative paths.
- VS Code now uses the workspace TypeScript 7 language server and recommends the `TypeScriptTeam.native-preview` extension.
- Added module declarations for `@fontsource-variable` packages and `types: ["bun"]` for the worker app.

<sup>Written for commit 2e74db90122ccbb386075ce088015bc1da5a7c3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FrontDeskHQ/front-desk/pull/383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Developer Experience**
  * Updated workspace TypeScript settings and recommendations for improved editor integration.
  * Added support for recognizing the project’s font packages in TypeScript.
  * Standardized TypeScript version management across workspace projects.

* **Configuration**
  * Simplified TypeScript path resolution across applications, connectors, and packages.
  * Added Bun runtime type support for the worker project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->